### PR TITLE
Apply max-width/height to all description images

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -498,7 +498,7 @@ td.tr-le { color: #E84C4C; }
     padding-left: 14px;
 }
 
-.torrent-info-box > * > img {
+.torrent-info-box img {
 	max-width: 100%;
 	max-height: 100%;
 }


### PR DESCRIPTION
Max-width & max-height only applied to images inside another element in the torrent description. It's fine because description images seem to always be in a \<p\>\<p/\>, but what if they weren't?
The max-width & max-height now apply to all images in the torrent description (.torrent-info-box img) instead of one in another element (.torrent-info-box > * > img), that way no image may ever go outside the bounds! Not on it's own at least.