### PR TITLE
Fix User Reset API

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -73,7 +73,7 @@ func init() {
 	Router.HandleFunc("/user/{id}/{username}/follow", UserFollowHandler).Name("user_follow").Methods("GET")
 	Router.Handle("/user/{id}/{username}/edit", wrapHandler(gzipUserDetailsHandler)).Name("user_profile_details").Methods("GET")
 	Router.Handle("/user/{id}/{username}/edit", wrapHandler(gzipUserProfileFormHandler)).Name("user_profile_edit").Methods("POST")
-	Router.Handle("/user/{id}/{username}/apireset", wrapHandler(gzipUserAPIKeyResetHandler)).Name("user_profile_apireset").Methods("POST")
+	Router.Handle("/user/{id}/{username}/apireset", wrapHandler(gzipUserAPIKeyResetHandler)).Name("user_profile_apireset").Methods("GET")
 	Router.Handle("/user/notifications", wrapHandler(gzipUserNotificationsHandler)).Name("user_notifications")
 	Router.HandleFunc("/user/{id}/{username}/feed", RSSHandler).Name("feed_user")
 	Router.HandleFunc("/user/{id}/{username}/feed/{page}", RSSHandler).Name("feed_user_page")

--- a/router/user_handler.go
+++ b/router/user_handler.go
@@ -345,11 +345,11 @@ func UserAPIKeyResetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	userProfile.APIToken, _ = crypto.GenerateRandomToken32()
 	userProfile.APITokenExpiry = time.Unix(0, 0)
-	_, errorUser = userService.UpdateUserCore(&userProfile)
+	_, errorUser = userService.UpdateRawUser(&userProfile)
 	if errorUser != nil {
 		messages.ImportFromError("errors", errorUser)
 	} else {
 		messages.AddInfo("infos", Ts("profile_updated"))
 	}
-
+	UserProfileHandler(w, r)
 }

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -178,6 +178,17 @@ func UpdateUserCore(user *model.User) (int, error) {
 	return http.StatusOK, nil
 }
 
+// UpdateRawUser : Function to update a user without updating his associations model
+func UpdateRawUser(user *model.User) (int, error) {
+	user.UpdatedAt = time.Now()
+	err := db.ORM.Model(&user).UpdateColumn(&user).Error
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	return http.StatusOK, nil
+}
+
 // UpdateUser updates a user.
 func UpdateUser(w http.ResponseWriter, form *formStruct.UserForm, formSet *formStruct.UserSettingsForm, currentUser *model.User, id string) (model.User, int, error) {
 	var user model.User


### PR DESCRIPTION
* Added a new function to only update columns of table user (less
useless query)
* Changed method to GET instead of POST because it is a link not a
button anymore
* Display of user profile if changes are successful