### PR TITLE
Add tooltips to category images

### DIFF
--- a/router/template_functions.go
+++ b/router/template_functions.go
@@ -163,4 +163,51 @@ var FuncMap = template.FuncMap{
 		// because time.* isn't available in templates...
 		return t.Format(time.RFC3339)
 	},
+    "Category_Sukebei": func(category string, sub_category string) string {
+        s := category + "_" + sub_category; e := ""
+        switch s {
+            default:        e = ""
+            case "1_":      e = "art"
+            case "1_1":     e = "art_anime"
+            case "1_2":     e = "art_doujinshi"
+            case "1_3":     e = "art_games"
+            case "1_4":     e = "art_manga"
+            case "1_5":     e = "art_pictures"
+            case "2_":      e = "real_life"
+            case "2_1":     e = "real_life_photobooks_and_pictures"
+            case "2_2":     e = "real_life_videos"
+        }
+        return e
+    },
+    "Category_Nyaa": func(category string, sub_category string) string {
+        s := category + "_" + sub_category; e := ""
+        switch s {
+            default:        e = ""
+            case "3_":      e = "anime"
+            case "3_12":    e = "anime_amv"
+            case "3_5":     e = "anime_english_translated"
+            case "3_13":    e = "anime_non_english_translated"
+            case "3_6":     e = "anime_raw"
+            case "2_":      e = "audio"
+            case "2_3":     e = "audio_lossless"
+            case "2_4":     e = "audio_lossy"
+            case "4_":      e = "literature"
+            case "4_7":     e = "literature_english_translated"
+            case "4_8":     e = "literature_raw"
+            case "4_14":    e = "literature_non_english_translated"
+            case "5_":      e = "live_action"
+            case "5_9":     e = "live_action_english_translated"
+            case "5_10":    e = "live_action_idol_pv"
+            case "5_18":    e = "live_action_non_english_translated"
+            case "5_11":    e = "live_action_raw"
+            case "6_":      e = "pictures"
+            case "6_15":    e = "pictures_graphics"
+            case "6_16":    e = "pictures_photos"
+            case "1_":      e = "software"
+            case "1_1":     e = "software_applications"
+            case "1_2":     e = "software_games"
+        }
+        return e
+    },
+}
 }

--- a/router/template_functions.go
+++ b/router/template_functions.go
@@ -210,4 +210,3 @@ var FuncMap = template.FuncMap{
         return e
     },
 }
-}

--- a/templates/_user_list_torrents.html
+++ b/templates/_user_list_torrents.html
@@ -21,11 +21,9 @@
               <td style="width:80px">
                   <a href="{{$.URL.Parse (printf "/search?c=%s_%s" .Category .SubCategory) }}">
                       {{ if Sukebei }}
-
-                      <img src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}">
-
+                      <img src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ T (Category_Sukebei .Category .SubCategory) }}">
                       {{ else }}
-                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}">
+                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ T (Category_Nyaa .Category .SubCategory) }}">
                       {{ end}}
                   </a>
               </td>

--- a/templates/home.html
+++ b/templates/home.html
@@ -45,11 +45,9 @@ Your browser does not support the audio element.
               <td class="hidden-xs" style="width:80px">
                   <a href="{{$.URL.Parse (printf "/search?c=%s_%s" .Category .SubCategory) }}">
                       {{ if Sukebei }}
-
-                      <img src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}">
-
+                      <img src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ T (Category_Sukebei .Category .SubCategory) }}">
                       {{ else }}
-                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}">
+                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ T (Category_Nyaa .Category .SubCategory) }}">
                       {{ end}}
                   </a>
               </td>

--- a/templates/view.html
+++ b/templates/view.html
@@ -16,9 +16,9 @@
                 <div class="col-md-12">
                     <div style="float: left;">
                           {{ if Sukebei }}
-                          <img style="float:left; margin-right: 1em;" src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}">
+                          <img style="float:left; margin-right: 1em;" src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ T (Category_Sukebei .Category .SubCategory) }}">
                           {{ else }}
-                          <img style="float:left; margin-right: 1em;" src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}">
+                          <img style="float:left; margin-right: 1em;" src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ T (Category_Nyaa .Category .SubCategory) }}">
                           {{ end }}
                           <br />
                           <h4 style="display:inline-block">


### PR DESCRIPTION
Adds tooltips to the category images which also work across translations
I did this by adding a couple functions which use the category and sub-category num's

![pop-up](https://cloud.githubusercontent.com/assets/28694152/26239116/9e7f24b8-3c30-11e7-9c50-4dbfcbd8c76c.png)
