### PR TITLE
Fix infohash decoding (fixes #799)

### DIFF
--- a/router/upload.go
+++ b/router/upload.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -172,12 +171,17 @@ func (f *uploadForm) ExtractInfo(r *http.Request) error {
 		if len(f.Magnet) != 0 {
 			return errTorrentPlusMagnet
 		}
-		binInfohash, err := torrent.Infohash()
-		if err != nil {
-			return err
+
+		_, seekErr = tfile.Seek(0, io.SeekStart)
+		if seekErr != nil {
+			return seekErr
 		}
-		f.Infohash = strings.ToUpper(hex.EncodeToString(binInfohash[:]))
-		f.Magnet = util.InfoHashToMagnet(f.Infohash, f.Name, trackers...)
+		infohash, err := metainfo.DecodeInfohash(tfile)
+		if err != nil {
+			return metainfo.ErrInvalidTorrentFile
+		}
+		f.Infohash = infohash
+		f.Magnet = util.InfoHashToMagnet(infohash, f.Name, trackers...)
 
 		// extract filesize
 		f.Filesize = int64(torrent.TotalSize())

--- a/service/api/api.go
+++ b/service/api/api.go
@@ -198,11 +198,15 @@ func (r *TorrentRequest) ValidateMultipartUpload(req *http.Request) (int64, erro
 			r.Name = torrent.TorrentName()
 		}
 
-		binInfohash, err := torrent.Infohash()
+		_, err = tfile.Seek(0, io.SeekStart)
 		if err != nil {
 			return 0, err, http.StatusInternalServerError
 		}
-		r.Hash = strings.ToUpper(hex.EncodeToString(binInfohash[:]))
+		infohash, err := metainfo.DecodeInfohash(tfile)
+		if err != nil {
+			return 0, err, http.StatusInternalServerError
+		}
+		r.Hash = infohash
 
 		// extract filesize
 		filesize := int64(torrent.TotalSize())


### PR DESCRIPTION
Calculate the info hash of the uploaded torrent file
instead of the re-encoded torrent file.

The re-encoded torrent files only contain a subset
of the original info values and thus have a different hash.

Fixes #799