### PR TITLE
Update zer0day tracker.

### DIFF
--- a/config/trackers.go
+++ b/config/trackers.go
@@ -6,7 +6,7 @@ package config
 var Trackers = []string{
 	"udp://tracker.doko.moe:6969",
 	"udp://tracker.coppersurfer.tk:6969",
-	"udp://zer0day.to:1337/announce",
+	"udp://tracker.zer0day.to:1337/announce",
 	"udp://tracker.leechers-paradise.org:6969",
 	"udp://explodie.org:6969",
 	"udp://tracker.opentrackr.org:1337",

--- a/templates/FAQ.html
+++ b/templates/FAQ.html
@@ -46,7 +46,7 @@
         <h2 id="trackers">{{call $.T "which_trackers_do_you_recommend"}}</h2>
         <p>{{call $.T "answer_which_trackers_do_you_recommend"}}</p>
 	<pre>udp://tracker.doko.moe:6969 
-udp://zer0day.to:1337/announce 
+udp://tracker.zer0day.to:1337/announce 
 udp://tracker.leechers-paradise.org:6969 
 udp://explodie.org:6969 
 udp://tracker.opentrackr.org:1337 


### PR DESCRIPTION
**Purpose**
Update tracker for zer0day

**Reason**
> please don't use udp://zer0day.to:1337/announce or any other URL variation