### PR TITLE
Possible fix for torrents order on user profile page

### DIFF
--- a/service/user/user.go
+++ b/service/user/user.go
@@ -281,7 +281,7 @@ func RetrieveOldUploadsByUsername(username string) ([]uint, error) {
 // RetrieveUserForAdmin retrieves a user for an administrator.
 func RetrieveUserForAdmin(id string) (model.User, int, error) {
 	var user model.User
-	if db.ORM.Preload("Torrents").First(&user, id).RecordNotFound() {
+	if db.ORM.Preload("Torrents").Last(&user, id).RecordNotFound() {
 		return user, http.StatusNotFound, errors.New("user not found")
 	}
 	var liked, likings []model.User


### PR DESCRIPTION
Changes query from:
```sql
SELECT * FROM "torrents"  WHERE "torrents"."deleted_at" IS NULL AND (("uploader" IN ('1'))) ORDER BY "torrents"."torrent_id" ASC
```
to:
```sql
SELECT * FROM "torrents"  WHERE "torrents"."deleted_at" IS NULL AND (("uploader" IN ('1'))) ORDER BY "torrents"."torrent_id" DESC
```

Should close #396