### PR TITLE
Move translation func to template variables

### DIFF
--- a/router/database_dump_handler.go
+++ b/router/database_dump_handler.go
@@ -49,8 +49,8 @@ func DatabaseDumpHandler(w http.ResponseWriter, r *http.Request) {
 
 	// TODO Remove ?
 	navigationTorrents := Navigation{0, 0, 0, "search_page"}
-	languages.SetTranslationFromRequest(databaseDumpTemplate, r)
-	dtv := DatabaseDumpTemplateVariables{dumpsJson, "/gpg/gpg.pub", NewSearchForm(), navigationTorrents, GetUser(r), r.URL, mux.CurrentRoute(r)}
+	T := languages.GetTfuncFromRequest(r)
+	dtv := DatabaseDumpTemplateVariables{dumpsJson, "/gpg/gpg.pub", NewSearchForm(), navigationTorrents, T, GetUser(r), r.URL, mux.CurrentRoute(r)}
 	err = databaseDumpTemplate.ExecuteTemplate(w, "index.html", dtv)
 	if err != nil {
 		log.Errorf("DatabaseDump(): %s", err)

--- a/router/faq_handler.go
+++ b/router/faq_handler.go
@@ -8,10 +8,10 @@ import (
 )
 
 func FaqHandler(w http.ResponseWriter, r *http.Request) {
-	languages.SetTranslationFromRequest(faqTemplate, r)
 	ftv := FaqTemplateVariables{
 		Navigation: NewNavigation(),
 		Search:     NewSearchForm(),
+		T:          languages.GetTfuncFromRequest(r),
 		User:       GetUser(r),
 		URL:        r.URL,
 		Route:      mux.CurrentRoute(r),

--- a/router/home_handler.go
+++ b/router/home_handler.go
@@ -63,13 +63,12 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 		Route:          "search_page",
 	}
 
-	languages.SetTranslationFromRequest(homeTemplate, r)
-
 	torrentsJson := model.TorrentsToJSON(torrents)
 	htv := HomeTemplateVariables{
 		ListTorrents: torrentsJson,
 		Search:       NewSearchForm(),
 		Navigation:   navigationTorrents,
+		T:            languages.GetTfuncFromRequest(r),
 		User:         GetUser(r),
 		URL:          r.URL,
 		Route:        mux.CurrentRoute(r),

--- a/router/language_handler.go
+++ b/router/language_handler.go
@@ -15,7 +15,7 @@ type LanguagesJSONResponse struct {
 }
 
 func SeeLanguagesHandler(w http.ResponseWriter, r *http.Request) {
-	_, Tlang := languages.GetTfuncAndLanguageFromRequest(r)
+	Tfunc, Tlang := languages.GetTfuncAndLanguageFromRequest(r)
 	availableLanguages := languages.GetAvailableLanguages()
 
 	contentType := r.Header.Get("Content-Type")
@@ -30,13 +30,13 @@ func SeeLanguagesHandler(w http.ResponseWriter, r *http.Request) {
 		clv := ChangeLanguageVariables{
 			Search:     NewSearchForm(),
 			Navigation: NewNavigation(),
+			T:          Tfunc,
 			Language:   Tlang.Tag,
 			Languages:  availableLanguages,
 			User:       GetUser(r),
 			URL:        r.URL,
 			Route:      mux.CurrentRoute(r),
 		}
-		languages.SetTranslationFromRequest(changeLanguageTemplate, r)
 		err := changeLanguageTemplate.ExecuteTemplate(w, "index.html", clv)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/router/language_handler.go
+++ b/router/language_handler.go
@@ -15,7 +15,7 @@ type LanguagesJSONResponse struct {
 }
 
 func SeeLanguagesHandler(w http.ResponseWriter, r *http.Request) {
-	Tfunc, Tlang := languages.GetTfuncAndLanguageFromRequest(r)
+	_, Tlang := languages.GetTfuncAndLanguageFromRequest(r)
 	availableLanguages := languages.GetAvailableLanguages()
 
 	contentType := r.Header.Get("Content-Type")
@@ -30,7 +30,7 @@ func SeeLanguagesHandler(w http.ResponseWriter, r *http.Request) {
 		clv := ChangeLanguageVariables{
 			Search:     NewSearchForm(),
 			Navigation: NewNavigation(),
-			T:          Tfunc,
+			T:          languages.GetTfuncFromRequest(r),
 			Language:   Tlang.Tag,
 			Languages:  availableLanguages,
 			User:       GetUser(r),

--- a/router/modpanel.go
+++ b/router/modpanel.go
@@ -116,8 +116,8 @@ func IndexModPanel(w http.ResponseWriter, r *http.Request) {
 	comments, _ := commentService.GetAllComments(offset, 0, "", "")
 	torrentReports, _, _ := reportService.GetAllTorrentReports(offset, 0)
 
-	languages.SetTranslationFromRequest(panelIndex, r)
-	htv := PanelIndexVbs{torrents, model.TorrentReportsToJSON(torrentReports), users, comments, NewPanelSearchForm(), currentUser, r.URL}
+	T := languages.GetTfuncFromRequest(r)
+	htv := PanelIndexVbs{torrents, model.TorrentReportsToJSON(torrentReports), users, comments, NewPanelSearchForm(), T, currentUser, r.URL}
 	err := panelIndex.ExecuteTemplate(w, "admin_index.html", htv)
 	log.CheckError(err)
 }
@@ -145,9 +145,9 @@ func TorrentsListPanel(w http.ResponseWriter, r *http.Request) {
 		}
 
 	messages := msg.GetMessages(r)
-	languages.SetTranslationFromRequest(panelTorrentList, r)
+	T := languages.GetTfuncFromRequest(r)
 	navigation := Navigation{ count, int(searchParam.Max), pagenum, "mod_tlist_page"}
-	ptlv := PanelTorrentListVbs{torrents, searchForm, navigation, currentUser, messages.GetAllErrors(), messages.GetAllInfos(), r.URL}
+	ptlv := PanelTorrentListVbs{torrents, searchForm, navigation, T, currentUser, messages.GetAllErrors(), messages.GetAllInfos(), r.URL}
 	err = panelTorrentList.ExecuteTemplate(w, "admin_index.html", ptlv)
 	log.CheckError(err)
 }
@@ -171,9 +171,9 @@ func TorrentReportListPanel(w http.ResponseWriter, r *http.Request) {
 	torrentReports, nbReports, _ := reportService.GetAllTorrentReports(offset, (pagenum-1)*offset)
 
 	reportJSON := model.TorrentReportsToJSON(torrentReports)
-	languages.SetTranslationFromRequest(panelTorrentReportList, r)
+	T := languages.GetTfuncFromRequest(r)
 	navigation := Navigation{nbReports, offset, pagenum, "mod_trlist_page"}
-	ptrlv := PanelTorrentReportListVbs{reportJSON, NewSearchForm(), navigation, currentUser, r.URL}
+	ptrlv := PanelTorrentReportListVbs{reportJSON, NewSearchForm(), navigation, T, currentUser, r.URL}
 	err = panelTorrentReportList.ExecuteTemplate(w, "admin_index.html", ptrlv)
 	log.CheckError(err)
 }
@@ -195,8 +195,8 @@ func UsersListPanel(w http.ResponseWriter, r *http.Request) {
 	offset := 100
 
 	users, nbUsers := userService.RetrieveUsersForAdmin(offset, (pagenum-1)*offset)
-	languages.SetTranslationFromRequest(panelUserList, r)
-	htv := PanelUserListVbs{users, NewSearchForm(), Navigation{nbUsers, offset, pagenum, "mod_ulist_page"}, currentUser, r.URL}
+	T := languages.GetTfuncFromRequest(r)
+	htv := PanelUserListVbs{users, NewSearchForm(), Navigation{nbUsers, offset, pagenum, "mod_ulist_page"}, T, currentUser, r.URL}
 	err = panelUserList.ExecuteTemplate(w, "admin_index.html", htv)
 	log.CheckError(err)
 }
@@ -225,8 +225,8 @@ func CommentsListPanel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	comments, nbComments := commentService.GetAllComments(offset, (pagenum-1)*offset, conditions, values...)
-	languages.SetTranslationFromRequest(panelCommentList, r)
-	htv := PanelCommentListVbs{comments, NewSearchForm(), Navigation{nbComments, offset, pagenum, "mod_clist_page"}, currentUser, r.URL}
+	T := languages.GetTfuncFromRequest(r)
+	htv := PanelCommentListVbs{comments, NewSearchForm(), Navigation{nbComments, offset, pagenum, "mod_clist_page"}, T, currentUser, r.URL}
 	err = panelCommentList.ExecuteTemplate(w, "admin_index.html", htv)
 	log.CheckError(err)
 }
@@ -235,7 +235,7 @@ func TorrentEditModPanel(w http.ResponseWriter, r *http.Request) {
 	currentUser := GetUser(r)
 	id := r.URL.Query().Get("id")
 	torrent, _ := torrentService.GetTorrentById(id)
-	languages.SetTranslationFromRequest(panelTorrentEd, r)
+	T := languages.GetTfuncFromRequest(r)
 
 	torrentJson := torrent.ToJSON()
 	uploadForm := NewUploadForm()
@@ -243,7 +243,7 @@ func TorrentEditModPanel(w http.ResponseWriter, r *http.Request) {
 	uploadForm.Category = torrentJson.Category + "_" + torrentJson.SubCategory
 	uploadForm.Status = torrentJson.Status
 	uploadForm.Description = string(torrentJson.Description)
-	htv := PanelTorrentEdVbs{uploadForm, NewPanelSearchForm(), currentUser, form.NewErrors(), form.NewInfos(), r.URL}
+	htv := PanelTorrentEdVbs{uploadForm, NewPanelSearchForm(), T, currentUser, form.NewErrors(), form.NewInfos(), r.URL}
 	err := panelTorrentEd.ExecuteTemplate(w, "admin_index.html", htv)
 	log.CheckError(err)
 }
@@ -272,8 +272,8 @@ func TorrentPostEditModPanel(w http.ResponseWriter, r *http.Request) {
 			infos["infos"] = append(infos["infos"], "Torrent details updated.")
 		}
 	}
-	languages.SetTranslationFromRequest(panelTorrentEd, r)
-	htv := PanelTorrentEdVbs{uploadForm, NewPanelSearchForm(), currentUser, err, infos, r.URL}
+	T := languages.GetTfuncFromRequest(r)
+	htv := PanelTorrentEdVbs{uploadForm, NewPanelSearchForm(), T, currentUser, err, infos, r.URL}
 	err_ := panelTorrentEd.ExecuteTemplate(w, "admin_index.html", htv)
 	log.CheckError(err_)
 }
@@ -315,9 +315,9 @@ func TorrentReportDeleteModPanel(w http.ResponseWriter, r *http.Request) {
 
 func TorrentReassignModPanel(w http.ResponseWriter, r *http.Request) {
 	currentUser := GetUser(r)
-	languages.SetTranslationFromRequest(panelTorrentReassign, r)
+	T := languages.GetTfuncFromRequest(r)
 
-	htv := PanelTorrentReassignVbs{ReassignForm{}, NewPanelSearchForm(), currentUser, form.NewErrors(), form.NewInfos(), r.URL}
+	htv := PanelTorrentReassignVbs{ReassignForm{}, NewPanelSearchForm(), T, currentUser, form.NewErrors(), form.NewInfos(), r.URL}
 	err := panelTorrentReassign.ExecuteTemplate(w, "admin_index.html", htv)
 	log.CheckError(err)
 }
@@ -340,7 +340,8 @@ func TorrentPostReassignModPanel(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	htv := PanelTorrentReassignVbs{rForm, NewPanelSearchForm(), currentUser, err, infos, r.URL}
+	T := languages.GetTfuncFromRequest(r)
+	htv := PanelTorrentReassignVbs{rForm, NewPanelSearchForm(), T, currentUser, err, infos, r.URL}
 	err_ := panelTorrentReassign.ExecuteTemplate(w, "admin_index.html", htv)
 	log.CheckError(err_)
 }

--- a/router/not_found_handler.go
+++ b/router/not_found_handler.go
@@ -8,12 +8,12 @@ import (
 )
 
 func NotFoundHandler(w http.ResponseWriter, r *http.Request) {
-	languages.SetTranslationFromRequest(notFoundTemplate, r)
 	w.WriteHeader(http.StatusNotFound)
 
 	nftv := NotFoundTemplateVariables{
 		Navigation: NewNavigation(),
 		Search:     NewSearchForm(),
+		T:          languages.GetTfuncFromRequest(r),
 		User:       GetUser(r),
 		URL:        r.URL,
 		Route:      mux.CurrentRoute(r),

--- a/router/search_handler.go
+++ b/router/search_handler.go
@@ -46,9 +46,9 @@ func SearchHandler(w http.ResponseWriter, r *http.Request) {
 		Category:         searchParam.Category.String(),
 		ShowItemsPerPage: true,
 	}
-	htv := HomeTemplateVariables{b, searchForm, navigationTorrents, GetUser(r), r.URL, mux.CurrentRoute(r)}
+	T := languages.GetTfuncFromRequest(r)
+	htv := HomeTemplateVariables{b, searchForm, navigationTorrents, T, GetUser(r), r.URL, mux.CurrentRoute(r)}
 
-	languages.SetTranslationFromRequest(searchTemplate, r)
 	err = searchTemplate.ExecuteTemplate(w, "index.html", htv)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/router/template_functions.go
+++ b/router/template_functions.go
@@ -11,7 +11,6 @@ import (
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/service/user/permission"
 	"github.com/NyaaPantsu/nyaa/util/languages"
-	"github.com/nicksnyder/go-i18n/i18n"
 )
 
 var FuncMap = template.FuncMap{
@@ -135,8 +134,6 @@ var FuncMap = template.FuncMap{
 		return template.HTML(ret)
 	},
 	"Sukebei":            config.IsSukebei,
-	"T":                  i18n.IdentityTfunc,
-	"Ts":                 i18n.IdentityTfunc,
 	"getDefaultLanguage": languages.GetDefaultLanguage,
 	"getAvatar": func(hash string, size int) string {
 		return "https://www.gravatar.com/avatar/" + hash + "?s=" + strconv.Itoa(size)

--- a/router/template_variables.go
+++ b/router/template_variables.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NyaaPantsu/nyaa/service/user"
 	userForms "github.com/NyaaPantsu/nyaa/service/user/form"
 	"github.com/gorilla/mux"
+	"github.com/nicksnyder/go-i18n/i18n"
 )
 
 /* Each Page should have an object to pass to their own template
@@ -20,6 +21,7 @@ import (
 type FaqTemplateVariables struct {
 	Navigation Navigation
 	Search     SearchForm
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -28,6 +30,7 @@ type FaqTemplateVariables struct {
 type NotFoundTemplateVariables struct {
 	Navigation Navigation
 	Search     SearchForm
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -40,6 +43,7 @@ type ViewTemplateVariables struct {
 	Infos   map[string][]string
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -50,6 +54,7 @@ type UserRegisterTemplateVariables struct {
 	FormErrors       map[string][]string
 	Search           SearchForm
 	Navigation       Navigation
+	T                i18n.TranslateFunc
 	User             *model.User
 	URL              *url.URL   // For parsing Url in templates
 	Route            *mux.Route // For getting current route in templates
@@ -63,6 +68,7 @@ type UserProfileEditVariables struct {
 	Languages   map[string]string
 	Search      SearchForm
 	Navigation  Navigation
+	T           i18n.TranslateFunc
 	User        *model.User
 	URL         *url.URL   // For parsing Url in templates
 	Route       *mux.Route // For getting current route in templates
@@ -72,6 +78,7 @@ type UserVerifyTemplateVariables struct {
 	FormErrors map[string][]string
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -82,6 +89,7 @@ type UserLoginFormVariables struct {
 	FormErrors map[string][]string
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -92,6 +100,7 @@ type UserProfileVariables struct {
 	FormInfos   map[string][]string
 	Search      SearchForm
 	Navigation  Navigation
+	T           i18n.TranslateFunc
 	User        *model.User
 	URL         *url.URL   // For parsing Url in templates
 	Route       *mux.Route // For getting current route in templates
@@ -101,6 +110,7 @@ type HomeTemplateVariables struct {
 	ListTorrents []model.TorrentJSON
 	Search       SearchForm
 	Navigation   Navigation
+	T            i18n.TranslateFunc
 	User         *model.User
 	URL          *url.URL   // For parsing Url in templates
 	Route        *mux.Route // For getting current route in templates
@@ -111,6 +121,7 @@ type DatabaseDumpTemplateVariables struct {
 	GPGLink    string
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -121,6 +132,7 @@ type UploadTemplateVariables struct {
 	FormErrors  map[string][]string
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL
 	Route      *mux.Route
@@ -129,6 +141,7 @@ type UploadTemplateVariables struct {
 type ChangeLanguageVariables struct {
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	Language   string
 	Languages  map[string]string
 	User       *model.User
@@ -144,6 +157,7 @@ type PanelIndexVbs struct {
 	Users          []model.User
 	Comments       []model.Comment
 	Search         SearchForm
+	T              i18n.TranslateFunc
 	User           *model.User
 	URL            *url.URL // For parsing Url in templates
 }
@@ -152,6 +166,7 @@ type PanelTorrentListVbs struct {
 	Torrents   []model.Torrent
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	User       *model.User
 	Errors map[string][]string
 	Infos  map[string][]string
@@ -161,6 +176,7 @@ type PanelUserListVbs struct {
 	Users      []model.User
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL // For parsing Url in templates
 }
@@ -168,6 +184,7 @@ type PanelCommentListVbs struct {
 	Comments   []model.Comment
 	Search     SearchForm
 	Navigation Navigation
+	T          i18n.TranslateFunc
 	User       *model.User
 	URL        *url.URL // For parsing Url in templates
 }
@@ -175,6 +192,7 @@ type PanelCommentListVbs struct {
 type PanelTorrentEdVbs struct {
 	Upload     UploadForm
 	Search     SearchForm
+	T          i18n.TranslateFunc
 	User       *model.User
 	FormErrors map[string][]string
 	FormInfos  map[string][]string
@@ -185,6 +203,7 @@ type PanelTorrentReportListVbs struct {
 	TorrentReports []model.TorrentReportJson
 	Search         SearchForm
 	Navigation     Navigation
+	T              i18n.TranslateFunc
 	User           *model.User
 	URL            *url.URL // For parsing Url in templates
 }
@@ -193,6 +212,7 @@ type PanelTorrentReassignVbs struct {
 	Reassign   ReassignForm
 	Search     SearchForm  // unused?
 	User       *model.User // unused?
+	T          i18n.TranslateFunc
 	FormErrors map[string][]string
 	FormInfos  map[string][]string
 	URL        *url.URL // For parsing Url in templates

--- a/router/template_variables.go
+++ b/router/template_variables.go
@@ -8,8 +8,8 @@ import (
 	"github.com/NyaaPantsu/nyaa/model"
 	"github.com/NyaaPantsu/nyaa/service/user"
 	userForms "github.com/NyaaPantsu/nyaa/service/user/form"
+	"github.com/NyaaPantsu/nyaa/util/languages"
 	"github.com/gorilla/mux"
-	"github.com/nicksnyder/go-i18n/i18n"
 )
 
 /* Each Page should have an object to pass to their own template
@@ -21,7 +21,7 @@ import (
 type FaqTemplateVariables struct {
 	Navigation Navigation
 	Search     SearchForm
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -30,7 +30,7 @@ type FaqTemplateVariables struct {
 type NotFoundTemplateVariables struct {
 	Navigation Navigation
 	Search     SearchForm
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -43,7 +43,7 @@ type ViewTemplateVariables struct {
 	Infos   map[string][]string
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -54,7 +54,7 @@ type UserRegisterTemplateVariables struct {
 	FormErrors       map[string][]string
 	Search           SearchForm
 	Navigation       Navigation
-	T                i18n.TranslateFunc
+	T                languages.TemplateTfunc
 	User             *model.User
 	URL              *url.URL   // For parsing Url in templates
 	Route            *mux.Route // For getting current route in templates
@@ -68,7 +68,7 @@ type UserProfileEditVariables struct {
 	Languages   map[string]string
 	Search      SearchForm
 	Navigation  Navigation
-	T           i18n.TranslateFunc
+	T           languages.TemplateTfunc
 	User        *model.User
 	URL         *url.URL   // For parsing Url in templates
 	Route       *mux.Route // For getting current route in templates
@@ -78,7 +78,7 @@ type UserVerifyTemplateVariables struct {
 	FormErrors map[string][]string
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -89,7 +89,7 @@ type UserLoginFormVariables struct {
 	FormErrors map[string][]string
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -100,7 +100,7 @@ type UserProfileVariables struct {
 	FormInfos   map[string][]string
 	Search      SearchForm
 	Navigation  Navigation
-	T           i18n.TranslateFunc
+	T           languages.TemplateTfunc
 	User        *model.User
 	URL         *url.URL   // For parsing Url in templates
 	Route       *mux.Route // For getting current route in templates
@@ -110,7 +110,7 @@ type HomeTemplateVariables struct {
 	ListTorrents []model.TorrentJSON
 	Search       SearchForm
 	Navigation   Navigation
-	T            i18n.TranslateFunc
+	T            languages.TemplateTfunc
 	User         *model.User
 	URL          *url.URL   // For parsing Url in templates
 	Route        *mux.Route // For getting current route in templates
@@ -121,7 +121,7 @@ type DatabaseDumpTemplateVariables struct {
 	GPGLink    string
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL   // For parsing Url in templates
 	Route      *mux.Route // For getting current route in templates
@@ -132,7 +132,7 @@ type UploadTemplateVariables struct {
 	FormErrors  map[string][]string
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL
 	Route      *mux.Route
@@ -141,7 +141,7 @@ type UploadTemplateVariables struct {
 type ChangeLanguageVariables struct {
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	Language   string
 	Languages  map[string]string
 	User       *model.User
@@ -157,7 +157,7 @@ type PanelIndexVbs struct {
 	Users          []model.User
 	Comments       []model.Comment
 	Search         SearchForm
-	T              i18n.TranslateFunc
+	T              languages.TemplateTfunc
 	User           *model.User
 	URL            *url.URL // For parsing Url in templates
 }
@@ -166,7 +166,7 @@ type PanelTorrentListVbs struct {
 	Torrents   []model.Torrent
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	Errors map[string][]string
 	Infos  map[string][]string
@@ -176,7 +176,7 @@ type PanelUserListVbs struct {
 	Users      []model.User
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL // For parsing Url in templates
 }
@@ -184,7 +184,7 @@ type PanelCommentListVbs struct {
 	Comments   []model.Comment
 	Search     SearchForm
 	Navigation Navigation
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	URL        *url.URL // For parsing Url in templates
 }
@@ -192,7 +192,7 @@ type PanelCommentListVbs struct {
 type PanelTorrentEdVbs struct {
 	Upload     UploadForm
 	Search     SearchForm
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User
 	FormErrors map[string][]string
 	FormInfos  map[string][]string
@@ -203,7 +203,7 @@ type PanelTorrentReportListVbs struct {
 	TorrentReports []model.TorrentReportJson
 	Search         SearchForm
 	Navigation     Navigation
-	T              i18n.TranslateFunc
+	T              languages.TemplateTfunc
 	User           *model.User
 	URL            *url.URL // For parsing Url in templates
 }
@@ -211,7 +211,7 @@ type PanelTorrentReportListVbs struct {
 type PanelTorrentReassignVbs struct {
 	Reassign   ReassignForm
 	Search     SearchForm  // unused?
-	T          i18n.TranslateFunc
+	T          languages.TemplateTfunc
 	User       *model.User // unused?
 	FormErrors map[string][]string
 	FormInfos  map[string][]string
@@ -252,3 +252,5 @@ func GetUser(r *http.Request) *model.User {
 	user, _, _ := userService.RetrieveCurrentUser(r)
 	return &user
 }
+
+

--- a/router/template_variables.go
+++ b/router/template_variables.go
@@ -211,8 +211,8 @@ type PanelTorrentReportListVbs struct {
 type PanelTorrentReassignVbs struct {
 	Reassign   ReassignForm
 	Search     SearchForm  // unused?
-	User       *model.User // unused?
 	T          i18n.TranslateFunc
+	User       *model.User // unused?
 	FormErrors map[string][]string
 	FormInfos  map[string][]string
 	URL        *url.URL // For parsing Url in templates

--- a/router/upload_handler.go
+++ b/router/upload_handler.go
@@ -97,7 +97,6 @@ func UploadPostHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func UploadGetHandler(w http.ResponseWriter, r *http.Request) {
-	languages.SetTranslationFromRequest(uploadTemplate, r)
 	messages := msg.GetMessages(r) // new util for errors and infos
 
 	var uploadForm UploadForm
@@ -114,6 +113,7 @@ func UploadGetHandler(w http.ResponseWriter, r *http.Request) {
 		FormErrors: messages.GetAllErrors(),
 		Search:     NewSearchForm(),
 		Navigation: NewNavigation(),
+		T:          languages.GetTfuncFromRequest(r),
 		User:       GetUser(r),
 		URL:        r.URL,
 		Route:      mux.CurrentRoute(r),

--- a/router/user_handler.go
+++ b/router/user_handler.go
@@ -90,10 +90,10 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			if follow != nil {
-				infosForm["infos"] = append(infosForm["infos"], fmt.Sprintf(T("user_followed_msg"), userProfile.Username))
+				infosForm["infos"] = append(infosForm["infos"], fmt.Sprintf(string(T("user_followed_msg")), userProfile.Username))
 			}
 			if unfollow != nil {
-				infosForm["infos"] = append(infosForm["infos"], fmt.Sprintf(T("user_unfollowed_msg"), userProfile.Username))
+				infosForm["infos"] = append(infosForm["infos"], fmt.Sprintf(string(T("user_unfollowed_msg")), userProfile.Username))
 			}
 			htv := UserProfileVariables{&userProfile, infosForm, NewSearchForm(), NewNavigation(), T, currentUser, r.URL, mux.CurrentRoute(r)}
 
@@ -172,14 +172,14 @@ func UserProfileFormHandler(w http.ResponseWriter, r *http.Request) {
 		if len(err) == 0 {
 			if userForm.Email != userProfile.Email {
 				userService.SendVerificationToUser(*currentUser, userForm.Email)
-				infos["infos"] = append(infos["infos"], fmt.Sprintf(T("email_changed"), userForm.Email))
+				infos["infos"] = append(infos["infos"], fmt.Sprintf(string(T("email_changed")), userForm.Email))
 				userForm.Email = userProfile.Email // reset, it will be set when user clicks verification
 			}
 			userProfile, _, errorUser = userService.UpdateUser(w, &userForm, currentUser, id)
 			if errorUser != nil {
 				err["errors"] = append(err["errors"], errorUser.Error())
 			} else {
-				infos["infos"] = append(infos["infos"], T("profile_updated"))
+				infos["infos"] = append(infos["infos"], string(T("profile_updated")))
 			}
 		}
 	}

--- a/router/user_handler.go
+++ b/router/user_handler.go
@@ -26,12 +26,12 @@ func UserRegisterFormHandler(w http.ResponseWriter, r *http.Request) {
 	registrationForm := form.RegistrationForm{}
 	modelHelper.BindValueForm(&registrationForm, r)
 	registrationForm.CaptchaID = captcha.GetID()
-	languages.SetTranslationFromRequest(viewRegisterTemplate, r)
 	urtv := UserRegisterTemplateVariables{
 		RegistrationForm: registrationForm,
 		FormErrors:       form.NewErrors(),
 		Search:           NewSearchForm(),
 		Navigation:       NewNavigation(),
+		T:                languages.GetTfuncFromRequest(r),
 		User:             GetUser(r),
 		URL:              r.URL,
 		Route:            mux.CurrentRoute(r),
@@ -46,13 +46,13 @@ func UserRegisterFormHandler(w http.ResponseWriter, r *http.Request) {
 func UserLoginFormHandler(w http.ResponseWriter, r *http.Request) {
 	loginForm := form.LoginForm{}
 	modelHelper.BindValueForm(&loginForm, r)
-	languages.SetTranslationFromRequest(viewLoginTemplate, r)
 
 	ulfv := UserLoginFormVariables{
 		LoginForm:  loginForm,
 		FormErrors: form.NewErrors(),
 		Search:     NewSearchForm(),
 		Navigation: NewNavigation(),
+		T:          languages.GetTfuncFromRequest(r),
 		User:       GetUser(r),
 		URL:        r.URL,
 		Route:      mux.CurrentRoute(r),
@@ -68,6 +68,7 @@ func UserLoginFormHandler(w http.ResponseWriter, r *http.Request) {
 func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
+	T := languages.GetTfuncFromRequest(r)
 	userProfile, _, errorUser := userService.RetrieveUserForAdmin(id)
 	if errorUser == nil {
 		currentUser := GetUser(r)
@@ -82,21 +83,19 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 			if errUser != nil {
 				err["errors"] = append(err["errors"], errUser.Error())
 			}
-			languages.SetTranslationFromRequest(viewUserDeleteTemplate, r)
-			htv := UserVerifyTemplateVariables{err, NewSearchForm(), NewNavigation(), GetUser(r), r.URL, mux.CurrentRoute(r)}
+			htv := UserVerifyTemplateVariables{err, NewSearchForm(), NewNavigation(), T, GetUser(r), r.URL, mux.CurrentRoute(r)}
 			errorTmpl := viewUserDeleteTemplate.ExecuteTemplate(w, "index.html", htv)
 			if errorTmpl != nil {
 				http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)
 			}
 		} else {
-			T := languages.SetTranslationFromRequest(viewProfileTemplate, r)
 			if follow != nil {
 				infosForm["infos"] = append(infosForm["infos"], fmt.Sprintf(T("user_followed_msg"), userProfile.Username))
 			}
 			if unfollow != nil {
 				infosForm["infos"] = append(infosForm["infos"], fmt.Sprintf(T("user_unfollowed_msg"), userProfile.Username))
 			}
-			htv := UserProfileVariables{&userProfile, infosForm, NewSearchForm(), NewNavigation(), currentUser, r.URL, mux.CurrentRoute(r)}
+			htv := UserProfileVariables{&userProfile, infosForm, NewSearchForm(), NewNavigation(), T, currentUser, r.URL, mux.CurrentRoute(r)}
 
 			err := viewProfileTemplate.ExecuteTemplate(w, "index.html", htv)
 			if err != nil {
@@ -104,8 +103,7 @@ func UserProfileHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		languages.SetTranslationFromRequest(notFoundTemplate, r)
-		err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{NewNavigation(), NewSearchForm(), GetUser(r), r.URL, mux.CurrentRoute(r)})
+		err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{NewNavigation(), NewSearchForm(), T, GetUser(r), r.URL, mux.CurrentRoute(r)})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -117,22 +115,21 @@ func UserDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 	currentUser := GetUser(r)
+	T := languages.GetTfuncFromRequest(r)
 	userProfile, _, errorUser := userService.RetrieveUserForAdmin(id)
 	if errorUser == nil && userPermission.CurrentOrAdmin(currentUser, userProfile.ID) {
 		if userPermission.CurrentOrAdmin(currentUser, userProfile.ID) {
 			b := form.UserForm{}
 			modelHelper.BindValueForm(&b, r)
-			languages.SetTranslationFromRequest(viewProfileEditTemplate, r)
 			availableLanguages := languages.GetAvailableLanguages()
-			htv := UserProfileEditVariables{&userProfile, b, form.NewErrors(), form.NewInfos(), availableLanguages, NewSearchForm(), NewNavigation(), currentUser, r.URL, mux.CurrentRoute(r)}
+			htv := UserProfileEditVariables{&userProfile, b, form.NewErrors(), form.NewInfos(), availableLanguages, NewSearchForm(), NewNavigation(), T, currentUser, r.URL, mux.CurrentRoute(r)}
 			err := viewProfileEditTemplate.ExecuteTemplate(w, "index.html", htv)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		}
 	} else {
-		languages.SetTranslationFromRequest(notFoundTemplate, r)
-		err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{NewNavigation(), NewSearchForm(), GetUser(r), r.URL, mux.CurrentRoute(r)})
+		err := notFoundTemplate.ExecuteTemplate(w, "index.html", NotFoundTemplateVariables{NewNavigation(), NewSearchForm(), T, GetUser(r), r.URL, mux.CurrentRoute(r)})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -153,7 +150,7 @@ func UserProfileFormHandler(w http.ResponseWriter, r *http.Request) {
 	userForm := form.UserForm{}
 	err := form.NewErrors()
 	infos := form.NewInfos()
-	T := languages.SetTranslationFromRequest(viewProfileEditTemplate, r)
+	T := languages.GetTfuncFromRequest(r)
 	if len(r.PostFormValue("email")) > 0 {
 		_, err = form.EmailValidation(r.PostFormValue("email"), err)
 	}
@@ -195,6 +192,7 @@ func UserProfileFormHandler(w http.ResponseWriter, r *http.Request) {
 		Languages:   availableLanguages,
 		Search:      NewSearchForm(),
 		Navigation:  NewNavigation(),
+		T:           T,
 		User:        currentUser,
 		URL:         r.URL,
 		Route:       mux.CurrentRoute(r),
@@ -207,6 +205,7 @@ func UserProfileFormHandler(w http.ResponseWriter, r *http.Request) {
 
 // Post Registration controller, we do some check on the form here, the rest on user service
 func UserRegisterPostHandler(w http.ResponseWriter, r *http.Request) {
+	T := languages.GetTfuncFromRequest(r)
 	b := form.RegistrationForm{}
 	err := form.NewErrors()
 	if !captcha.Authenticate(captcha.Extract(r)) {
@@ -226,11 +225,10 @@ func UserRegisterPostHandler(w http.ResponseWriter, r *http.Request) {
 					err["errors"] = append(err["errors"], errorUser.Error())
 				}
 				if len(err) == 0 {
-					languages.SetTranslationFromRequest(viewRegisterSuccessTemplate, r)
 					u := model.User{
 						Email: r.PostFormValue("email"), // indicate whether user had email set
 					}
-					htv := UserRegisterTemplateVariables{b, err, NewSearchForm(), NewNavigation(), &u, r.URL, mux.CurrentRoute(r)}
+					htv := UserRegisterTemplateVariables{b, err, NewSearchForm(), NewNavigation(), T, &u, r.URL, mux.CurrentRoute(r)}
 					errorTmpl := viewRegisterSuccessTemplate.ExecuteTemplate(w, "index.html", htv)
 					if errorTmpl != nil {
 						http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)
@@ -241,8 +239,7 @@ func UserRegisterPostHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(err) > 0 {
 		b.CaptchaID = captcha.GetID()
-		languages.SetTranslationFromRequest(viewRegisterTemplate, r)
-		htv := UserRegisterTemplateVariables{b, err, NewSearchForm(), NewNavigation(), GetUser(r), r.URL, mux.CurrentRoute(r)}
+		htv := UserRegisterTemplateVariables{b, err, NewSearchForm(), NewNavigation(), T, GetUser(r), r.URL, mux.CurrentRoute(r)}
 		errorTmpl := viewRegisterTemplate.ExecuteTemplate(w, "index.html", htv)
 		if errorTmpl != nil {
 			http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)
@@ -258,8 +255,8 @@ func UserVerifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 	if errEmail != nil {
 		err["errors"] = append(err["errors"], errEmail.Error())
 	}
-	languages.SetTranslationFromRequest(viewVerifySuccessTemplate, r)
-	htv := UserVerifyTemplateVariables{err, NewSearchForm(), NewNavigation(), GetUser(r), r.URL, mux.CurrentRoute(r)}
+	T := languages.GetTfuncFromRequest(r)
+	htv := UserVerifyTemplateVariables{err, NewSearchForm(), NewNavigation(), T, GetUser(r), r.URL, mux.CurrentRoute(r)}
 	errorTmpl := viewVerifySuccessTemplate.ExecuteTemplate(w, "index.html", htv)
 	if errorTmpl != nil {
 		http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)
@@ -268,6 +265,7 @@ func UserVerifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 
 // Post Login controller
 func UserLoginPostHandler(w http.ResponseWriter, r *http.Request) {
+	T := languages.GetTfuncFromRequest(r)
 	b := form.LoginForm{}
 	modelHelper.BindValueForm(&b, r)
 	err := form.NewErrors()
@@ -276,8 +274,7 @@ func UserLoginPostHandler(w http.ResponseWriter, r *http.Request) {
 		_, errorUser := userService.CreateUserAuthentication(w, r)
 		if errorUser != nil {
 			err["errors"] = append(err["errors"], errorUser.Error())
-			languages.SetTranslationFromRequest(viewLoginTemplate, r)
-			htv := UserLoginFormVariables{b, err, NewSearchForm(), NewNavigation(), GetUser(r), r.URL, mux.CurrentRoute(r)}
+			htv := UserLoginFormVariables{b, err, NewSearchForm(), NewNavigation(), T, GetUser(r), r.URL, mux.CurrentRoute(r)}
 			errorTmpl := viewLoginTemplate.ExecuteTemplate(w, "index.html", htv)
 			if errorTmpl != nil {
 				http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)
@@ -289,8 +286,7 @@ func UserLoginPostHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if len(err) > 0 {
-		languages.SetTranslationFromRequest(viewLoginTemplate, r)
-		htv := UserLoginFormVariables{b, err, NewSearchForm(), NewNavigation(), GetUser(r), r.URL, mux.CurrentRoute(r)}
+		htv := UserLoginFormVariables{b, err, NewSearchForm(), NewNavigation(), T, GetUser(r), r.URL, mux.CurrentRoute(r)}
 		errorTmpl := viewLoginTemplate.ExecuteTemplate(w, "index.html", htv)
 		if errorTmpl != nil {
 			http.Error(w, errorTmpl.Error(), http.StatusInternalServerError)

--- a/router/view_torrent_handler.go
+++ b/router/view_torrent_handler.go
@@ -38,9 +38,9 @@ func ViewHandler(w http.ResponseWriter, r *http.Request) {
 	if userPermission.NeedsCaptcha(user) {
 		captchaID = captcha.GetID()
 	}
-	htv := ViewTemplateVariables{b, captchaID, messages.GetAllErrors(), messages.GetAllInfos(), NewSearchForm(), NewNavigation(), user, r.URL, mux.CurrentRoute(r)}
+	T := languages.GetTfuncFromRequest(r)
+	htv := ViewTemplateVariables{b, captchaID, messages.GetAllErrors(), messages.GetAllInfos(), NewSearchForm(), NewNavigation(), T, user, r.URL, mux.CurrentRoute(r)}
 
-	languages.SetTranslationFromRequest(viewTemplate, r)
 	err = viewTemplate.ExecuteTemplate(w, "index.html", htv)
 	if err != nil {
 		log.Errorf("ViewHandler(): %s", err)

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,7 +1,7 @@
-{{define "title"}}{{T "404_not_found"}}{{end}}
+{{define "title"}}{{call $.T "404_not_found"}}{{end}}
 {{define "content"}}
     <div>
-        <h1>{{T "404_not_found"}}</h1>
+        <h1>{{call $.T "404_not_found"}}</h1>
         <br />
         <img class="center-block center-image" src="/img/404.svg"></img>
     </div>

--- a/templates/FAQ.html
+++ b/templates/FAQ.html
@@ -1,50 +1,50 @@
-{{define "title"}}{{T "faq"}}{{end}}
+{{define "title"}}{{call $.T "faq"}}{{end}}
 {{define "content"}}
     <div class="blockBody">
         <!-- marquees are the true purpose of HTML -->
-        <marquee><h2>{{T "notice_keep_seeding"}}</h2></marquee>
+        <marquee><h2>{{call $.T "notice_keep_seeding"}}</h2></marquee>
 
-        <h1>{{T "official_nyaapocalipse_faq"}}</h1>
+        <h1>{{call $.T "official_nyaapocalipse_faq"}}</h1>
         <br />
 
-        <h2>{{T "links_replacement_mirror"}}</h2>
+        <h2>{{call $.T "links_replacement_mirror"}}</h2>
         <a href="https://nyaa.pantsu.cat">Nyaa - nyaa.pantsu.cat</a><br />
         <a href="https://sukebei.pantsu.cat">Sukebei - sukebei.pantsu.cat</a>
 
-        <h2>{{T "server_status_link"}}</h2>
+        <h2>{{call $.T "server_status_link"}}</h2>
         <a href="https://status.pantsu.cat/">https://status.pantsu.cat/</a><br />
 
-        <h2>{{T "what_happened"}}</h2>
+        <h2>{{call $.T "what_happened"}}</h2>
         <ul>
-            <li>{{T "nyaa_se_went_offline"}}</li>
-            <li>{{T "its_not_a_ddos"}}</li>
-            <li>{{T "future_not_looking_good"}}</li>
-            <li>{{T "recovery_effort"}}</li>
+            <li>{{call $.T "nyaa_se_went_offline"}}</li>
+            <li>{{call $.T "its_not_a_ddos"}}</li>
+            <li>{{call $.T "future_not_looking_good"}}</li>
+            <li>{{call $.T "recovery_effort"}}</li>
         </ul>
 
-        <h2>{{T "is_everything_lost"}}</h2>
-        <p>{{T "in_short_no"}}</p>
+        <h2>{{call $.T "is_everything_lost"}}</h2>
+        <p>{{call $.T "in_short_no"}}</p>
 
-        <h2>{{T "are_some_things_lost"}}</h2>
-        <p>{{T "answer_is_nyaa_db_lost"}}</p>
-        <p>{{T "answer_is_sukebei_db_lost"}}</p>
+        <h2>{{call $.T "are_some_things_lost"}}</h2>
+        <p>{{call $.T "answer_is_nyaa_db_lost"}}</p>
+        <p>{{call $.T "answer_is_sukebei_db_lost"}}</p>
 
-        <h2>{{T "how_are_we_recovering"}}</h2>
-        <p>{{T "answer_how_are_we_recovering"}}</p>
+        <h2>{{call $.T "how_are_we_recovering"}}</h2>
+        <p>{{call $.T "answer_how_are_we_recovering"}}</p>
 
-        <h2>{{T "are_the_trackers_working"}}</h2>
-        <p>{{T "answer_are_the_trackers_working"}}</p>
+        <h2>{{call $.T "are_the_trackers_working"}}</h2>
+        <p>{{call $.T "answer_are_the_trackers_working"}}</p>
 
-        <h2>{{T "how_do_i_download_the_torrents"}}</h2>
-        <p>{{T "answer_how_do_i_download_the_torrents"}}</p>
-        <p>{{T "magnet_link_should_look_like"}} <span style="font-family:monospace">
+        <h2>{{call $.T "how_do_i_download_the_torrents"}}</h2>
+        <p>{{call $.T "answer_how_do_i_download_the_torrents"}}</p>
+        <p>{{call $.T "magnet_link_should_look_like"}} <span style="font-family:monospace">
             magnet:?xt=urn:btih:[hash]&amp;dn=[name]&amp;tr=[tracker]&amp;tr=[...]</span></p>
 
-        <h2>{{T "how_do_i_link_my_old_account"}}</h2>
-        <p>{{T "answer_how_do_i_link_my_old_account"}}</p>
+        <h2>{{call $.T "how_do_i_link_my_old_account"}}</h2>
+        <p>{{call $.T "answer_how_do_i_link_my_old_account"}}</p>
 
-        <h2 id="trackers">{{T "which_trackers_do_you_recommend"}}</h2>
-        <p>{{T "answer_which_trackers_do_you_recommend"}}</p>
+        <h2 id="trackers">{{call $.T "which_trackers_do_you_recommend"}}</h2>
+        <p>{{call $.T "answer_which_trackers_do_you_recommend"}}</p>
 	<pre>udp://tracker.doko.moe:6969 
 udp://zer0day.to:1337/announce 
 udp://tracker.leechers-paradise.org:6969 
@@ -54,17 +54,17 @@ udp://tracker.internetwarriors.net:1337/announce
 http://mgtracker.org:6969/announce 
 http://tracker.baka-sub.cf/announce</pre> 
 
-        <h2>{{T "how_can_i_help"}}</h2>
-        <p>{{T "answer_how_can_i_help"}}</p>
+        <h2>{{call $.T "how_can_i_help"}}</h2>
+        <p>{{call $.T "answer_how_can_i_help"}}</p>
 
-        <h2>{{T "your_design_sucks_found_a_bug"}}</h2>
+        <h2>{{call $.T "your_design_sucks_found_a_bug"}}</h2>
         <p><a href="https://github.com/NyaaPantsu/nyaa/issues">https://github.com/NyaaPantsu/nyaa/issues</a>.</p>
 
-        <h2>{{T "why_written_in_go"}}</h2>
-        <p>{{T "authors_favorite_language"}}</p>
+        <h2>{{call $.T "why_written_in_go"}}</h2>
+        <p>{{call $.T "authors_favorite_language"}}</p>
 
-		<h2>{{T "who_is_renchon"}}</h2>
-		<p>{{T "renchon_anon_explanation" }}</p>
+		<h2>{{call $.T "who_is_renchon"}}</h2>
+		<p>{{call $.T "renchon_anon_explanation" }}</p>
 
         <br />
 

--- a/templates/_badgemenu.html
+++ b/templates/_badgemenu.html
@@ -6,21 +6,21 @@
 		    <a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}" class="dropdown-toggle profile-image" data-toggle="dropdown">
 		    <img src="https://www.gravatar.com/avatar/{{ .MD5 }}?s=50" class="img-circle special-img"> {{ .Username }} <b class="caret"></b></a>
 		    <ul class="dropdown-menu">
-		        <li><a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}"><i class="fa fa-cog"></i> {{T "profile"}}</a></li>
-		        <li><a href="{{ genRoute "user_profile_edit" "id" (print .ID) "username" .Username }}"><i class="fa fa-cog"></i> {{T "settings"}}</a></li>
-		        {{if HasAdmin . }}<li><a href="{{ genRoute "mod_index" }}"><i class="fa fa-cog"></i> {{T "moderation"}}</a></li>{{end}}
+		        <li><a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}"><i class="fa fa-cog"></i> {{call $.T "profile"}}</a></li>
+		        <li><a href="{{ genRoute "user_profile_edit" "id" (print .ID) "username" .Username }}"><i class="fa fa-cog"></i> {{call $.T "settings"}}</a></li>
+		        {{if HasAdmin . }}<li><a href="{{ genRoute "mod_index" }}"><i class="fa fa-cog"></i> {{call $.T "moderation"}}</a></li>{{end}}
 		        <li class="divider"></li>
-		        <li><a href="{{ genRoute "user_logout" }}"><i class="fa fa-sign-out"></i> {{ T "sign_out"}}</a></li>
+		        <li><a href="{{ genRoute "user_logout" }}"><i class="fa fa-sign-out"></i> {{ call $.T "sign_out"}}</a></li>
 		    </ul>
 		    {{ else }}
             <a href="#" class="dropdown-toggle profile-image" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-		    <span class="hidden-md hidden-sm">{{ T "member" }}</span>
+		    <span class="hidden-md hidden-sm">{{ call $.T "member" }}</span>
 		    <span class="glyphicon glyphicon-user visible-md-inline"></span>
 		    <span class="caret"></span>
 	    </a>
             <ul class="dropdown-menu">
-                <li><a href="{{ genRoute "user_login" }}"><i class="fa fa-sign-out"></i> {{ T "sign_in"}}</a></li>
-                <li><a href="{{ genRoute "user_register" }}"><i class="fa fa-cog"></i> {{ T "sign_up"}}</a></li>
+                <li><a href="{{ genRoute "user_login" }}"><i class="fa fa-sign-out"></i> {{ call $.T "sign_in"}}</a></li>
+                <li><a href="{{ genRoute "user_register" }}"><i class="fa fa-cog"></i> {{ call $.T "sign_up"}}</a></li>
             </ul>
 	{{end}}
 		</li>

--- a/templates/_captcha.html
+++ b/templates/_captcha.html
@@ -2,10 +2,10 @@
 	{{/* unset if user doesn't need captcha */}}
 	{{if ne .CaptchaID ""}}
 	<div class="form-group captcha-container">
-		<label for="solution">{{T "captcha"}}</label>
+		<label for="solution">{{call $.T "captcha"}}</label>
 		<input type="text" name="captchaID" value="{{.CaptchaID}}" hidden>
 		<img src="/captcha/{{.CaptchaID}}.png">
-		<input type="text" name="solution" id="solution" class="form-control" placeholder="{{T "captcha"}}" autocomplete="off" required>
+		<input type="text" name="solution" id="solution" class="form-control" placeholder="{{call $.T "captcha"}}" autocomplete="off" required>
 	</div>
 	{{end}}
 {{end}}

--- a/templates/_profile_edit.html
+++ b/templates/_profile_edit.html
@@ -6,15 +6,15 @@
 		{{ range (index $.FormErrors "errors")}}
 			<div class="alert alert-danger"><a class="panel-close close" data-dismiss="alert">×</a><i class="glyphicon glyphicon-exclamation-sign"></i> {{ . }}</div>
 		{{end}}
-        <h3>{{ T "personal_info"}}</h3>
+        <h3>{{ call $.T "personal_info"}}</h3>
         
         <form class="form-horizontal" role="form" method="POST">
           <div class="form-group">
-            <label class="col-lg-3 control-label">{{T "api_token" }}:</label>
+            <label class="col-lg-3 control-label">{{call $.T "api_token" }}:</label>
               <div class="col-lg-8">{{.ApiToken}}</div>
           </div>
           <div class="form-group">
-            <label class="col-lg-3 control-label">{{ T "email_address" }}:</label>
+            <label class="col-lg-3 control-label">{{ call $.T "email_address" }}:</label>
             <div class="col-lg-8">
               <input class="form-control" type="text" name="email" id="email" value="{{.Email}}">
 	 			{{ range (index $.FormErrors "email")}}
@@ -23,13 +23,13 @@
             </div>
           </div>
           <div class="form-group">
-            <label class="col-lg-3 control-label">{{ T "language"}}:</label>
+            <label class="col-lg-3 control-label">{{ call $.T "language"}}:</label>
             <div class="col-lg-8">
               <div class="ui-select">
                 <select id="language" name="language" class="form-control">
 					{{ $userLanguage := .Language }}
 					{{ range $tag, $translatedName := $.Languages }}
-						<option value="{{ $tag }}" {{ if or (eq $userLanguage $tag) (and (eq $userLanguage "") (eq $tag getDefaultLanguage)) }}selected{{end}}>{{ $translatedName }} {{if eq $tag getDefaultLanguage}}({{ T "default" }}){{end}}</option>
+						<option value="{{ $tag }}" {{ if or (eq $userLanguage $tag) (and (eq $userLanguage "") (eq $tag getDefaultLanguage)) }}selected{{end}}>{{ $translatedName }} {{if eq $tag getDefaultLanguage}}({{ call $.T "default" }}){{end}}</option>
 					{{ end }}
                 </select>
               </div>
@@ -40,7 +40,7 @@
           </div>
           {{ if not (HasAdmin $.User)}}
           <div class="form-group">
-            <label class="col-md-3 control-label">{{ T "current_password"}}:</label>
+            <label class="col-md-3 control-label">{{ call $.T "current_password"}}:</label>
             <div class="col-md-8">
               <input class="form-control" name="current_password" id="current_password" type="password">
 	 			{{ range (index $.FormErrors "current_password")}}
@@ -50,7 +50,7 @@
           </div>
           {{end}}
           <div class="form-group">
-            <label class="col-md-3 control-label">{{ T "password"}}:</label>
+            <label class="col-md-3 control-label">{{ call $.T "password"}}:</label>
             <div class="col-md-8">
               <input class="form-control" name="password" id="password" type="password">
 	 			{{ range (index $.FormErrors "password")}}
@@ -59,7 +59,7 @@
             </div>
           </div>
           <div class="form-group">
-            <label class="col-md-3 control-label">{{ T "confirm_password"}}:</label>
+            <label class="col-md-3 control-label">{{ call $.T "confirm_password"}}:</label>
             <div class="col-md-8">
               <input class="form-control" name="password_confirmation" id="password_confirmation" type="password">
 	 			{{ range (index $.FormErrors "password_confirmation")}}
@@ -68,9 +68,9 @@
             </div>
           </div>
           {{ if HasAdmin $.User}}
-          <h3>{{ T "moderation"}}</h3>
+          <h3>{{ call $.T "moderation"}}</h3>
           <div class="form-group">
-            <label class="col-md-3 control-label">{{ T "username"}}:</label>
+            <label class="col-md-3 control-label">{{ call $.T "username"}}:</label>
             <div class="col-md-8">
               <input class="form-control" name="username" id="username" type="text" value="{{.Username}}">
 	 			{{ range (index $.FormErrors "username")}}
@@ -79,15 +79,15 @@
             </div>
           </div>
           <div class="form-group">
-            <label class="col-lg-3 control-label">{{ T "role" }}:</label>
+            <label class="col-lg-3 control-label">{{ call $.T "role" }}:</label>
             <div class="col-lg-8">
               <div class="ui-select">
                 <select id="status" name="status" class="form-control">
-                	<option value="-1" {{ if eq .Status -1 }}selected{{end}}>{{ T "banned"}}</option>
-                	<option value="0" {{ if eq .Status 0 }}selected{{end}}>{{ T "member"}} ({{ T "default" }})</option>
-                	<option value="1" {{ if eq .Status 1 }}selected{{end}}>{{ T "trusted_member"}}</option>
+                	<option value="-1" {{ if eq .Status -1 }}selected{{end}}>{{ call $.T "banned"}}</option>
+                	<option value="0" {{ if eq .Status 0 }}selected{{end}}>{{ call $.T "member"}} ({{ call $.T "default" }})</option>
+                	<option value="1" {{ if eq .Status 1 }}selected{{end}}>{{ call $.T "trusted_member"}}</option>
                 	{{ if eq .Status 2 }} <!-- just so that it shows correctly -->
-                        <option value="2" selected>{{ T "moderator"}}</option>
+                        <option value="2" selected>{{ call $.T "moderator"}}</option>
                 	{{end}}
                 </select>
               </div>
@@ -100,15 +100,15 @@
           <div class="form-group">
             <label class="col-md-3 control-label"></label>
             <div class="col-md-8">
-              <input type="submit" class="btn btn-primary" name="save" value="{{ T "save_changes"}}">
+              <input type="submit" class="btn btn-primary" name="save" value="{{ call $.T "save_changes"}}">
               <span></span>
-              <input type="reset" class="btn btn-default" value="{{ T "cancel"}}">
+              <input type="reset" class="btn btn-default" value="{{ call $.T "cancel"}}">
             </div>
           </div>
         </form>
         {{ if CurrentOrAdmin $.User .ID }}
         <hr>
-        <a href="?delete" onclick="if (!confirm('{{ T "delete_account_confirm" }}')) return false;" class="btn btn-danger btn-lg"><i class="glyphicon glyphicon-trash"></i> {{ T "delete_account"}}</a>
+        <a href="?delete" onclick="if (!confirm('{{ call $.T "delete_account_confirm" }}')) return false;" class="btn btn-danger btn-lg"><i class="glyphicon glyphicon-trash"></i> {{ call $.T "delete_account"}}</a>
         {{end}}
 	{{end}}
 {{end}}

--- a/templates/_search.html
+++ b/templates/_search.html
@@ -1,46 +1,46 @@
 {{define "search_common"}}
   <select name="c" class="form-control input-sm" value>
-    <option value="_">{{T "all_categories"}}</option>
+    <option value="_">{{call $.T "all_categories"}}</option>
     {{ if Sukebei }}
-    <option value="1_" {{if eq .Search.Category "1_"}}selected{{end}}>{{T "art"}}</option>
-    <option value="1_1" {{if eq .Search.Category "1_1"}}selected{{end}}>{{T "art_anime"}}</option>
-    <option value="1_2" {{if eq .Search.Category "1_2"}}selected{{end}}>{{T "art_doujinshi"}}</option>
-    <option value="1_3" {{if eq .Search.Category "1_3"}}selected{{end}}>{{T "art_games"}}</option>
-    <option value="1_4" {{if eq .Search.Category "1_4"}}selected{{end}}>{{T "art_manga"}}</option>
-    <option value="1_5" {{if eq .Search.Category "1_5"}}selected{{end}}>{{T "art_pictures"}}</option>
-    <option value="2_" {{if eq .Search.Category "2_"}}selected{{end}}>{{T "real_life"}}</option>
-    <option value="2_1" {{if eq .Search.Category "2_1"}}selected{{end}}>{{T "real_life_photobooks_and_pictures"}}</option>
-    <option value="2_2" {{if eq .Search.Category "2_2"}}selected{{end}}>{{T "real_life_videos"}}</option>
+    <option value="1_" {{if eq .Search.Category "1_"}}selected{{end}}>{{call $.T "art"}}</option>
+    <option value="1_1" {{if eq .Search.Category "1_1"}}selected{{end}}>{{call $.T "art_anime"}}</option>
+    <option value="1_2" {{if eq .Search.Category "1_2"}}selected{{end}}>{{call $.T "art_doujinshi"}}</option>
+    <option value="1_3" {{if eq .Search.Category "1_3"}}selected{{end}}>{{call $.T "art_games"}}</option>
+    <option value="1_4" {{if eq .Search.Category "1_4"}}selected{{end}}>{{call $.T "art_manga"}}</option>
+    <option value="1_5" {{if eq .Search.Category "1_5"}}selected{{end}}>{{call $.T "art_pictures"}}</option>
+    <option value="2_" {{if eq .Search.Category "2_"}}selected{{end}}>{{call $.T "real_life"}}</option>
+    <option value="2_1" {{if eq .Search.Category "2_1"}}selected{{end}}>{{call $.T "real_life_photobooks_and_pictures"}}</option>
+    <option value="2_2" {{if eq .Search.Category "2_2"}}selected{{end}}>{{call $.T "real_life_videos"}}</option>
     {{ else }}
-    <option value="3_" {{if eq .Search.Category "3_"}}selected{{end}}>{{T "anime"}}</option>
-    <option value="3_12" {{if eq .Search.Category "3_12"}}selected{{end}}>{{T "anime_amv"}}</option>
-    <option value="3_5" {{if eq .Search.Category "3_5"}}selected{{end}}>{{T "anime_english_translated"}}</option>
-    <option value="3_13" {{if eq .Search.Category "3_13"}}selected{{end}}>{{T "anime_non_english_translated"}}</option>
-    <option value="3_6" {{if eq .Search.Category "3_6"}}selected{{end}}>{{T "anime_raw"}}</option>
-    <option value="2_" {{if eq .Search.Category "2_"}}selected{{end}}>{{T "audio"}}</option>
-    <option value="2_3" {{if eq .Search.Category "2_3"}}selected{{end}}>{{T "audio_lossless"}}</option>
-    <option value="2_4" {{if eq .Search.Category "2_4"}}selected{{end}}>{{T "audio_lossy"}}</option>
-    <option value="4_" {{if eq .Search.Category "4_"}}selected{{end}}>{{T "literature"}}</option>
-    <option value="4_7" {{if eq .Search.Category "4_7"}}selected{{end}}>{{T "literature_english_translated"}}</option>
-    <option value="4_8" {{if eq .Search.Category "4_8"}}selected{{end}}>{{T "literature_raw"}}</option>
-    <option value="4_14" {{if eq .Search.Category "4_14"}}selected{{end}}>{{T "literature_non_english_translated"}}</option>
-    <option value="5_" {{if eq .Search.Category "5_"}}selected{{end}}>{{T "live_action"}}</option>
-    <option value="5_9" {{if eq .Search.Category "5_9"}}selected{{end}}>{{T "live_action_english_translated"}}</option>
-    <option value="5_10" {{if eq .Search.Category "5_10"}}selected{{end}}>{{T "live_action_idol_pv"}}</option>
-    <option value="5_18" {{if eq .Search.Category "5_18"}}selected{{end}}>{{T "live_action_non_english_translated"}}</option>
-    <option value="5_11" {{if eq .Search.Category "5_11"}}selected{{end}}>{{T "live_action_raw"}}</option>
-    <option value="6_" {{if eq .Search.Category "6_"}}selected{{end}}>{{T "pictures"}}</option>
-    <option value="6_15" {{if eq .Search.Category "6_15"}}selected{{end}}>{{T "pictures_graphics"}}</option>
-    <option value="6_16" {{if eq .Search.Category "6_16"}}selected{{end}}>{{T "pictures_photos"}}</option>
-    <option value="1_" {{if eq .Search.Category "1_"}}selected{{end}}>{{T "software"}}</option>
-    <option value="1_1" {{if eq .Search.Category "1_1"}}selected{{end}}>{{T "software_applications"}}</option>
-    <option value="1_2" {{if eq .Search.Category "1_2"}}selected{{end}}>{{T "software_games"}}</option>
+    <option value="3_" {{if eq .Search.Category "3_"}}selected{{end}}>{{call $.T "anime"}}</option>
+    <option value="3_12" {{if eq .Search.Category "3_12"}}selected{{end}}>{{call $.T "anime_amv"}}</option>
+    <option value="3_5" {{if eq .Search.Category "3_5"}}selected{{end}}>{{call $.T "anime_english_translated"}}</option>
+    <option value="3_13" {{if eq .Search.Category "3_13"}}selected{{end}}>{{call $.T "anime_non_english_translated"}}</option>
+    <option value="3_6" {{if eq .Search.Category "3_6"}}selected{{end}}>{{call $.T "anime_raw"}}</option>
+    <option value="2_" {{if eq .Search.Category "2_"}}selected{{end}}>{{call $.T "audio"}}</option>
+    <option value="2_3" {{if eq .Search.Category "2_3"}}selected{{end}}>{{call $.T "audio_lossless"}}</option>
+    <option value="2_4" {{if eq .Search.Category "2_4"}}selected{{end}}>{{call $.T "audio_lossy"}}</option>
+    <option value="4_" {{if eq .Search.Category "4_"}}selected{{end}}>{{call $.T "literature"}}</option>
+    <option value="4_7" {{if eq .Search.Category "4_7"}}selected{{end}}>{{call $.T "literature_english_translated"}}</option>
+    <option value="4_8" {{if eq .Search.Category "4_8"}}selected{{end}}>{{call $.T "literature_raw"}}</option>
+    <option value="4_14" {{if eq .Search.Category "4_14"}}selected{{end}}>{{call $.T "literature_non_english_translated"}}</option>
+    <option value="5_" {{if eq .Search.Category "5_"}}selected{{end}}>{{call $.T "live_action"}}</option>
+    <option value="5_9" {{if eq .Search.Category "5_9"}}selected{{end}}>{{call $.T "live_action_english_translated"}}</option>
+    <option value="5_10" {{if eq .Search.Category "5_10"}}selected{{end}}>{{call $.T "live_action_idol_pv"}}</option>
+    <option value="5_18" {{if eq .Search.Category "5_18"}}selected{{end}}>{{call $.T "live_action_non_english_translated"}}</option>
+    <option value="5_11" {{if eq .Search.Category "5_11"}}selected{{end}}>{{call $.T "live_action_raw"}}</option>
+    <option value="6_" {{if eq .Search.Category "6_"}}selected{{end}}>{{call $.T "pictures"}}</option>
+    <option value="6_15" {{if eq .Search.Category "6_15"}}selected{{end}}>{{call $.T "pictures_graphics"}}</option>
+    <option value="6_16" {{if eq .Search.Category "6_16"}}selected{{end}}>{{call $.T "pictures_photos"}}</option>
+    <option value="1_" {{if eq .Search.Category "1_"}}selected{{end}}>{{call $.T "software"}}</option>
+    <option value="1_1" {{if eq .Search.Category "1_1"}}selected{{end}}>{{call $.T "software_applications"}}</option>
+    <option value="1_2" {{if eq .Search.Category "1_2"}}selected{{end}}>{{call $.T "software_games"}}</option>
     {{ end }}
   </select>
   <select name="s" class="form-control input-sm">
-    <option value="0">{{T "show_all"}}</option>
-    <option value="1" {{if eq .Search.Status 1}}selected{{end}}>{{T "filter_remakes"}}</option>
-    <option value="2" {{if eq .Search.Status 2}}selected{{end}}>{{T "trusted"}}</option>
+    <option value="0">{{call $.T "show_all"}}</option>
+    <option value="1" {{if eq .Search.Status 1}}selected{{end}}>{{call $.T "filter_remakes"}}</option>
+    <option value="2" {{if eq .Search.Status 2}}selected{{end}}>{{call $.T "trusted"}}</option>
     <option value="3" {{if eq .Search.Status 3}}selected{{end}}>A+</option>
   </select>
   {{ if .Search.ShowItemsPerPage }}
@@ -66,9 +66,9 @@
 {{end}}
 {{define "search_button"}}
   <div class="input-group">
-    <input name="q" class="form-control input-sm" placeholder="{{T "search"}}" type="text" value="{{.Search.Query}}">
+    <input name="q" class="form-control input-sm" placeholder="{{call $.T "search"}}" type="text" value="{{.Search.Query}}">
     <span class="input-group-btn">
-      <button type="submit" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-search" aria-hidden="true"></span><span class="search_text"> {{T "search"}}</span></button>
+      <button type="submit" class="btn btn-sm btn-success"><span class="glyphicon glyphicon-search" aria-hidden="true"></span><span class="search_text"> {{call $.T "search"}}</span></button>
     </span>
   </div>
 {{end}}

--- a/templates/_user_list_torrents.html
+++ b/templates/_user_list_torrents.html
@@ -4,11 +4,11 @@
       <div class="table-responsive">
           <table class="table custom-table-hover">
           <tr>
-			<th>{{T "category"}}</th>
-            <th>{{T "name"}}</th>
-            <th>{{T "date"}}</th>
-            <th>{{T "size"}}</th>
-            <th>{{T "links"}}</th>
+            <th>{{call $.T "category"}}</th>
+            <th>{{call $.T "name"}}</th>
+            <th>{{call $.T "date"}}</th>
+            <th>{{call $.T "size"}}</th>
+            <th>{{call $.T "links"}}</th>
           </tr>
           {{ range $i, $t := .Torrents }}
           {{ if lt $i 16 }}
@@ -21,9 +21,9 @@
               <td style="width:80px">
                   <a href="{{$.URL.Parse (printf "/search?c=%s_%s" .Category .SubCategory) }}">
                       {{ if Sukebei }}
-                      <img src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ T (Category_Sukebei .Category .SubCategory) }}">
+                      <img src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ call $.T (Category_Sukebei .Category .SubCategory) }}">
                       {{ else }}
-                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ T (Category_Nyaa .Category .SubCategory) }}">
+                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ call $.T (Category_Nyaa .Category .SubCategory) }}">
                       {{ end}}
                   </a>
               </td>
@@ -35,11 +35,11 @@
               <td class="nowrap date-short">{{.Date}}</td>
               <td class="nowrap">{{.Filesize}}</td>
               <td>
-                  <a href="{{.Magnet}}" title="{{ T "magnet_link" }}">
+                  <a href="{{.Magnet}}" title="{{ call $.T "magnet_link" }}">
                       <span class="glyphicon glyphicon-magnet" aria-hidden="true"></span>
                   </a>
                   {{if ne .TorrentLink ""}}
-                  <a href="{{.TorrentLink}}" title="{{ T "torrent_file" }}">
+                  <a href="{{.TorrentLink}}" title="{{ call $.T "torrent_file" }}">
                       <span class="glyphicon glyphicon-floppy-save" aria-hidden="true"></span> 
                   </a>
                   {{end}}
@@ -51,12 +51,12 @@
       </table>
       <nav class="torrentNav" aria-label="Page navigation">
           <ul class="pagination">
-              <li><a href="{{ genRoute "search" }}?userID={{ .ID }}" aria-label="Next"><span class="glyphicon glyphicon-add"></span> {{ T "see_more_torrents_from" .Username }}</a></li>
+              <li><a href="{{ genRoute "search" }}?userID={{ .ID }}" aria-label="Next"><span class="glyphicon glyphicon-add"></span> {{ call $.T "see_more_torrents_from" .Username }}</a></li>
           </ul>
       </nav>
     </div>
     {{else}}
-     <h2 style="text-align: center;">{{ T "no_torrents_uploaded" }}</h2>
+     <h2 style="text-align: center;">{{ call $.T "no_torrents_uploaded" }}</h2>
 {{end}}
 {{end}}
 {{end}}

--- a/templates/admin/commentlist.html
+++ b/templates/admin/commentlist.html
@@ -15,7 +15,7 @@
     <td><a>{{ .Content }}</a></td>
     <td><a href="{{ genViewTorrentRoute .TorrentID }}">{{ .TorrentID }}</a></td>
     <td>{{ .UserID }}</td>
-    <td><a href="{{ genRoute "mod_cdelete" }}?id={{.ID}}" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ T "delete" }}</a></td></tr>
+    <td><a href="{{ genRoute "mod_cdelete" }}?id={{.ID}}" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ call $.T "delete" }}</a></td></tr>
 {{end}}
 </table>
       <nav class="torrentNav" aria-label="Page navigation">

--- a/templates/admin/panelindex.html
+++ b/templates/admin/panelindex.html
@@ -11,7 +11,7 @@
 <tr>
     <td><a href="{{ genViewTorrentRoute .ID }}">{{ .Name }}</a> (<a href="{{ genRoute "mod_tedit" }}?id={{.ID}}">Edit</a>)</td>
     <td><a href="{{ genRoute "mod_tlist" }}?userID={{.UploaderID}}">{{ .UploaderID }}</a></td>
-    <td><a href="{{ genRoute "mod_tdelete" }}?id={{ .ID }}" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ T "delete" }}</a></td>
+    <td><a href="{{ genRoute "mod_tdelete" }}?id={{ .ID }}" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ call $.T "delete" }}</a></td>
 </tr>
 {{end}}
 </table>
@@ -36,7 +36,7 @@
     <td><a href="{{ genRoute "view_torrent" "id" .Torrent.ID }}">{{ .Torrent.Name }}</a> (<a href="{{ genRoute "mod_tedit" }}?id={{.Torrent.ID}}">Edit</a>)</td>
     <td>{{.User.Username}}</td>
     <td>{{.Description}}</td>
-    <td><a href="{{ genRoute "mod_trdelete" }}?id={{ .ID }}" class="btn btn-danger btn-lg"><i class="glyphicon glyphicon-trash"></i> {{ T "delete" }}</a></td>
+    <td><a href="{{ genRoute "mod_trdelete" }}?id={{ .ID }}" class="btn btn-danger btn-lg"><i class="glyphicon glyphicon-trash"></i> {{ call $.T "delete" }}</a></td>
 </tr>
 {{end}}
 </table>
@@ -57,7 +57,7 @@
 
 <tr>
     <td><a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}?edit">{{ .Username }}</a></td>
-    <td><a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}?delete" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ T "delete" }}</a></td>
+    <td><a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}?delete" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ call $.T "delete" }}</a></td>
 </tr>
 {{end}}
 </table>
@@ -80,7 +80,7 @@
 <tr>
     <td><a href="{{ genRoute "mod_cedit" }}?id={{.ID}}">{{ .Content }}</a></td>
     <td><a href="{{ genRoute "mod_cedit" }}?id={{.ID}}">{{.UserID}}</a></td>
-    <td><a href="{{ genRoute "mod_cdelete" }}?id={{ .ID }}" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ T "delete" }}</a></td>
+    <td><a href="{{ genRoute "mod_cdelete" }}?id={{ .ID }}" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ call $.T "delete" }}</a></td>
 </tr>
 {{end}}
 </table>

--- a/templates/admin/paneltorrentedit.html
+++ b/templates/admin/paneltorrentedit.html
@@ -9,67 +9,67 @@
 			<div class="alert alert-danger"><a class="panel-close close" data-dismiss="alert">×</a><i class="glyphicon glyphicon-exclamation-sign"></i> {{ . }}</div>
 		{{end}}
       <div class="form-group">
-      <label for="name">{{T "name"}}</label>
-          <input type="text" name="name" class="form-control" placeholder="{{T "file_name"}}" value="{{.Name}}" required>
+      <label for="name">{{call $.T "name"}}</label>
+          <input type="text" name="name" class="form-control" placeholder="{{call $.T "file_name"}}" value="{{.Name}}" required>
       </div>
       <div class="form-group">
-          <label for="c">{{T "category"}}</label>
+          <label for="c">{{call $.T "category"}}</label>
           <select name="c" class="form-control input-sm">
-              <option value="">{{T "select_a_torrent_category"}}</option>
+              <option value="">{{call $.T "select_a_torrent_category"}}</option>
               {{ if Sukebei }}
-              <option value="1_" {{if eq .Category "1_"}}selected{{end}}>{{T "art"}}</option>
-              <option value="1_1" {{if eq .Category "1_1"}}selected{{end}}>{{T "art_anime"}}</option>
-              <option value="1_2" {{if eq .Category "1_2"}}selected{{end}}>{{T "art_doujinshi"}}</option>
-              <option value="1_3" {{if eq .Category "1_3"}}selected{{end}}>{{T "art_games"}}</option>
-              <option value="1_4" {{if eq .Category "1_4"}}selected{{end}}>{{T "art_manga"}}</option>
-              <option value="1_5" {{if eq .Category "1_5"}}selected{{end}}>{{T  "art_pictures"}}</option>
-              <option value="2_" {{if eq .Category "2_"}}selected{{end}}>{{T "real_life"}}</option>
-              <option value="2_1" {{if eq .Category "2_1"}}selected{{end}}>{{T "real_life_photobooks_and_Pictures"}}</option>
-              <option value="2_2" {{if eq .Category "2_2"}}selected{{end}}>{{T "real_life_videos"}}</option>
+              <option value="1_" {{if eq .Category "1_"}}selected{{end}}>{{call $.T "art"}}</option>
+              <option value="1_1" {{if eq .Category "1_1"}}selected{{end}}>{{call $.T "art_anime"}}</option>
+              <option value="1_2" {{if eq .Category "1_2"}}selected{{end}}>{{call $.T "art_doujinshi"}}</option>
+              <option value="1_3" {{if eq .Category "1_3"}}selected{{end}}>{{call $.T "art_games"}}</option>
+              <option value="1_4" {{if eq .Category "1_4"}}selected{{end}}>{{call $.T "art_manga"}}</option>
+              <option value="1_5" {{if eq .Category "1_5"}}selected{{end}}>{{call $.T "art_pictures"}}</option>
+              <option value="2_" {{if eq .Category "2_"}}selected{{end}}>{{call $.T "real_life"}}</option>
+              <option value="2_1" {{if eq .Category "2_1"}}selected{{end}}>{{call $.T "real_life_photobooks_and_Pictures"}}</option>
+              <option value="2_2" {{if eq .Category "2_2"}}selected{{end}}>{{call $.T "real_life_videos"}}</option>
               {{ else }}
-              <option value="3_" {{if eq .Category "3_"}}selected{{end}}>{{T "anime"}}</option>
-              <option value="3_12" {{if eq .Category "3_12"}}selected{{end}}>{{T "anime_amv"}}</option>
-              <option value="3_5" {{if eq .Category "3_5"}}selected{{end}}>{{T "anime_english_translated"}}</option>
-              <option value="3_13" {{if eq .Category "3_13"}}selected{{end}}>{{T "anime_non_english_translated"}}</option>
-              <option value="3_6" {{if eq .Category "3_6"}}selected{{end}}>{{T "anime_raw"}}</option>
-              <option value="2_" {{if eq .Category "2_"}}selected{{end}}>{{T "audio"}}</option>
-              <option value="2_3" {{if eq .Category "2_3"}}selected{{end}}>{{T "audio_lossless"}}</option>
-              <option value="2_4" {{if eq .Category "2_4"}}selected{{end}}>{{T "audio_lossy"}}</option>
-              <option value="4_" {{if eq .Category "4_"}}selected{{end}}>{{T "literature"}}</option>
-              <option value="4_7" {{if eq .Category "4_7"}}selected{{end}}>{{T "literature_english_translated"}}</option>
-              <option value="4_8" {{if eq .Category "4_8"}}selected{{end}}>{{T "literature_raw"}}</option>
-              <option value="4_14" {{if eq .Category "4_14"}}selected{{end}}>{{T "literature_non_english_translated"}}</option>
-              <option value="5_" {{if eq .Category "5_"}}selected{{end}}>{{T "live_action"}}</option>
-              <option value="5_9" {{if eq .Category "5_9"}}selected{{end}}>{{T "live_action_english_translated"}}</option>
-              <option value="5_10" {{if eq .Category "5_10"}}selected{{end}}>{{T "live_action_idol_pv"}}</option>
-              <option value="5_18" {{if eq .Category "5_18"}}selected{{end}}>{{T "live_action_non_english_translated"}}</option>
-              <option value="5_11" {{if eq .Category "5_11"}}selected{{end}}>{{T "live_action_raw"}}</option>
-              <option value="6_" {{if eq .Category "6_"}}selected{{end}}>{{T "pictures"}}</option>
-              <option value="6_15" {{if eq .Category "6_15"}}selected{{end}}>{{T "pictures_graphics"}}</option>
-              <option value="6_16" {{if eq .Category "6_16"}}selected{{end}}>{{T "pictures_photos"}}</option>
-              <option value="1_" {{if eq .Category "1_"}}selected{{end}}>{{T "software"}}</option>
-              <option value="1_1" {{if eq .Category "1_1"}}selected{{end}}>{{T "software_applications"}}</option>
-              <option value="1_2" {{if eq .Category "1_2"}}selected{{end}}>{{T "software_games"}}</option>
+              <option value="3_" {{if eq .Category "3_"}}selected{{end}}>{{call $.T "anime"}}</option>
+              <option value="3_12" {{if eq .Category "3_12"}}selected{{end}}>{{call $.T "anime_amv"}}</option>
+              <option value="3_5" {{if eq .Category "3_5"}}selected{{end}}>{{call $.T "anime_english_translated"}}</option>
+              <option value="3_13" {{if eq .Category "3_13"}}selected{{end}}>{{call $.T "anime_non_english_translated"}}</option>
+              <option value="3_6" {{if eq .Category "3_6"}}selected{{end}}>{{call $.T "anime_raw"}}</option>
+              <option value="2_" {{if eq .Category "2_"}}selected{{end}}>{{call $.T "audio"}}</option>
+              <option value="2_3" {{if eq .Category "2_3"}}selected{{end}}>{{call $.T "audio_lossless"}}</option>
+              <option value="2_4" {{if eq .Category "2_4"}}selected{{end}}>{{call $.T "audio_lossy"}}</option>
+              <option value="4_" {{if eq .Category "4_"}}selected{{end}}>{{call $.T "literature"}}</option>
+              <option value="4_7" {{if eq .Category "4_7"}}selected{{end}}>{{call $.T "literature_english_translated"}}</option>
+              <option value="4_8" {{if eq .Category "4_8"}}selected{{end}}>{{call $.T "literature_raw"}}</option>
+              <option value="4_14" {{if eq .Category "4_14"}}selected{{end}}>{{call $.T "literature_non_english_translated"}}</option>
+              <option value="5_" {{if eq .Category "5_"}}selected{{end}}>{{call $.T "live_action"}}</option>
+              <option value="5_9" {{if eq .Category "5_9"}}selected{{end}}>{{call $.T "live_action_english_translated"}}</option>
+              <option value="5_10" {{if eq .Category "5_10"}}selected{{end}}>{{call $.T "live_action_idol_pv"}}</option>
+              <option value="5_18" {{if eq .Category "5_18"}}selected{{end}}>{{call $.T "live_action_non_english_translated"}}</option>
+              <option value="5_11" {{if eq .Category "5_11"}}selected{{end}}>{{call $.T "live_action_raw"}}</option>
+              <option value="6_" {{if eq .Category "6_"}}selected{{end}}>{{call $.T "pictures"}}</option>
+              <option value="6_15" {{if eq .Category "6_15"}}selected{{end}}>{{call $.T "pictures_graphics"}}</option>
+              <option value="6_16" {{if eq .Category "6_16"}}selected{{end}}>{{call $.T "pictures_photos"}}</option>
+              <option value="1_" {{if eq .Category "1_"}}selected{{end}}>{{call $.T "software"}}</option>
+              <option value="1_1" {{if eq .Category "1_1"}}selected{{end}}>{{call $.T "software_applications"}}</option>
+              <option value="1_2" {{if eq .Category "1_2"}}selected{{end}}>{{call $.T "software_games"}}</option>
               {{ end }}
           </select>
       </div>
       <div class="form-group">
-          <label for="Status">{{T "torrent_status"}}</label>
+          <label for="Status">{{call $.T "torrent_status"}}</label>
           <select name="status" class="form-control input-sm">
-              <option value="0" {{if eq .Status 0}}selected{{end}}>{{T "torrent_status_hidden"}}</option>
-              <option value="1" {{if eq .Status 1}}selected{{end}}>{{T "torrent_status_normal"}}</option>
-              <option value="2" {{if eq .Status 2}}selected{{end}}>{{T "torrent_status_remake"}}</option>
-              <option value="3" {{if eq .Status 3}}selected{{end}}>{{T "trusted"}}</option>
+              <option value="0" {{if eq .Status 0}}selected{{end}}>{{call $.T "torrent_status_hidden"}}</option>
+              <option value="1" {{if eq .Status 1}}selected{{end}}>{{call $.T "torrent_status_normal"}}</option>
+              <option value="2" {{if eq .Status 2}}selected{{end}}>{{call $.T "torrent_status_remake"}}</option>
+              <option value="3" {{if eq .Status 3}}selected{{end}}>{{call $.T "trusted"}}</option>
               <option value="4" {{if eq .Status 4}}selected{{end}}>A+</option>
       	 </select>
       </div>
 
       <div class="form-group">
-          <label for="desc">{{T "torrent_description"}}</label>
-          <p class="help-block">{{T "description_markdown_notice"}}</p>
+          <label for="desc">{{call $.T "torrent_description"}}</label>
+          <p class="help-block">{{call $.T "description_markdown_notice"}}</p>
           <textarea name="desc" class="form-control" rows="10">{{.Description}}</textarea>
       </div>
-      <button type="submit" class="btn btn-success">{{T "save_changes"}}</button>
+      <button type="submit" class="btn btn-success">{{call $.T "save_changes"}}</button>
   </form>
 {{end}}
 {{end}}

--- a/templates/admin/reassign.html
+++ b/templates/admin/reassign.html
@@ -27,6 +27,6 @@
     {{end}}
 
     <p>Might take a long time, do <b>NOT</b> abort the request.</p>
-    <button type="submit" class="btn btn-success">{{T "save_changes"}}</button>
+    <button type="submit" class="btn btn-success">{{call $.T "save_changes"}}</button>
 </form>
 {{end}}

--- a/templates/admin/torrentlist.html
+++ b/templates/admin/torrentlist.html
@@ -19,10 +19,10 @@
           </select>
           <select class="form-control" style="display: none;" name="moveto">
             <option value="">To...</option>
-            <option value="0">{{T "torrent_status_hidden"}}</option>
-            <option value="1">{{T "torrent_status_normal"}}</option>
-            <option value="2">{{T "torrent_status_remake"}}</option>
-            <option value="3">{{T "trusted"}}</option>
+            <option value="0">{{call $.T "torrent_status_hidden"}}</option>
+            <option value="1">{{call $.T "torrent_status_normal"}}</option>
+            <option value="2">{{call $.T "torrent_status_remake"}}</option>
+            <option value="3">{{call $.T "trusted"}}</option>
             <option value="4">A+</option>
           </select>
         </div>
@@ -44,7 +44,7 @@
         <td><input type="checkbox" name="torrent_id" value="{{.ID }}"></td>
         <td><a href="{{ genViewTorrentRoute .ID }}">{{ .Name }}</a> (<a href="{{ genRoute "mod_tedit" }}?id={{.ID}}">Edit</a>)</td>
         <td>{{ if gt .UploaderID 0 }}<a href="{{ genRoute "mod_tlist" }}?userID={{.UploaderID}}">{{ .Uploader.Username }}</a>{{ else }}れんちょん{{end}}</td>
-        <td><a href="{{ genRoute "mod_tdelete" }}?id={{ .ID }}" class="btn btn-danger" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ T "delete" }}</a></td>
+        <td><a href="{{ genRoute "mod_tdelete" }}?id={{ .ID }}" class="btn btn-danger" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ call $.T "delete" }}</a></td>
     </tr>
     {{end}}
     </table>

--- a/templates/admin/userlist.html
+++ b/templates/admin/userlist.html
@@ -10,7 +10,7 @@
 
 <tr>
     <td><a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}?edit">{{ .Username }}</a></td>
-    <td>{{if gt .ID 0}}<a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}?delete" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ T "delete" }}</a>{{end}}</td>
+    <td>{{if gt .ID 0}}<a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}?delete" class="btn btn-danger btn-lg" onclick="if (!confirm('Are you sure?')) return false;"><i class="glyphicon glyphicon-trash"></i> {{ call $.T "delete" }}</a>{{end}}</td>
 </tr>
 {{end}}
 </table>

--- a/templates/admin_index.html
+++ b/templates/admin_index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-	<title>{{if Sukebei}}Sukebei{{else}}Nyaa{{end}} Pantsu - {{block "title" .}}{{ T "error_404" }}{{end}}</title>
+	<title>{{if Sukebei}}Sukebei{{else}}Nyaa{{end}} Pantsu - {{block "title" .}}{{ call $.T "error_404" }}{{end}}</title>
     <link rel="icon" type="image/png" href="/img/favicon.png?v=3" />
 
     <!-- RSS Feed with Context -->
@@ -33,7 +33,7 @@
           <div class="container">
               <div class="navbar-header">
                   <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                      <span class="sr-only">{{ T "toggle_navigation" }}</span>
+                      <span class="sr-only">{{ call $.T "toggle_navigation" }}</span>
                       <span class="icon-bar"></span>
                       <span class="icon-bar"></span>
                       <span class="icon-bar"></span>
@@ -43,14 +43,14 @@
               </div>
               <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                   <ul class="nav navbar-nav">
-                      <li><a href="{{.URL.Parse "/"}}">{{T "Nyaa Pantsu"}}</a></li>
-                      <li><a href="{{ genRoute "mod_tlist"}}">{{T "Torrents"}}</a></li>
-                      <li><a href="{{ genRoute "mod_ulist"}}">{{T "Users"}}</a></li>
-                      <li><a href="{{ genRoute "mod_clist"}}">{{T "Comments"}}</a></li>
+                      <li><a href="{{.URL.Parse "/"}}">{{call $.T "Nyaa Pantsu"}}</a></li>
+                      <li><a href="{{ genRoute "mod_tlist"}}">{{call $.T "Torrents"}}</a></li>
+                      <li><a href="{{ genRoute "mod_ulist"}}">{{call $.T "Users"}}</a></li>
+                      <li><a href="{{ genRoute "mod_clist"}}">{{call $.T "Comments"}}</a></li>
                       <li class="dropdown">
                           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Other<span class="caret"></span></a>
                           <ul class="dropdown-menu">
-                              <li><a href="{{ genRoute "mod_trlist"}}">{{T "Torrent Reports"}}</a></li>
+                              <li><a href="{{ genRoute "mod_trlist"}}">{{call $.T "Torrent Reports"}}</a></li>
                               <li><a href="{{ genRoute "mod_treassign" }}">Torrent Reassign</a></li>
                           </ul>
                       </li>

--- a/templates/change_language.html
+++ b/templates/change_language.html
@@ -1,10 +1,10 @@
-{{define "title"}}{{T "change_language"}}{{end}}
+{{define "title"}}{{call $.T "change_language"}}{{end}}
 {{define "content"}}
 <div class="blockBody">
     <hr>
     <form role="form" method="POST">
         <div class="form-group">
-            <label for="language">{{T "language"}}</label>
+            <label for="language">{{call $.T "language"}}</label>
             <div class="ui-select">
                 <select id="language" name="language" class="form-control">
                     {{ $currentLanguage := .Language }}
@@ -15,7 +15,7 @@
             </div>
         </div>
 
-        <button type="submit" class="btn btn-success">{{T "save_changes"}}</button>
+        <button type="submit" class="btn btn-success">{{call $.T "save_changes"}}</button>
     </form>
 	<div style="padding-bottom: 1em"></div>
 </div>

--- a/templates/dumps.html
+++ b/templates/dumps.html
@@ -1,4 +1,4 @@
-{{define "title"}}{{T "home"}}{{end}}
+{{define "title"}}{{call $.T "home"}}{{end}}
 {{define "contclass"}}cont-home{{end}}
 {{define "content"}}
 	<div class="blockBody">
@@ -13,10 +13,10 @@
 		  {{ if gt (len .ListDumps) 0 }}
           <table class="table custom-table-hover">
           <tr>
-              <th class="col-xs-8">{{T "name"}}</th>
-              <th class="col-xs-1 hidden-xs">{{T "date"}}</th>
-              <th class="col-xs-1 hidden-xs">{{T "size"}}</th>
-              <th class="col-xs-1 hidden-xs">{{T "links"}}</th>
+              <th class="col-xs-8">{{call $.T "name"}}</th>
+              <th class="col-xs-1 hidden-xs">{{call $.T "date"}}</th>
+              <th class="col-xs-1 hidden-xs">{{call $.T "size"}}</th>
+              <th class="col-xs-1 hidden-xs">{{call $.T "links"}}</th>
           </tr>
           {{ range .ListDumps}}
           <tr class="torrent-info">
@@ -28,7 +28,7 @@
               <td class="hidden-xs nowrap">{{.Filesize}}</td>
               <td class="hidden-xs">
                   {{if ne .TorrentLink ""}}
-                  <a href="{{.TorrentLink}}" title="{{ T "torrent_file" }}">
+                  <a href="{{.TorrentLink}}" title="{{ call $.T "torrent_file" }}">
                       <span class="glyphicon glyphicon-floppy-save" aria-hidden="true"></span> 
                   </a>
                   {{end}}
@@ -37,7 +37,7 @@
           {{end}}
       </table>
 	  {{else}}
-	  <h1>{{T "no_database_dumps_available"}}</h1>
+	  <h1>{{call $.T "no_database_dumps_available"}}</h1>
 	  {{end}}
       </div>
       <nav class="torrentNav" aria-label="Page navigation">

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,4 +1,4 @@
-{{define "title"}}{{T "home"}}{{end}}
+{{define "title"}}{{call $.T "home"}}{{end}}
 {{define "contclass"}}cont-home{{end}}
 {{define "content"}}
 
@@ -24,19 +24,19 @@ Your browser does not support the audio element.
       <div class="table-responsive">
           <table class="table custom-table-hover">
           <tr>
-              <th class="col-xs-1 hidden-xs">{{T "category"}}</th>
+              <th class="col-xs-1 hidden-xs">{{call $.T "category"}}</th>
               <th class="col-xs-12">
-                <a href="{{ genSearchWithOrdering .URL "1" }}">{{T "name"}}{{ genSortArrows .URL "1" }}</a>
+                <a href="{{ genSearchWithOrdering .URL "1" }}">{{call $.T "name"}}{{ genSortArrows .URL "1" }}</a>
               </th>
               <th class="col-xs-1 hidden-xs">
-                <a href="{{ genSearchWithOrdering .URL "5" }}">{{T "S"}}{{ genSortArrows .URL "5" }}</a> / 
-                <a href="{{ genSearchWithOrdering .URL "6" }}">{{T "L"}}{{ genSortArrows .URL "6" }}</a> / 
-                <a href="{{ genSearchWithOrdering .URL "7" }}">{{T "D"}}{{ genSortArrows .URL "7" }}</a>
+                <a href="{{ genSearchWithOrdering .URL "5" }}">{{call $.T "S"}}{{ genSortArrows .URL "5" }}</a> / 
+                <a href="{{ genSearchWithOrdering .URL "6" }}">{{call $.T "L"}}{{ genSortArrows .URL "6" }}</a> / 
+                <a href="{{ genSearchWithOrdering .URL "7" }}">{{call $.T "D"}}{{ genSortArrows .URL "7" }}</a>
               </th>
               <!-- <th class="col-xs-1 hidden-xs"><span class="glyphicon glyphicon-comment"></span></th> -->
-              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "2" }}">{{T "date"}}{{ genSortArrows .URL "2" }}</th></a>
-              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "4" }}">{{T "size"}}{{ genSortArrows .URL "4" }}</a></th>
-              <th class="col-xs-1 hidden-xs">{{T "links"}}</th>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "2" }}">{{call $.T "date"}}{{ genSortArrows .URL "2" }}</th></a>
+              <th class="col-xs-1 hidden-xs"><a href="{{ genSearchWithOrdering .URL "4" }}">{{call $.T "size"}}{{ genSortArrows .URL "4" }}</a></th>
+              <th class="col-xs-1 hidden-xs">{{call $.T "links"}}</th>
           </tr>
           {{ range .ListTorrents}}
           <tr class="torrent-info
@@ -47,9 +47,9 @@ Your browser does not support the audio element.
               <td class="hidden-xs" style="width:80px">
                   <a href="{{$.URL.Parse (printf "/search?c=%s_%s" .Category .SubCategory) }}">
                       {{ if Sukebei }}
-                      <img src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ T (Category_Sukebei .Category .SubCategory) }}">
+                      <img src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ call $.T (Category_Sukebei .Category .SubCategory) }}">
                       {{ else }}
-                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ T (Category_Nyaa .Category .SubCategory) }}">
+                      <img src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ call $.T (Category_Nyaa .Category .SubCategory) }}">
                       {{ end}}
                   </a>
               </td>
@@ -64,7 +64,7 @@ Your browser does not support the audio element.
               </td>
               -->
               {{if .LastScrape.IsZero}}
-              <td class="hidden-xs" align="center">{{T "unknown"}}</td>
+              <td class="hidden-xs" align="center">{{call $.T "unknown"}}</td>
               {{else}}
               <td class="hidden-xs">
                 <b class="text-success">{{.Seeders}}</b> / 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,3 @@
-{{ $T := .T }}
 <!DOCTYPE html>
 <html lang="{{ call $.T "language_code" }}">
   <head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,12 @@
+{{ $T := .T }}
 <!DOCTYPE html>
-<html lang="{{ T "language_code" }}">
+<html lang="{{ call $.T "language_code" }}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-	<title>{{if Sukebei}}Sukebei{{else}}Nyaa{{end}} Pantsu - {{block "title" .}}{{ T "error_404" }}{{end}}</title>
+	<title>{{if Sukebei}}Sukebei{{else}}Nyaa{{end}} Pantsu - {{block "title" .}}{{ call $.T "error_404" }}{{end}}</title>
     <link rel="icon" type="image/png" href="/img/favicon.png?v=3" />
 
     <!-- RSS Feed with Context -->
@@ -39,7 +40,7 @@
           <div class="container">
               <div class="navbar-header">
                   <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                      <span class="sr-only">{{ T "toggle_navigation" }}</span>
+                      <span class="sr-only">{{ call $.T "toggle_navigation" }}</span>
                       <span class="icon-bar"></span>
                       <span class="icon-bar"></span>
                       <span class="icon-bar"></span>
@@ -49,13 +50,13 @@
               </div>
               <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                   <ul class="nav navbar-nav">
-                      <li><a href="{{.URL.Parse "/upload"}}"><div class="hidden-md hidden-sm">{{T "upload"}}</div><span class="glyphicon glyphicon-cloud-upload visible-md"></span></a></li>
-                      <li><a href="{{.URL.Parse "/faq"}}"><div class="hidden-md hidden-sm">{{T "faq"}}</div><span class="glyphicon glyphicon-question-sign visible-md"></span></a></li>
+                      <li><a href="{{.URL.Parse "/upload"}}"><div class="hidden-md hidden-sm">{{call $.T "upload"}}</div><span class="glyphicon glyphicon-cloud-upload visible-md"></span></a></li>
+                      <li><a href="{{.URL.Parse "/faq"}}"><div class="hidden-md hidden-sm">{{call $.T "faq"}}</div><span class="glyphicon glyphicon-question-sign visible-md"></span></a></li>
                       <li><a href="{{ genRouteWithQuery "feed" .URL }}"><div class="hidden-md hidden-sm">RSS</div><span class="glyphicon glyphicon-flash visible-md"></span></a></li>
                       {{ if Sukebei }}
-                      <li><a href="https://nyaa.pantsu.cat"><div class="hidden-md hidden-sm">{{T "fun"}}</div><span class="glyphicon glyphicon-eye-open visible-md"></span></a></li>
+                      <li><a href="https://nyaa.pantsu.cat"><div class="hidden-md hidden-sm">{{call $.T "fun"}}</div><span class="glyphicon glyphicon-eye-open visible-md"></span></a></li>
                       {{ else }}
-                      <li><a href="https://sukebei.pantsu.cat"><div class="hidden-md hidden-sm">{{T "fap"}}</div><span class="glyphicon glyphicon-eye-close visible-md"></span></a></li>
+                      <li><a href="https://sukebei.pantsu.cat"><div class="hidden-md hidden-sm">{{call $.T "fap"}}</div><span class="glyphicon glyphicon-eye-close visible-md"></span></a></li>
                       {{ end }}
                   </ul>
                   {{block "badge_user" .}}{{end}}
@@ -76,7 +77,7 @@
       <div style="padding-top: 10rem"></div>
 
       <div class="container {{block "contclass" .}}generic{{end}}" id="container">
-        {{block "content" .}}{{T "nothing_here"}}{{end}}
+        {{block "content" .}}{{call $.T "nothing_here"}}{{end}}
       </div>
 
       <!-- bottom padding -->
@@ -91,7 +92,7 @@
 		  <select id="bottom_language_selector" name="language" onchange="javascript:document.getElementById('bottom_language_selector_form').submit()" hidden class="form-control"></select>
 	  </form>
 	  <noscript>
-		  <center><a href="{{ .URL.Parse "/language" }}">{{ T "change_language" }}</a></center>
+		  <center><a href="{{ .URL.Parse "/language" }}">{{ call $.T "change_language" }}</a></center>
 	  </noscript>
     <script type="text/javascript" charset="utf-8" src="{{.URL.Parse "/js/languages.js"}}"></script>
 	  {{end}}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -8,79 +8,79 @@
       <div class="alert alert-danger"><a class="panel-close close" data-dismiss="alert">×</a><i class="glyphicon glyphicon-exclamation-sign"></i> {{ . }}</div>
     {{end}}
       <div class="form-group">
-      <label for="name">{{T "name"}}</label>
-          <input type="text" name="name" id="name" class="form-control" placeholder="{{T "file_name"}}" value="{{.Name}}" autofocus required>
+      <label for="name">{{call $.T "name"}}</label>
+          <input type="text" name="name" id="name" class="form-control" placeholder="{{call $.T "file_name"}}" value="{{.Name}}" autofocus required>
       </div>
       <div class="form-group">
-          <label for="torrent">{{T "torrent_file"}}</label>
+          <label for="torrent">{{call $.T "torrent_file"}}</label>
           <input type="file" name="torrent" id="torrent" accept=".torrent">
-          <p class="help-block">{{T "uploading_file_prefills_fields"}}</p>
+          <p class="help-block">{{call $.T "uploading_file_prefills_fields"}}</p>
       </div>
       <div class="form-group">
-          <label for="magnet">{{T "magnet_link"}}</label>
+          <label for="magnet">{{call $.T "magnet_link"}}</label>
           <input  type="text" name="magnet" id="magnet" class="form-control"
-          style="width:60rem" placeholder="{{T "magnet_link"}}" value="{{.Magnet}}">
+          style="width:60rem" placeholder="{{call $.T "magnet_link"}}" value="{{.Magnet}}">
       </div>
       <div class="form-group">
-          <label for="c">{{T "category"}}</label>
+          <label for="c">{{call $.T "category"}}</label>
           <select name="c" id="c" class="form-control input-sm" required>
-              <option value="">{{T "select_a_torrent_category"}}</option>
+              <option value="">{{call $.T "select_a_torrent_category"}}</option>
               {{ if Sukebei }}
-              <option value="1_" {{if eq .Category "1_"}}selected{{end}}>{{T "art"}}</option>
-              <option value="1_1" {{if eq .Category "1_1"}}selected{{end}}>{{T "art_anime"}}</option>
-              <option value="1_2" {{if eq .Category "1_2"}}selected{{end}}>{{T "art_doujinshi"}}</option>
-              <option value="1_3" {{if eq .Category "1_3"}}selected{{end}}>{{T "art_games"}}</option>
-              <option value="1_4" {{if eq .Category "1_4"}}selected{{end}}>{{T "art_manga"}}</option>
-              <option value="1_5" {{if eq .Category "1_5"}}selected{{end}}>{{T  "art_pictures"}}</option>
-              <option value="2_" {{if eq .Category "2_"}}selected{{end}}>{{T "real_life"}}</option>
-              <option value="2_1" {{if eq .Category "2_1"}}selected{{end}}>{{T "real_life_photobooks_and_Pictures"}}</option>
-              <option value="2_2" {{if eq .Category "2_2"}}selected{{end}}>{{T "real_life_videos"}}</option>
+              <option value="1_" {{if eq .Category "1_"}}selected{{end}}>{{call $.T "art"}}</option>
+              <option value="1_1" {{if eq .Category "1_1"}}selected{{end}}>{{call $.T "art_anime"}}</option>
+              <option value="1_2" {{if eq .Category "1_2"}}selected{{end}}>{{call $.T "art_doujinshi"}}</option>
+              <option value="1_3" {{if eq .Category "1_3"}}selected{{end}}>{{call $.T "art_games"}}</option>
+              <option value="1_4" {{if eq .Category "1_4"}}selected{{end}}>{{call $.T "art_manga"}}</option>
+              <option value="1_5" {{if eq .Category "1_5"}}selected{{end}}>{{call $.T "art_pictures"}}</option>
+              <option value="2_" {{if eq .Category "2_"}}selected{{end}}>{{call $.T "real_life"}}</option>
+              <option value="2_1" {{if eq .Category "2_1"}}selected{{end}}>{{call $.T "real_life_photobooks_and_Pictures"}}</option>
+              <option value="2_2" {{if eq .Category "2_2"}}selected{{end}}>{{call $.T "real_life_videos"}}</option>
               {{ else }}
-              <option value="3_" {{if eq .Category "3_"}}selected{{end}}>{{T "anime"}}</option>
-              <option value="3_12" {{if eq .Category "3_12"}}selected{{end}}>{{T "anime_amv"}}</option>
-              <option value="3_5" {{if eq .Category "3_5"}}selected{{end}}>{{T "anime_english_translated"}}</option>
-              <option value="3_13" {{if eq .Category "3_13"}}selected{{end}}>{{T "anime_non_english_translated"}}</option>
-              <option value="3_6" {{if eq .Category "3_6"}}selected{{end}}>{{T "anime_raw"}}</option>
-              <option value="2_" {{if eq .Category "2_"}}selected{{end}}>{{T "audio"}}</option>
-              <option value="2_3" {{if eq .Category "2_3"}}selected{{end}}>{{T "audio_lossless"}}</option>
-              <option value="2_4" {{if eq .Category "2_4"}}selected{{end}}>{{T "audio_lossy"}}</option>
-              <option value="4_" {{if eq .Category "4_"}}selected{{end}}>{{T "literature"}}</option>
-              <option value="4_7" {{if eq .Category "4_7"}}selected{{end}}>{{T "literature_english_translated"}}</option>
-              <option value="4_8" {{if eq .Category "4_8"}}selected{{end}}>{{T "literature_raw"}}</option>
-              <option value="4_14" {{if eq .Category "4_14"}}selected{{end}}>{{T "literature_non_english_translated"}}</option>
-              <option value="5_" {{if eq .Category "5_"}}selected{{end}}>{{T "live_action"}}</option>
-              <option value="5_9" {{if eq .Category "5_9"}}selected{{end}}>{{T "live_action_english_translated"}}</option>
-              <option value="5_10" {{if eq .Category "5_10"}}selected{{end}}>{{T "live_action_idol_pv"}}</option>
-              <option value="5_18" {{if eq .Category "5_18"}}selected{{end}}>{{T "live_action_non_english_translated"}}</option>
-              <option value="5_11" {{if eq .Category "5_11"}}selected{{end}}>{{T "live_action_raw"}}</option>
-              <option value="6_" {{if eq .Category "6_"}}selected{{end}}>{{T "pictures"}}</option>
-              <option value="6_15" {{if eq .Category "6_15"}}selected{{end}}>{{T "pictures_graphics"}}</option>
-              <option value="6_16" {{if eq .Category "6_16"}}selected{{end}}>{{T "pictures_photos"}}</option>
-              <option value="1_" {{if eq .Category "1_"}}selected{{end}}>{{T "software"}}</option>
-              <option value="1_1" {{if eq .Category "1_1"}}selected{{end}}>{{T "software_applications"}}</option>
-              <option value="1_2" {{if eq .Category "1_2"}}selected{{end}}>{{T "software_games"}}</option>
+              <option value="3_" {{if eq .Category "3_"}}selected{{end}}>{{call $.T "anime"}}</option>
+              <option value="3_12" {{if eq .Category "3_12"}}selected{{end}}>{{call $.T "anime_amv"}}</option>
+              <option value="3_5" {{if eq .Category "3_5"}}selected{{end}}>{{call $.T "anime_english_translated"}}</option>
+              <option value="3_13" {{if eq .Category "3_13"}}selected{{end}}>{{call $.T "anime_non_english_translated"}}</option>
+              <option value="3_6" {{if eq .Category "3_6"}}selected{{end}}>{{call $.T "anime_raw"}}</option>
+              <option value="2_" {{if eq .Category "2_"}}selected{{end}}>{{call $.T "audio"}}</option>
+              <option value="2_3" {{if eq .Category "2_3"}}selected{{end}}>{{call $.T "audio_lossless"}}</option>
+              <option value="2_4" {{if eq .Category "2_4"}}selected{{end}}>{{call $.T "audio_lossy"}}</option>
+              <option value="4_" {{if eq .Category "4_"}}selected{{end}}>{{call $.T "literature"}}</option>
+              <option value="4_7" {{if eq .Category "4_7"}}selected{{end}}>{{call $.T "literature_english_translated"}}</option>
+              <option value="4_8" {{if eq .Category "4_8"}}selected{{end}}>{{call $.T "literature_raw"}}</option>
+              <option value="4_14" {{if eq .Category "4_14"}}selected{{end}}>{{call $.T "literature_non_english_translated"}}</option>
+              <option value="5_" {{if eq .Category "5_"}}selected{{end}}>{{call $.T "live_action"}}</option>
+              <option value="5_9" {{if eq .Category "5_9"}}selected{{end}}>{{call $.T "live_action_english_translated"}}</option>
+              <option value="5_10" {{if eq .Category "5_10"}}selected{{end}}>{{call $.T "live_action_idol_pv"}}</option>
+              <option value="5_18" {{if eq .Category "5_18"}}selected{{end}}>{{call $.T "live_action_non_english_translated"}}</option>
+              <option value="5_11" {{if eq .Category "5_11"}}selected{{end}}>{{call $.T "live_action_raw"}}</option>
+              <option value="6_" {{if eq .Category "6_"}}selected{{end}}>{{call $.T "pictures"}}</option>
+              <option value="6_15" {{if eq .Category "6_15"}}selected{{end}}>{{call $.T "pictures_graphics"}}</option>
+              <option value="6_16" {{if eq .Category "6_16"}}selected{{end}}>{{call $.T "pictures_photos"}}</option>
+              <option value="1_" {{if eq .Category "1_"}}selected{{end}}>{{call $.T "software"}}</option>
+              <option value="1_1" {{if eq .Category "1_1"}}selected{{end}}>{{call $.T "software_applications"}}</option>
+              <option value="1_2" {{if eq .Category "1_2"}}selected{{end}}>{{call $.T "software_games"}}</option>
               {{ end }}
           </select>
-          <p class="help-block">{{ T "please_include_our_tracker" }}</p>
+          <p class="help-block">{{ call $.T "please_include_our_tracker" }}</p>
       </div>
       <div class="form-group">
       	  <input type="checkbox" name="remake" id="remake" >
-          <label for="remake">{{T "mark_as_remake"}}</label>
+          <label for="remake">{{call $.T "mark_as_remake"}}</label>
       </div>
 
       <div class="form-group">
-          <label for="desc">{{T "torrent_description"}}</label>
-          <p class="help-block">{{T "description_markdown_notice"}}</p>
+          <label for="desc">{{call $.T "torrent_description"}}</label>
+          <p class="help-block">{{call $.T "description_markdown_notice"}}</p>
           <textarea name="desc" id="desc" class="form-control torrent-desc" rows="15">{{.Description}}</textarea>
       </div>
       <div class="form-group">
-          <label for="website_link">{{T "website_link"}}</label>
+          <label for="website_link">{{call $.T "website_link"}}</label>
           <input name="website_link" id="website_link" class="form-control" type="text" value="{{.WebsiteLink}}">
       </div>
 
       {{block "captcha" .}}{{end}}
 
-      <button type="submit" class="btn btn-success">{{T "upload"}}</button>
+      <button type="submit" class="btn btn-success">{{call $.T "upload"}}</button>
       <br />
       <br />
   </form>

--- a/templates/user/delete_success.html
+++ b/templates/user/delete_success.html
@@ -1,11 +1,11 @@
-{{define "title"}}{{ T "delete_account" }}{{end}}
+{{define "title"}}{{ call $.T "delete_account" }}{{end}}
 {{define "contclass"}}cont-view{{end}}
 {{define "content"}}
 <div class="blockBody">
 	<div class="row" style="margin-top:20px">
 	    <div class="col-xs-12 col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
 
-					<h2>{{T "delete_success"}}</h2>
+					<h2>{{call $.T "delete_success"}}</h2>
 					<hr class="colorgraph">
 					{{ range (index $.FormErrors "errors")}}
 	   					<div class="alert alert-danger">{{ . }}</div>

--- a/templates/user/login.html
+++ b/templates/user/login.html
@@ -1,4 +1,4 @@
-{{define "title"}}{{ T "sign_in_title" }}{{end}}
+{{define "title"}}{{ call $.T "sign_in_title" }}{{end}}
 {{define "contclass"}}cont-view{{end}}
 {{define "content"}}
 <div class="blockBody">
@@ -7,35 +7,35 @@
 			{{ with .LoginForm }}
 			<form role="form" method="POST">
 				<fieldset>
-					<h2>{{T "sign_in_box_title"}}</h2>
+					<h2>{{call $.T "sign_in_box_title"}}</h2>
 					<hr class="colorgraph">
 					{{ range (index $.FormErrors "errors")}}
 	   					<div class="alert alert-danger">{{ . }}</div>
 	   				{{end}}
 					<div class="form-group">
-	                    <input type="text" name="username" id="username" class="form-control input-lg" autofocus placeholder="{{ T "email_address_or_username"}}">
+	                    <input type="text" name="username" id="username" class="form-control input-lg" autofocus placeholder="{{ call $.T "email_address_or_username"}}">
        	            	{{ range (index $.FormErrors "username")}}
 						<p class="text-error">{{ . }}</p>
 						{{end}}
 					</div>
 					<div class="form-group">
-	                    <input type="password" name="password" id="password" class="form-control input-lg" placeholder="{{ T "password"}}">
+	                    <input type="password" name="password" id="password" class="form-control input-lg" placeholder="{{ call $.T "password"}}">
                			{{ range (index $.FormErrors "password")}}
 						<p class="text-error">{{ . }}</p>
 						{{end}}
 					</div>
 					<!-- <span class="button-checkbox">
-						<button type="button" class="btn hidden" data-color="info">{{ T "remember_me"}}</button>
+						<button type="button" class="btn hidden" data-color="info">{{ call $.T "remember_me"}}</button>
 	                    <input type="checkbox" name="remember_me" id="remember_me" checked="checked">
-						<a href="" class="btn btn-link pull-right">{{ T "forgot_password"}}</a>
+						<a href="" class="btn btn-link pull-right">{{ call $.T "forgot_password"}}</a>
 					</span> -->
 					<hr class="colorgraph">
 					<div class="row">
 						<div class="col-xs-6 col-sm-6 col-md-6">
-	                        <input type="submit" class="btn btn-lg btn-success btn-block" value="{{ T "signin"}}">
+	                        <input type="submit" class="btn btn-lg btn-success btn-block" value="{{ call $.T "signin"}}">
 						</div>
 						<div class="col-xs-6 col-sm-6 col-md-6">
-							<a href="{{ genRoute "user_register" }}" class="btn btn-lg btn-primary btn-block">{{ T "register"}}</a>
+							<a href="{{ genRoute "user_register" }}" class="btn btn-lg btn-primary btn-block">{{ call $.T "register"}}</a>
 						</div>
 					</div>
 				</fieldset>

--- a/templates/user/profile.html
+++ b/templates/user/profile.html
@@ -1,4 +1,4 @@
-{{define "title"}}{{ T "profile_page" .UserProfile.Username }}{{end}}
+{{define "title"}}{{ call $.T "profile_page" .UserProfile.Username }}{{end}}
 {{define "contclass"}}cont-view{{end}}
 {{define "content"}}
 {{ range (index $.FormInfos "infos")}}
@@ -28,9 +28,9 @@
 						{{if gt $.User.ID 0 }}
 							{{if not (CurrentUserIdentical $.User .ID) }}
 								{{if not (IsFollower . $.User)}}
-									<a href="{{ genRoute "user_follow" "id" ( print .ID ) "username" .Username }}" class="btn btn-success btn-sm">{{ T "follow"}}</a>
+									<a href="{{ genRoute "user_follow" "id" ( print .ID ) "username" .Username }}" class="btn btn-success btn-sm">{{ call $.T "follow"}}</a>
 								{{else}}
-									<a href="{{ genRoute "user_follow" "id" ( print .ID ) "username" .Username }}" class="btn btn-danger btn-sm">{{ T "unfollow"}}</a>
+									<a href="{{ genRoute "user_follow" "id" ( print .ID ) "username" .Username }}" class="btn btn-danger btn-sm">{{ call $.T "unfollow"}}</a>
 								{{end}}
 							{{end}}
 						{{end}}
@@ -41,12 +41,12 @@
 				<div class="profile-usermenu">
 					<ul class="nav">
 						<li class="active">
-							<a href="{{ genRoute "user_profile" "id" ( print .ID ) "username" .Username }}"><i class="glyphicon glyphicon-home"></i>{{T "torrents"}}</a>
+							<a href="{{ genRoute "user_profile" "id" ( print .ID ) "username" .Username }}"><i class="glyphicon glyphicon-home"></i>{{call $.T "torrents"}}</a>
 						</li>
 						{{if gt $.User.ID 0 }}
 						{{if CurrentOrAdmin $.User .ID }}
 						<li>
-							<a href="{{ genRoute "user_profile_details" "id" ( print .ID ) "username" .Username }}"><i class="glyphicon glyphicon-user"></i>{{T "settings"}}</a>
+							<a href="{{ genRoute "user_profile_details" "id" ( print .ID ) "username" .Username }}"><i class="glyphicon glyphicon-user"></i>{{call $.T "settings"}}</a>
 
 						</li>
 						{{end}}

--- a/templates/user/profile_edit.html
+++ b/templates/user/profile_edit.html
@@ -1,4 +1,4 @@
-{{define "title"}}{{ T "profile_edit_page" .UserProfile.Username }}{{end}}
+{{define "title"}}{{ call $.T "profile_edit_page" .UserProfile.Username }}{{end}}
 {{define "contclass"}}cont-view{{end}}
 {{define "content"}}
 <div class="row profile">
@@ -25,9 +25,9 @@
 						{{if gt $.User.ID 0 }}
 							{{if not (CurrentUserIdentical $.User .ID) }}
 								{{if not (IsFollower . $.User)}}
-									<a href="{{ genRoute "user_follow" "id" (print .ID) "username" .Username }}" class="btn btn-success btn-sm">{{ T "follow"}}</a>
+									<a href="{{ genRoute "user_follow" "id" (print .ID) "username" .Username }}" class="btn btn-success btn-sm">{{ call $.T "follow"}}</a>
 								{{else}}
-									<a href="{{ genRoute "user_follow" "id" (print .ID) "username" .Username }}" class="btn btn-danger btn-sm">{{ T "unfollow"}}</a>
+									<a href="{{ genRoute "user_follow" "id" (print .ID) "username" .Username }}" class="btn btn-danger btn-sm">{{ call $.T "unfollow"}}</a>
 								{{end}}
 							{{end}}
 						{{end}}
@@ -38,12 +38,12 @@
 				<div class="profile-usermenu">
 					<ul class="nav">
 						<li>
-							<a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}"><i class="glyphicon glyphicon-home"></i>{{T "torrents"}}</a>
+							<a href="{{ genRoute "user_profile" "id" (print .ID) "username" .Username }}"><i class="glyphicon glyphicon-home"></i>{{call $.T "torrents"}}</a>
 						</li>
 						{{if gt $.User.ID 0 }}
 							{{if CurrentOrAdmin $.User .ID }}
 								<li class="active">
-									<a href="{{ genRoute "user_profile_edit" "id" (print .ID) "username" .Username }}"><i class="glyphicon glyphicon-user"></i>{{T "settings"}}</a>
+									<a href="{{ genRoute "user_profile_edit" "id" (print .ID) "username" .Username }}"><i class="glyphicon glyphicon-user"></i>{{call $.T "settings"}}</a>
 								</li>
 							{{end}}
 						{{end}}

--- a/templates/user/register.html
+++ b/templates/user/register.html
@@ -1,4 +1,4 @@
-{{define "title"}}{{ T "register_title" }}{{end}}
+{{define "title"}}{{ call $.T "register_title" }}{{end}}
 {{define "contclass"}}cont-view{{end}}
 {{define "content"}}
 <div class="blockBody">
@@ -6,19 +6,19 @@
 	    <div class="col-xs-12 col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
 	    {{ with .RegistrationForm }}
 			<form role="form" method="POST">
-				<h2>{{T "signup_box_title" }}</h2>
+				<h2>{{call $.T "signup_box_title" }}</h2>
 				<hr class="colorgraph">
 				{{ range (index $.FormErrors "errors")}}
    					<div class="alert alert-danger">{{ . }}</div>
    				{{end}}
 				<div class="form-group">
-					<input type="text" name="username" id="display_name" class="form-control input-lg" placeholder="{{T "username" }}" value="{{ .Username }}" autofocus>
+					<input type="text" name="username" id="display_name" class="form-control input-lg" placeholder="{{call $.T "username" }}" value="{{ .Username }}" autofocus>
    							{{ range (index $.FormErrors "username")}}
    							<p class="text-error">{{ . }}</p>
    							{{end}}
 				</div>
 				<div class="form-group">
-					<input type="email" name="email" id="email" class="form-control input-lg" placeholder="{{T "email_address" }}" value="{{ .Email }}">
+					<input type="email" name="email" id="email" class="form-control input-lg" placeholder="{{call $.T "email_address" }}" value="{{ .Email }}">
    							{{ range (index $.FormErrors "email")}}
    							<p class="text-error">{{ . }}</p>
    							{{end}}
@@ -26,7 +26,7 @@
 				<div class="row">
 					<div class="col-xs-12 col-sm-6 col-md-6">
 						<div class="form-group">
-							<input type="password" name="password" id="password" class="form-control input-lg" placeholder="{{T "password" }}" value="{{ .Password }}">
+							<input type="password" name="password" id="password" class="form-control input-lg" placeholder="{{call $.T "password" }}" value="{{ .Password }}">
    							{{ range (index $.FormErrors "password")}}
    							<p class="text-error">{{ . }}</p>
    							{{end}}
@@ -34,7 +34,7 @@
 					</div>
 					<div class="col-xs-12 col-sm-6 col-md-6">
 						<div class="form-group">
-							<input type="password" name="password_confirmation" id="password_confirmation" class="form-control input-lg" placeholder="{{T "confirm_password" }}">
+							<input type="password" name="password_confirmation" id="password_confirmation" class="form-control input-lg" placeholder="{{call $.T "confirm_password" }}">
    							{{ range (index $.FormErrors "password_confirmation")}}
    							<p class="text-error">{{ . }}</p>
    							{{end}}
@@ -44,7 +44,7 @@
 				<div class="row">
 					<div class="col-xs-4 col-sm-3 col-md-3">
 						<span class="button-checkbox">
-							<button type="button" class="btn hidden" data-color="info">{{T "i_agree" }}</button>
+							<button type="button" class="btn hidden" data-color="info">{{call $.T "i_agree" }}</button>
 	                        <input type="checkbox" name="t_and_c" id="t_and_c" value="1">
    							{{ range (index $.FormErrors "t_and_c")}}
    							<p class="text-error">{{ . }}</p>
@@ -52,7 +52,7 @@
 						</span>
 					</div>
 					<div class="col-xs-8 col-sm-9 col-md-9">
-						{{T "terms_conditions_confirm" }}
+						{{call $.T "terms_conditions_confirm" }}
 					</div>
 				</div>
 
@@ -60,8 +60,8 @@
 
 				<hr class="colorgraph">
 				<div class="row">
-					<div class="col-xs-12 col-md-6"><input type="submit" value="{{T "register" }}" class="btn btn-primary btn-block btn-lg"></div>
-					<div class="col-xs-12 col-md-6">or <a href="{{ genRoute "user_login" }}" class="">{{T "signin" }}</a></div>
+					<div class="col-xs-12 col-md-6"><input type="submit" value="{{call $.T "register" }}" class="btn btn-primary btn-block btn-lg"></div>
+					<div class="col-xs-12 col-md-6">or <a href="{{ genRoute "user_login" }}" class="">{{call $.T "signin" }}</a></div>
 				</div>
 			</form>
 			{{end}}
@@ -73,13 +73,13 @@
 			<div class="modal-content">
 				<div class="modal-header">
 					<button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-					<h4 class="modal-title" id="myModalLabel">{{T "terms_conditions" }}</h4>
+					<h4 class="modal-title" id="myModalLabel">{{call $.T "terms_conditions" }}</h4>
 				</div>
 				<div class="modal-body">
-					<p>{{T "terms_conditions_full" }}</p>
+					<p>{{call $.T "terms_conditions_full" }}</p>
 				</div>
 				<div class="modal-footer">
-					<button type="button" class="btn btn-primary" data-dismiss="modal">{{T "i_agree" }}</button>
+					<button type="button" class="btn btn-primary" data-dismiss="modal">{{call $.T "i_agree" }}</button>
 				</div>
 			</div><!-- /.modal-content -->
 		</div><!-- /.modal-dialog -->

--- a/templates/user/signup_success.html
+++ b/templates/user/signup_success.html
@@ -1,16 +1,16 @@
-{{define "title"}}{{ T "register_success_title" }}{{end}}
+{{define "title"}}{{ call $.T "register_success_title" }}{{end}}
 {{define "contclass"}}cont-view{{end}}
 {{define "content"}}
 <div class="blockBody">
 	<div class="row" style="margin-top:20px">
 	    <div class="col-xs-12 col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
 
-					<h2>{{T "sign_up_success"}}</h2>
+					<h2>{{call $.T "sign_up_success"}}</h2>
 					<hr class="colorgraph">
 					{{if ne .User.Email ""}}
-					<p>{{ T "signup_verification_email" }}</p>
+					<p>{{ call $.T "signup_verification_email" }}</p>
 					{{else}}
-					<p>{{ T "signup_verification_noemail" }}</p>
+					<p>{{ call $.T "signup_verification_noemail" }}</p>
 					{{end}}
 		</div>
 	</div>

--- a/templates/user/verify_success.html
+++ b/templates/user/verify_success.html
@@ -1,11 +1,11 @@
-{{define "title"}}{{ T "register_success_title" }}{{end}}
+{{define "title"}}{{ call $.T "register_success_title" }}{{end}}
 {{define "contclass"}}cont-view{{end}}
 {{define "content"}}
 <div class="blockBody">
 	<div class="row" style="margin-top:20px">
 	    <div class="col-xs-12 col-sm-8 col-md-6 col-sm-offset-2 col-md-offset-3">
 
-					<h2>{{T "verify_success"}}</h2>
+					<h2>{{call $.T "verify_success"}}</h2>
 					<hr class="colorgraph">
 					{{ range (index $.FormErrors "errors")}}
 	   					<div class="alert alert-danger">{{ . }}</div>

--- a/templates/view.html
+++ b/templates/view.html
@@ -22,15 +22,15 @@
                 <div class="col-md-12">
                     <div style="float: left;">
                           {{ if Sukebei }}
-                          <img style="float:left; margin-right: 1em;" src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ T (Category_Sukebei .Category .SubCategory) }}"> 
-                          <span style="vertical-align:middle;font-size:large;">{{ T (Category_Sukebei .Category .SubCategory) }}</span>
+                          <img style="float:left; margin-right: 1em;" src="{{$.URL.Parse (printf "/img/torrents/sukebei/%s%s.png" .Category .SubCategory) }}" title="{{ call $.T (Category_Sukebei .Category .SubCategory) }}"> 
+						  <span style="vertical-align:middle;font-size:large;">{{ call $.T (Category_Sukebei .Category .SubCategory) }}</span>
                           {{ else }}
-                          <img style="float:left; margin-right: 1em;" src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ T (Category_Nyaa .Category .SubCategory) }}"> 
-                          <span style="vertical-align:middle;font-size:large;">{{ T (Category_Nyaa .Category .SubCategory) }}</span>
+                          <img style="float:left; margin-right: 1em;" src="{{$.URL.Parse (printf "/img/torrents/%s.png" .SubCategory) }}" title="{{ call $.T (Category_Nyaa .Category .SubCategory) }}"> 
+                          <span style="vertical-align:middle;font-size:large;">{{ call $.T (Category_Nyaa .Category .SubCategory) }}</span>
                           {{ end }}
                           <br />
                           <h4 style="display:inline-block">
-                              {{ T "uploaded_by" }} <a href="{{$.URL.Parse (printf "/user/%d/-" .UploaderID) }}">{{.UploaderName}}</a>
+                              {{ call $.T "uploaded_by" }} <a href="{{$.URL.Parse (printf "/user/%d/-" .UploaderID) }}">{{.UploaderName}}</a>
                           </h4>
                           {{if ne .OldUploader ""}}
                           <span>({{.OldUploader}})</span>
@@ -39,57 +39,57 @@
 
                     <div style="float:right;">
                         <a style="margin: 5px;" aria-label="Magnet Button" href="{{.Magnet}}" type="button" class="btn btn-lg btn-success">
-                            <span class="glyphicon glyphicon-magnet" aria-hidden="true"></span> {{ T "download_btn" }}
+                            <span class="glyphicon glyphicon-magnet" aria-hidden="true"></span> {{ call $.T "download_btn" }}
                         </a>
                         {{if ne .TorrentLink ""}}
                         <a style="margin: 5px;" aria-label="Torrent file" href="{{.TorrentLink}}" type="button" class="btn btn-lg btn-success">
-                            <span class="glyphicon glyphicon-floppy-save" aria-hidden="true"></span> {{ T "torrent_file" }}
+                            <span class="glyphicon glyphicon-floppy-save" aria-hidden="true"></span> {{ call $.T "torrent_file" }}
                         </a>
                         {{end}}
                         <a style="margin: 5px;" aria-label="Report button" data-toggle="modal" data-target="#reportModal" class="btn btn-danger btn-sm">
-                            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> {{ T "report_btn" }}
+                            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> {{ call $.T "report_btn" }}
                         </a>
 
                       {{ if HasAdmin $.User}}
-                      <a href="{{ genRoute "mod_tdelete" }}?id={{ .ID }}" class="btn btn-danger btn-lg" onclick="if (!confirm('{{ T "are_you_sure" }}')) return false;"><i class="glyphicon glyphicon-trash"></i></a>
+                      <a href="{{ genRoute "mod_tdelete" }}?id={{ .ID }}" class="btn btn-danger btn-lg" onclick="if (!confirm('{{ call $.T "are_you_sure" }}')) return false;"><i class="glyphicon glyphicon-trash"></i></a>
                       <a href="{{ genRoute "mod_tedit" }}?id={{ .ID }}" class="btn btn-warning btn-lg"><i class="glyphicon glyphicon-pencil"></i></a>
                       {{end}}
                     </div>
                     <div style="clear: both;"></div>
                 </div>
                     <div class="col-md-12">
-                        <h4>{{T "description"}}</h4>
+                        <h4>{{call $.T "description"}}</h4>
                         <div class="break">{{.Description}}</div>
                     </div>
                 </div>
             </div>
             <div class="col-md-4">
-                <h4>{{T "hash"}}</h4>
+                <h4>{{call $.T "hash"}}</h4>
                 <p class="torrent-hash break">{{.Hash}}</p>
                 <hr>
-                <h4>{{T "date"}}</h4>
+                <h4>{{call $.T "date"}}</h4>
                 <p class="date-full">{{.Date}}</p>
                 <hr>
-                <h4>{{T "size"}}</h4>
+                <h4>{{call $.T "size"}}</h4>
                 <p>{{.Filesize}}</p>
                 <hr>
                 {{if ne .WebsiteLink ""}}
-                <h4>{{T "link"}}</h4>
+                <h4>{{call $.T "link"}}</h4>
                 <p><a href="{{.WebsiteLink}}">{{.WebsiteLink}}</a></p>
                 <hr>
                 {{end}}
                 <div class="row">
                     <div class="col-md-12 col-xs-6">
                     <div class="row">
-                        <div class="col-md-4">{{T "seeders"}}</div>
-                        <div class="col-md-4">{{T "leechers"}}</div>
-                        <div class="col-md-4">{{T "completed"}}</div>
+                        <div class="col-md-4">{{call $.T "seeders"}}</div>
+                        <div class="col-md-4">{{call $.T "leechers"}}</div>
+                        <div class="col-md-4">{{call $.T "completed"}}</div>
                     </div>
                     </div>
                     <div class="col-md-12 col-xs-6">
                     <div class="row">
                         {{if .LastScrape.IsZero}}
-                        <div class="col-md-12" align="center">{{T "unknown"}}</div>
+                        <div class="col-md-12" align="center">{{call $.T "unknown"}}</div>
                         {{else}}
                         <div class="col-md-4">{{.Seeders}}</div>
                         <div class="col-md-4">{{.Leechers}}</div>
@@ -107,7 +107,7 @@
                     </div>
                     <div class="col-md-12 col-xs-12">
                         {{if not .LastScrape.IsZero}}
-                        {{T "last_scraped"}}<span class="date-short">{{ formatDateRFC .LastScrape }}</span>
+                        {{call $.T "last_scraped"}}<span class="date-short">{{ formatDateRFC .LastScrape }}</span>
                         {{end}}
                     </div>
                 </div>
@@ -117,12 +117,12 @@
         {{ if gt (len .FileList) 0 }}
         <div class="row">
             <div class="col-md-12">
-                <h4 data-toggle="collapse" data-target="#files" class="filelist-control" aria-expanded="false">{{T "files"}}</h4>
+                <h4 data-toggle="collapse" data-target="#files" class="filelist-control" aria-expanded="false">{{call $.T "files"}}</h4>
                 <div class="table-responsive collapse" id="files">
                     <table class="table custom-table-hover">
                     <tr>
-                        <th class="col-xs-8">{{T "filename"}}</th>
-                        <th class="col-xs-1">{{T "size"}}</th>
+                        <th class="col-xs-8">{{call $.T "filename"}}</th>
+                        <th class="col-xs-1">{{call $.T "size"}}</th>
                     </tr>
                     {{ range .FileList }}
                     <tr>
@@ -138,7 +138,7 @@
         <div class="row" id="comments">
             <div class="col-md-12">
                 <div class="commentList">
-                    <h4>{{T "comments"}}</h4>
+                    <h4>{{call $.T "comments"}}</h4>
                     <hr/>
                     <ul class="comments">
                         {{ range $index, $element := .Comments }}
@@ -186,11 +186,11 @@
             <form method="post">
                 <div class="form-group">
                     {{/* There should be a better way to use translation on this... */}}
-                    <label for="comment">{{ if gt .User.ID 0}} {{T "submit_a_comment_as_username" .User.Username}} {{else}} {{T "submit_a_comment_as_anonymous"}} {{end}}</label>
+                    <label for="comment">{{ if gt .User.ID 0}} {{call $.T "submit_a_comment_as_username" .User.Username}} {{else}} {{call $.T "submit_a_comment_as_anonymous"}} {{end}}</label>
                     <textarea name="comment" class="form-control" rows="5"></textarea>
                 </div>
                 {{block "captcha" .}}{{end}}
-                <button type="submit" class="btn btn-success">{{T "submit" }}</button>
+                <button type="submit" class="btn btn-success">{{call $.T "submit" }}</button>
             </form>
         </div>
     </div>
@@ -202,17 +202,17 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal">&times;</button>
-                <h4 class="modal-title">{{ T "report_torrent_number" (print .Torrent.ID) }}</h4>
+                <h4 class="modal-title">{{ call $.T "report_torrent_number" (print .Torrent.ID) }}</h4>
             </div>
             <div class="modal-body">
-                <b>{{ T "report_type" }}:</b>
+                <b>{{ call $.T "report_type" }}:</b>
                 <form method="post" action="/report/{{.Torrent.ID}}">
-                    <input type="radio" name="report_type" value="illegal" id="illegal" required> <label for="illegal">{{ T "illegal_content" }}</label><br />
-                    <input type="radio" name="report_type" value="spam" id="spam" required> <label for="spam">{{ T "spam_garbage" }}</label><br />
-                    <input type="radio" name="report_type" value="wrongcat" id="wrongcat" required> <label for="wrongcat">{{ T "wrong_category" }}</label><br />
-                    <input type="radio" name="report_type" value="dup" id="dup" required> <label for="dup">{{ T "duplicate_deprecated" }}</label><br />
+                    <input type="radio" name="report_type" value="illegal" id="illegal" required> <label for="illegal">{{ call $.T "illegal_content" }}</label><br />
+                    <input type="radio" name="report_type" value="spam" id="spam" required> <label for="spam">{{ call $.T "spam_garbage" }}</label><br />
+                    <input type="radio" name="report_type" value="wrongcat" id="wrongcat" required> <label for="wrongcat">{{ call $.T "wrong_category" }}</label><br />
+                    <input type="radio" name="report_type" value="dup" id="dup" required> <label for="dup">{{ call $.T "duplicate_deprecated" }}</label><br />
                     {{block "captcha" .}}{{end}}
-                    <button type="submit" class="btn btn-default">{{ T "report_btn" }}</button>
+                    <button type="submit" class="btn btn-default">{{ call $.T "report_btn" }}</button>
                 </form> <br />
             </div>
             <div class="modal-footer">

--- a/util/languages/translation.go
+++ b/util/languages/translation.go
@@ -3,6 +3,7 @@ package languages
 import (
 	"errors"
 	"fmt"
+	"html/template"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -17,6 +18,8 @@ import (
 type UserRetriever interface {
 	RetrieveCurrentUser(r *http.Request) (model.User, error)
 }
+
+type TemplateTfunc func(string, ...interface{}) template.HTML
 
 var (
 	defaultLanguage string        = config.DefaultI18nConfig.DefaultLanguage
@@ -117,9 +120,11 @@ func GetTfuncAndLanguageFromRequest(r *http.Request) (T i18n.TranslateFunc, Tlan
 	return
 }
 
-func GetTfuncFromRequest(r *http.Request) i18n.TranslateFunc {
+func GetTfuncFromRequest(r *http.Request) TemplateTfunc {
 	T, _ := GetTfuncAndLanguageFromRequest(r)
-	return T
+	return func(id string, args ...interface{}) template.HTML {
+		return template.HTML(fmt.Sprintf(T(id), args...))
+	}
 }
 
 func getCurrentUser(r *http.Request) (model.User, error) {

--- a/util/languages/translation.go
+++ b/util/languages/translation.go
@@ -95,17 +95,6 @@ func GetAvailableLanguages() (languages map[string]string) {
 	return
 }
 
-func setTranslation(tmpl *template.Template, T i18n.TranslateFunc) {
-	tmpl.Funcs(map[string]interface{}{
-		"T": func(str string, args ...interface{}) template.HTML {
-			return template.HTML(fmt.Sprintf(T(str), args...))
-		},
-		"Ts": func(str string, args ...interface{}) string {
-			return fmt.Sprintf(T(str), args...)
-		},
-	})
-}
-
 func GetDefaultTfunc() (i18n.TranslateFunc, error) {
 	return i18n.Tfunc(defaultLanguage)
 }
@@ -127,13 +116,6 @@ func GetTfuncAndLanguageFromRequest(r *http.Request) (T i18n.TranslateFunc, Tlan
 	headerLanguage := r.Header.Get("Accept-Language")
 	T, Tlang, _ = TfuncAndLanguageWithFallback(userLanguage, cookieLanguage, headerLanguage)
 	return
-}
-
-func SetTranslationFromRequest(tmpl *template.Template, r *http.Request) i18n.TranslateFunc {
-	r.Header.Add("Vary", "Accept-Encoding")
-	T, _ := GetTfuncAndLanguageFromRequest(r)
-	setTranslation(tmpl, T)
-	return T
 }
 
 func getCurrentUser(r *http.Request) (model.User, error) {

--- a/util/languages/translation.go
+++ b/util/languages/translation.go
@@ -3,7 +3,6 @@ package languages
 import (
 	"errors"
 	"fmt"
-	"html/template"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -116,6 +115,11 @@ func GetTfuncAndLanguageFromRequest(r *http.Request) (T i18n.TranslateFunc, Tlan
 	headerLanguage := r.Header.Get("Accept-Language")
 	T, Tlang, _ = TfuncAndLanguageWithFallback(userLanguage, cookieLanguage, headerLanguage)
 	return
+}
+
+func GetTfuncFromRequest(r *http.Request) i18n.TranslateFunc {
+	T, _ := GetTfuncAndLanguageFromRequest(r)
+	return T
 }
 
 func getCurrentUser(r *http.Request) (model.User, error) {


### PR DESCRIPTION
Apparently [template.ExecuteTemplate doesn't lock the templates' FuncMap](golang.org/src/text/template/exec.go?s=5133:5197#L181), meaning that the FuncMap can change during the template execution. As the current translation method is changing the translation func on the FuncMap, this means the language can change too.

Hopefully this will fix the bug with mixed translations on the site.