### PR TITLE
Make usernames stick to avatar in navbar

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -187,7 +187,7 @@ select.form-input {
 	/* Property is ignored due to the display. With 'display: block', vertical-align should not be used. */
 	vertical-align: middle;
 	/* Hardcoded so the div always fills up all available space while floating right */
-	width: 91px;
+	max-width: 91px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
Usernames were hovering in between the search bar & avatar because of a fixed width:91px; (done because of character limit), so i instead replaced it to a max-width so that short usernames wouldn't just float in there
This change doesn't change anything if the name length is above the character limit

Before:

![before](https://cloud.githubusercontent.com/assets/11745692/26743664/fc6d3a84-47e2-11e7-89e9-8810748d39c1.png)

After:

![after](https://cloud.githubusercontent.com/assets/11745692/26743667/ff5c5856-47e2-11e7-8cde-1dd3b4513eed.png)
