### PR TITLE
Fix "see more torrents from" box width

### DIFF
--- a/templates/_user_list_torrents.html
+++ b/templates/_user_list_torrents.html
@@ -52,7 +52,7 @@
       </table>
       <nav class="torrentNav" aria-label="Page navigation">
           <ul class="pagination">
-              <li><a href="{{ genRoute "search" }}?userID={{ .ID }}" aria-label="Next"><span class="glyphicon glyphicon-add"></span> {{ call $.T "see_more_torrents_from" .Username }}</a></li>
+              <li style="width:100%;"><a href="{{ genRoute "search" }}?userID={{ .ID }}" aria-label="Next"><span class="glyphicon glyphicon-add"></span> {{ call $.T "see_more_torrents_from" .Username }}</a></li>
           </ul>
       </nav>
     {{else}}


### PR DESCRIPTION
The width is fixed to 35px because all \<li\> are fixed at 35px width, which is obviously not enough for the text it is trying to contain.
At first i tried to remove that 35px and just let the size change based on nickname length, but making it stick to 100% looks better in my opinion

Here is how it looks right now:
![picture1](https://cloud.githubusercontent.com/assets/11745692/26528822/c21ad1da-43b3-11e7-8839-cb0eb1cc8644.png)
Here is how it would look without the 35px:
![picture2](https://cloud.githubusercontent.com/assets/11745692/26528825/cc632c1e-43b3-11e7-997c-9b395a2f7167.png)
Here is how it would look with my change to force it at 100% width:
![picture3](https://cloud.githubusercontent.com/assets/11745692/26528827/d4698cf0-43b3-11e7-8260-f8b3383d3f4e.png)
