### PR TITLE
Implement HEAD for views

### DIFF
--- a/router/api_handler.go
+++ b/router/api_handler.go
@@ -14,8 +14,8 @@ import (
 	"github.com/NyaaPantsu/nyaa/model"
 	"github.com/NyaaPantsu/nyaa/service"
 	"github.com/NyaaPantsu/nyaa/service/api"
-	"github.com/NyaaPantsu/nyaa/service/upload"
 	"github.com/NyaaPantsu/nyaa/service/torrent"
+	"github.com/NyaaPantsu/nyaa/service/upload"
 	"github.com/NyaaPantsu/nyaa/util"
 	"github.com/NyaaPantsu/nyaa/util/log"
 	"github.com/gorilla/mux"
@@ -100,6 +100,23 @@ func ApiViewHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+}
+
+func ApiViewHeadHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, err := strconv.ParseInt(vars["id"], 10, 32)
+	if err != nil {
+		return
+	}
+
+	_, err = torrentService.GetRawTorrentById(uint(id))
+
+	if err != nil {
+		NotFoundHandler(w, r)
+		return
+	}
+
+	w.Write(nil)
 }
 
 func ApiUploadHandler(w http.ResponseWriter, r *http.Request) {

--- a/router/router.go
+++ b/router/router.go
@@ -52,6 +52,7 @@ func init() {
 	Router.HandleFunc("/feed", RSSHandler).Name("feed")
 	Router.HandleFunc("/feed/{page}", RSSHandler).Name("feed_page")
 	Router.Handle("/view/{id}", wrapHandler(gzipViewHandler)).Methods("GET").Name("view_torrent")
+	Router.HandleFunc("/view/{id}", ViewHeadHandler).Methods("HEAD")
 	Router.HandleFunc("/view/{id}", PostCommentHandler).Methods("POST").Name("post_comment")
 	Router.HandleFunc("/upload", UploadHandler).Name("upload")
 	Router.HandleFunc("/user/register", UserRegisterFormHandler).Name("user_register").Methods("GET")

--- a/router/router.go
+++ b/router/router.go
@@ -46,6 +46,7 @@ func init() {
 	Router.Handle("/api", wrapHandler(gzipAPIHandler)).Methods("GET")
 	Router.Handle("/api/{page:[0-9]*}", wrapHandler(gzipAPIHandler)).Methods("GET")
 	Router.Handle("/api/view/{id}", wrapHandler(gzipAPIViewHandler)).Methods("GET")
+	Router.HandleFunc("/api/view/{id}", ApiViewHeadHandler).Methods("HEAD")
 	Router.HandleFunc("/api/upload", ApiUploadHandler).Methods("POST")
 	Router.HandleFunc("/api/update", ApiUpdateHandler).Methods("PUT")
 	Router.HandleFunc("/faq", FaqHandler).Name("faq")

--- a/router/view_torrent_handler.go
+++ b/router/view_torrent_handler.go
@@ -25,13 +25,13 @@ func ViewHandler(w http.ResponseWriter, r *http.Request) {
 	messages := msg.GetMessages(r)
 	user := GetUser(r)
 
-	if (r.URL.Query()["success"] != nil) {
+	if r.URL.Query()["success"] != nil {
 		messages.AddInfo("infos", "Torrent uploaded successfully!")
 	}
 
 	torrent, err := torrentService.GetTorrentById(id)
-	
-	if (r.URL.Query()["notif"] != nil) {
+
+	if r.URL.Query()["notif"] != nil {
 		notifierService.ToggleReadNotification(torrent.Identifier(), user.ID)
 	}
 
@@ -52,12 +52,29 @@ func ViewHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func ViewHeadHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, err := strconv.ParseInt(vars["id"], 10, 32)
+	if err != nil {
+		return
+	}
+
+	_, err = torrentService.GetRawTorrentById(uint(id))
+
+	if err != nil {
+		NotFoundHandler(w, r)
+		return
+	}
+
+	w.Write(nil)
+}
+
 func PostCommentHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 
 	torrent, err := torrentService.GetTorrentById(id)
-	if (err != nil) {
+	if err != nil {
 		NotFoundHandler(w, r)
 		return
 	}
@@ -93,7 +110,7 @@ func PostCommentHandler(w http.ResponseWriter, r *http.Request) {
 			messages.ImportFromError("errors", err)
 		}
 	}
-	ViewHandler(w,r)
+	ViewHandler(w, r)
 }
 
 func ReportTorrentHandler(w http.ResponseWriter, r *http.Request) {
@@ -123,5 +140,5 @@ func ReportTorrentHandler(w http.ResponseWriter, r *http.Request) {
 			messages.ImportFromError("errors", err)
 		}
 	}
-	ViewHandler(w,r)
+	ViewHandler(w, r)
 }


### PR DESCRIPTION
This implements HEAD methods for both /api/view/{id} and /view/{id} in a way that should only be minimal impact to the server.

Should be able to close #678 unless other HEAD requests are wanted/needed.

Let me know if something isn't quite right and I can tweak it.