### PR TITLE
Add err check from GetTorrentById return in ApiViewHandler

### DIFF
--- a/router/api_handler.go
+++ b/router/api_handler.go
@@ -92,6 +92,12 @@ func ApiViewHandler(w http.ResponseWriter, r *http.Request) {
 	id := vars["id"]
 
 	torrent, err := torrentService.GetTorrentById(id)
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
 	b := torrent.ToJSON()
 	w.Header().Set("Content-Type", "application/json")
 	err = json.NewEncoder(w).Encode(b)


### PR DESCRIPTION
This should give a better response to API users for when something is not found.