### PR TITLE
Add Markdown Editor for torrent description

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,8 @@
     <!-- Latest compiled and minified CSS -->
     <!-- This should come before website CSS because it can f3ck up the website completely.. Use !important as a workaround -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <!-- Bootstrap Markdown -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.10.0/css/bootstrap-markdown.min.css" crossorigin="anonymous">
 
     <!-- Bootstrap -->
 

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -69,7 +69,7 @@
       <div class="form-group">
           <label for="desc">{{T "torrent_description"}}</label>
           <p class="help-block">{{T "description_markdown_notice"}}</p>
-          <textarea name="desc" id="desc" class="form-control" rows="10">{{.Description}}</textarea>
+          <textarea name="desc" id="desc" class="form-contro torrent-desc" rows="15">{{.Description}}</textarea>
       </div>
 
       {{block "captcha" .}}{{end}}
@@ -83,4 +83,10 @@
 {{end}}
 {{define "js_footer"}}
   <script type="text/javascript" charset="utf-8" src="{{.URL.Parse "/js/uploadPage.js"}}"></script>
+  <script type="text/javascript" charset="utf-8" src="https://cdnjs.cloudflare.com/ajax/libs/markdown.js/0.5.0/markdown.min.js"></script>
+  <script type="text/javascript" charset="utf-8" src="https://cdnjs.cloudflare.com/ajax/libs/to-markdown/3.0.4/to-markdown.js"></script>
+  <script type="text/javascript" charset="utf-8" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.10.0/js/bootstrap-markdown.js"></script>
+  <script>
+    $(".torrent-desc").markdown({resize: "both"})
+  </script>
 {{end}}


### PR DESCRIPTION
Works well, and if you don't have Javascript enabled you don't see anything extra.

![](http://i.imgur.com/jy6sWie.png)
![](http://i.imgur.com/CygSfVd.png)