### PR TITLE
Activate the never_go_down again switch (fix slowdown issue)

### DIFF
--- a/db/gorm.go
+++ b/db/gorm.go
@@ -39,8 +39,10 @@ func GormInit(conf *config.Config, logger Logger) (*gorm.DB, error) {
 		log.CheckError(connectionErr)
 		return nil, connectionErr
 	}
-	db.DB().SetMaxIdleConns(10)
-	db.DB().SetMaxOpenConns(100)
+
+	// Negative MaxIdleConns means don't retain any idle connection
+	db.DB().SetMaxIdleConns(-1)
+	db.DB().SetMaxOpenConns(400)
 
 	if config.Environment == "DEVELOPMENT" {
 		db.LogMode(true)

--- a/db/gorm_test.go
+++ b/db/gorm_test.go
@@ -26,7 +26,7 @@ func (logger *errorLogger) Print(values ...interface{}) {
 
 func TestGormInitSqlite(t *testing.T) {
 	conf := config.New()
-	conf.DBType = "sqlite3"
+	conf.DBType = SqliteType
 	conf.DBParams = ":memory:?cache=shared&mode=memory"
 	conf.DBLogMode = "detailed"
 

--- a/deploy/ansible/roles/postgresql/templates/pgpool.conf.j2
+++ b/deploy/ansible/roles/postgresql/templates/pgpool.conf.j2
@@ -62,7 +62,7 @@ max_pool = 4
 
 # - Life time -
 
-child_life_time = 300
+child_life_time = {{ child_life_time }}
 # Pool exits after being idle for this many seconds
 child_max_connections = 0
 # Pool exits after receiving that many connections

--- a/deploy/ansible/roles/postgresql/vars/main.yml
+++ b/deploy/ansible/roles/postgresql/vars/main.yml
@@ -6,3 +6,5 @@ memqcache_total_size_byte: 10737418240
 memqcache_maxcache_byte: 131072000
 # Has to be bigger or equal to maxcache_byte
 memqcache_cache_block_size_byte: 131072000
+# 20 seconds idle max (application shouldn't even make idle connections)
+child_life_time: 20


### PR DESCRIPTION
Tried this in dev and on prod, seemed to eliminate the slowdown issue.
We were having a lot of 'idle' and 'idle in transaction' connection issue with pgpool.
Connection should never go idle now which should let new connections in.