### PR TITLE
TorrentJSON.ID is uint now, fix weird page sorting

### DIFF
--- a/common/torrent.go
+++ b/common/torrent.go
@@ -165,7 +165,7 @@ func (p *TorrentParam) Find(client *elastic.Client) (int64, []model.Torrent, err
 		// INFO We are not using Hits.Id because the id in the index might not
 		// correspond to the id in the database later on.
 		type TId struct {
-			Id string
+			Id uint
 		}
 		var tid TId
 		var torrents []model.Torrent
@@ -175,11 +175,11 @@ func (p *TorrentParam) Find(client *elastic.Client) (int64, []model.Torrent, err
 			// Building a string of the form {id1,id2,id3}
 			source, _ := hits[0].Source.MarshalJSON()
 			json.Unmarshal(source, &tid)
-			idsToString := "{" + tid.Id
+			idsToString := "{" + strconv.FormatUint(uint64(tid.Id), 10)
 			for _, t := range hits[1:] {
 				source, _ = t.Source.MarshalJSON()
 				json.Unmarshal(source, &tid)
-				idsToString += "," + tid.Id
+				idsToString += "," + strconv.FormatUint(uint64(tid.Id), 10)
 			}
 			idsToString += "}"
 			db.ORM.Raw("SELECT * FROM " + config.TorrentsTableName +

--- a/deploy/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
+++ b/deploy/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
@@ -24,8 +24,7 @@ mappings:
     properties:
       # TODO Consistent ID's type in TorrentJSON
       id:
-        type: text
-        fielddata: true # Use to sort by id because it is currently a text field
+        type: long
       name:
         type: text
         analyzer: nyaapantsu_analyzer

--- a/deploy/ansible/roles/elasticsearch/files/index_nyaapantsu.py
+++ b/deploy/ansible/roles/elasticsearch/files/index_nyaapantsu.py
@@ -32,9 +32,8 @@ fetches = cur.fetchmany(CHUNK_SIZE)
 while fetches:
     actions = list()
     for torrent_id, torrent_name, category, sub_category, status, torrent_hash, date, uploader, downloads, filesize, seeders, leechers, completed in fetches:
-        # TODO Consistent ID representation on the codebase
         doc = {
-          'id': str(torrent_id),
+          'id': torrent_id,
           'name': torrent_name.decode('utf-8'),
           'category': str(category),
           'sub_category': str(sub_category),

--- a/model/torrent.go
+++ b/model/torrent.go
@@ -138,7 +138,7 @@ func (t Torrent) AddToESIndex(client *elastic.Client) error {
 	_, err := client.Index().
 		Index(config.DefaultElasticsearchIndex).
 		Type(config.DefaultElasticsearchType).
-		Id(torrentJson.ID).
+		Id(strconv.FormatUint(uint64(torrentJson.ID), 10)).
 		BodyJson(torrentJson).
 		Refresh("true").
 		Do(ctx)
@@ -182,7 +182,7 @@ type FileJSON struct {
 
 // TorrentJSON for torrent model in json for api
 type TorrentJSON struct {
-	ID           string        `json:"id"`
+	ID           uint          `json:"id"`
 	Name         string        `json:"name"`
 	Status       int           `json:"status"`
 	Hash         string        `json:"hash"`
@@ -254,7 +254,7 @@ func (t *Torrent) ToJSON() TorrentJSON {
 		torrentlink = fmt.Sprintf(config.TorrentStorageLink, t.Hash)
 	}
 	res := TorrentJSON{
-		ID:           strconv.FormatUint(uint64(t.ID), 10),
+		ID:           t.ID,
 		Name:         t.Name,
 		Status:       t.Status,
 		Hash:         t.Hash,

--- a/model/torrent.go
+++ b/model/torrent.go
@@ -126,7 +126,7 @@ func (t Torrent) AddToESIndex(client *elastic.Client) error {
 	_, err := client.Index().
 		Index(config.DefaultElasticsearchIndex).
 		Type(config.DefaultElasticsearchType).
-		Id(strconv.FormatUint(uint64(torrentJson.ID), 10)).
+		Id(strconv.FormatUint(uint64(torrentJSON.ID), 10)).
 		BodyJson(torrentJSON).
 		Refresh("true").
 		Do(ctx)

--- a/router/rss_handler.go
+++ b/router/rss_handler.go
@@ -74,7 +74,7 @@ func RSSHandler(w http.ResponseWriter, r *http.Request) {
 	for i, torrent := range torrents {
 		torrentJSON := torrent.ToJSON()
 		feed.Items[i] = &feeds.Item{
-			ID:          "https://" + config.WebAddress + "/view/" + torrentJSON.ID,
+			ID:          "https://" + config.WebAddress + "/view/" + strconv.FormatUint(uint64(torrentJSON.ID), 10),
 			Title:       torrent.Name,
 			Link:        &feeds.Link{Href: string(torrentJSON.Magnet)},
 			Description: string(torrentJSON.Description),

--- a/templates/_user_list_torrents.html
+++ b/templates/_user_list_torrents.html
@@ -27,7 +27,7 @@
                   </a>
               </td>
               <td class="tr-name">
-                  <a href="{{genRoute "view_torrent" "id" .ID }}">
+                  <a href="{{genRoute "view_torrent" "id" ( print .ID ) }}">
                       {{.Name}}
                   </a>
               </td>

--- a/templates/home.html
+++ b/templates/home.html
@@ -50,7 +50,7 @@ Your browser does not support the audio element.
                   </a>
               </td>
               <td class="tr-name home-td">
-                  <a href="{{genRoute "view_torrent" "id" .ID }}">
+                  <a href="{{genRoute "view_torrent" "id" ( print .ID ) }}">
                       {{.Name}}
                   </a>
               </td>


### PR DESCRIPTION
The bug was that ES would sort by ID in a weird manner because the id
was a string. The id is now a uint.

I'm probably missing templates changes somewhere. They'll give runtime error.
Fixes an issue in #755 