### PR TITLE
Make markdown editor background match current theme

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -128,6 +128,10 @@ td {
 	color:#bbb;
 }
 
+.md-editor > textarea, .md-preview {
+    background: none !important;
+}
+
 /* Table style & fixes */
 .table > tbody > tr > th, .nowrap {
 	white-space: nowrap;


### PR DESCRIPTION
Prevents the night theme's markdown editor preview from appearing with a white background