### PR TITLE
Add max image width & height in torrent description

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -487,6 +487,11 @@ td.tr-le { color: #E84C4C; }
 	border-radius: 4px;
 }
 
+.torrent-info-box > * > img {
+	max-width: 100%;
+	max-height: 100%;
+}
+
 .comment-box {
 	margin-top: 10px;
 	padding-left: 7px;


### PR DESCRIPTION
Big images were broking it and going outside of it!
Before:
https://cloud.githubusercontent.com/assets/11745692/26528093/f86ec28e-43a2-11e7-8288-f850ff51f04e.png

After:
https://cloud.githubusercontent.com/assets/11745692/26528121/a8cabd18-43a3-11e7-9e66-5299e98eef8e.png

Fix for issue #809 

thank you tomleb for your assistance in this