### PR TITLE
Added a counter below the search result nav

### DIFF
--- a/router/template_functions.go
+++ b/router/template_functions.go
@@ -135,6 +135,9 @@ var FuncMap = template.FuncMap{
 				url, _ := Router.Get(nav.Route).URL("page", strconv.Itoa(nav.CurrentPage+1))
 				ret = ret + "<li><a id=\"page-next\" href=\"" + url.String() + "?" + currentUrl.RawQuery + "\" aria-label=\"Next\"><span aria-hidden=\"true\">&raquo;</span></a></li>"
 			}
+			itemsThisPageStart := nav.MaxItemPerPage * (nav.CurrentPage - 1) + 1
+			itemsThisPageEnd := nav.MaxItemPerPage * nav.CurrentPage
+			ret = ret + "<p>" + strconv.Itoa(itemsThisPageStart) + "-" + strconv.Itoa(itemsThisPageEnd) + "/" + strconv.Itoa(nav.TotalItem) + "</p>"
 		}
 		return template.HTML(ret)
 	},


### PR DESCRIPTION
As suggested in #699, makes navigation of the website easier.

This commit does not come with styling, as @kipukun would be throwing it away shortly anyway.

![screenshot - 052317 - 23 28 34](https://cloud.githubusercontent.com/assets/12187513/26380691/a1a9e9c4-400f-11e7-9cf0-f50b64927b07.png)
