### PR TITLE
Add web address config

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -15,12 +15,18 @@ db_params: ./nyaa.db?cache_size=50
 db_logmode: default
 # Environment should be one of: DEVELOPMENT, TEST, PRODUCTION
 environment: DEVELOPMENT
-# WebAddress : url of the website
-web_address: nyaa.pantsu.cat
 # AuthTokenExpirationDay : Number of Days for token expiration when logged in
 auth_token_expiration: 1000
 # EnableSecureCSRF : Enable CSRF https mode : True if website support https, false otherwise (eg. testing locally: false)
 enable_secure_csrf: true
+# the default config for web addresses
+web_address:
+  # Nyaa : Origin of the website
+  nyaa: https://nyaa.pantsu.cat
+  # Sukebei : Origin of the sukebei website
+  sukebei: https://sukebei.pantsu.cat
+  # Status : Origin of the status website
+  status: https://status.pantsu.cat
 # the default config for session cookies
 cookies:
   # DomainName : The host domain so the cookies can be shared across subdomains

--- a/config/types.go
+++ b/config/types.go
@@ -6,7 +6,6 @@ type Config struct {
 	Port                   int    `json:"port" yaml:"port,omitempty"`
 	DBType                 string `json:"db_type" yaml:"db_type,omitempty"`
 	Environment            string `json:"environment" yaml:"environment,omitempty"`
-	WebAddress             string `json:"web_address" yaml:"web_address,omitempty"`
 	AuthTokenExpirationDay int    `json:"auth_token_expiration" yaml:"auth_token_expiration,omitempty"`
 	EnableSecureCSRF       bool   `json:"enable_secure_csrf" yaml:"enable_secure_csrf,omitempty"`
 	// DBParams will be directly passed to Gorm, and its internal
@@ -15,6 +14,8 @@ type Config struct {
 	DBLogMode string `json:"db_logmode" yaml:"db_logmode,omitempty"`
 	Version   string `json:"version" yaml:"version,omitempty"`
 	Build     string `yaml:"-"`
+	// web address config
+	WebAddress WebAddressConfig `yaml:"web_address,flow,omitempty"`
 	// cookies config
 	Cookies CookiesConfig `yaml:"cookies,flow,omitempty"`
 	// tracker scraper config (required)
@@ -41,6 +42,13 @@ type Config struct {
 	Email EmailConfig `yaml:"email,flow,omitempty"`
 	// models config
 	Models ModelsConfig `yaml:"models,flow,omitempty"`
+}
+
+// WebAddressConfig : Config struct for web addresses
+type WebAddressConfig struct {
+	Nyaa    string `yaml:"nyaa,omitempty"`
+	Sukebei string `yaml:"sukebei,omitempty"`
+	Status  string `yaml:"status,omitempty"`
 }
 
 // CookiesConfig : Config struct for session cookies

--- a/router/rss_handler.go
+++ b/router/rss_handler.go
@@ -67,7 +67,7 @@ func RSSHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	feed := &feeds.Feed{
 		Title:   "Nyaa Pantsu",
-		Link:    &feeds.Link{Href: "https://" + config.Conf.WebAddress + "/"},
+		Link:    &feeds.Link{Href: config.Conf.WebAddress.Nyaa + "/"},
 		Created: createdAsTime,
 	}
 	feed.Items = make([]*feeds.Item, len(torrents))
@@ -75,7 +75,7 @@ func RSSHandler(w http.ResponseWriter, r *http.Request) {
 	for i, torrent := range torrents {
 		torrentJSON := torrent.ToJSON()
 		feed.Items[i] = &feeds.Item{
-			ID:          "https://" + config.Conf.WebAddress + "/view/" + strconv.FormatUint(uint64(torrentJSON.ID), 10),
+			ID:          config.Conf.WebAddress.Nyaa + "/view/" + strconv.FormatUint(uint64(torrentJSON.ID), 10),
 			Title:       torrent.Name,
 			Link:        &feeds.Link{Href: string("<![CDATA[" + torrentJSON.Magnet + "]]>")},
 			Description: string(torrentJSON.Description),

--- a/router/template_functions.go
+++ b/router/template_functions.go
@@ -170,6 +170,7 @@ var FuncMap = template.FuncMap{
 		// because time.* isn't available in templates...
 		return t.Format(time.RFC3339)
 	},
+	"GetHostname": util.GetHostname,
 	"GetCategories": func(keepParent bool) map[string]string {
 		return categories.GetCategoriesSelect(keepParent)
 	},

--- a/router/upload.go
+++ b/router/upload.go
@@ -70,7 +70,7 @@ var errTorrentPlusMagnet = errors.New("Upload either a torrent file or magnet li
 var errPrivateTorrent = errors.New("Torrent is private")
 
 // error indicating a problem with its trackers
-var errTrackerProblem = errors.New("Torrent does not have any (working) trackers: https://" + config.Conf.WebAddress + "/faq#trackers")
+var errTrackerProblem = errors.New("Torrent does not have any (working) trackers: " + config.Conf.WebAddress.Nyaa + "/faq#trackers")
 
 // error indicating a torrent's name is invalid
 var errInvalidTorrentName = errors.New("Torrent name is invalid")

--- a/service/user/verification.go
+++ b/service/user/verification.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/db"
 	"github.com/NyaaPantsu/nyaa/model"
+	"github.com/NyaaPantsu/nyaa/util"
 	"github.com/NyaaPantsu/nyaa/util/email"
 	"github.com/NyaaPantsu/nyaa/util/publicSettings"
 	"github.com/NyaaPantsu/nyaa/util/timeHelper"
@@ -24,8 +25,8 @@ func SendEmailVerification(to string, token string) error {
 	if err != nil {
 		return err
 	}
-	content := T("link") + " : https://" + config.Conf.WebAddress + "/verify/email/" + token
-	contentHTML := T("verify_email_content") + "<br/>" + "<a href=\"https://" + config.Conf.WebAddress + "/verify/email/" + token + "\" target=\"_blank\">" + config.Conf.WebAddress + "/verify/email/" + token + "</a>"
+	content := T("link") + " : " + config.Conf.WebAddress.Nyaa + "/verify/email/" + token
+	contentHTML := T("verify_email_content") + "<br/>" + "<a href=\"" + config.Conf.WebAddress.Nyaa + "/verify/email/" + token + "\" target=\"_blank\">" + util.GetHostname(config.Conf.WebAddress.Nyaa) + "/verify/email/" + token + "</a>"
 	return email.SendEmailFromAdmin(to, T("verify_email_title"), content, contentHTML)
 }
 

--- a/templates/FAQ.html
+++ b/templates/FAQ.html
@@ -8,11 +8,11 @@
         <br />
 
         <h2>{{call $.T "links_replacement_mirror"}}</h2>
-        <a href="https://nyaa.pantsu.cat">Nyaa - nyaa.pantsu.cat</a><br />
-        <a href="https://sukebei.pantsu.cat">Sukebei - sukebei.pantsu.cat</a>
+        <a href="{{.Config.WebAddress.Nyaa}}">Nyaa - {{GetHostname .Config.WebAddress.Nyaa}}</a><br />
+        <a href="{{.Config.WebAddress.Sukebei}}">Sukebei - {{GetHostname .Config.WebAddress.Sukebei}}</a>
 
         <h2>{{call $.T "server_status_link"}}</h2>
-        <a href="https://status.pantsu.cat/">https://status.pantsu.cat/</a><br />
+        <a href="{{.Config.WebAddress.Status}}">Status - {{GetHostname .Config.WebAddress.Status}}</a><br />
 
         <h2>{{call $.T "what_happened"}}</h2>
         <ul>

--- a/templates/admin_index.html
+++ b/templates/admin_index.html
@@ -32,7 +32,7 @@
 			<link rel="stylesheet" id="theme" href="/css/{{$.Theme}}.css?v={{ .Config.Version }}">
 		{{end}}
 		<!-- Search Box for Google -->
-		<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","url":"https://nyaa.pantsu.cat/","potentialAction":{"@type":"SearchAction","target":"https://nyaa.pantsu.cat/search?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
+		<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","url":"{{.Config.WebAddress.Nyaa}}/","potentialAction":{"@type":"SearchAction","target":"{{.Config.WebAddress.Nyaa}}/search?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 		{{ block "additional_header" .}}{{end}}
   </head>
    <body {{if Sukebei}}class="sukebei"{{end}}>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
 			<link rel="stylesheet" id="theme" href="/css/{{$.Theme}}.css?v={{ .Config.Version }}">
 		{{end}}
 		<!-- Search Box for Google -->
-		<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","url":"https://nyaa.pantsu.cat/","potentialAction":{"@type":"SearchAction","target":"https://nyaa.pantsu.cat/search?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
+		<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","url":"{{.Config.WebAddress.Nyaa}}/","potentialAction":{"@type":"SearchAction","target":"{{.Config.WebAddress.Nyaa}}/search?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 		{{ block "additional_header" .}}{{end}}
 	</head>
    <body {{if Sukebei}}class="sukebei"{{end}}>
@@ -47,9 +47,9 @@
 							<a href="{{ genRouteWithQuery "feed" .URL }}" class="nav-btn"><div class="rss-icon visible-md"></div><span class="hide-md">RSS</span></a>
 							<a href="{{.URL.Parse "/faq"}}" class="nav-btn"><div class="faq-icon visible-md"></div><span class="hide-md">{{ call $.T "faq" }}</span></a>
 							{{if Sukebei}}
-							<a href="//nyaa.pantsu.cat" class="nav-btn"><div class="fun-icon visible-md"></div><span class="hide-md">{{ call $.T "fun" }}</span></a>
+							<a href="{{.Config.WebAddress.Nyaa}}" class="nav-btn"><div class="fun-icon visible-md"></div><span class="hide-md">{{ call $.T "fun" }}</span></a>
 							{{else}}
-							<a href="//sukebei.pantsu.cat" class="nav-btn"><div class="fap-icon visible-md"></div><span class="hide-md">{{ call $.T "fap" }}</span></a>
+							<a href="{{.Config.WebAddress.Sukebei}}" class="nav-btn"><div class="fap-icon visible-md"></div><span class="hide-md">{{ call $.T "fap" }}</span></a>
 							{{end}}
 						</div>
 				</div>

--- a/templates/view.html
+++ b/templates/view.html
@@ -50,7 +50,7 @@
           <td class="torrent-info-td torrent-info-label">{{call $.T "seeders"}}:</td><td class="tr-se torrent-info-td">{{if .LastScrape.IsZero}}{{call $.T "unknown"}}{{else}}{{.Seeders}}{{end}}</td>
       </tr>
       <tr class="torrent-info-row">
-          <td class="torrent-info-td torrent-info-label">{{ call $.T "website_link" }}:</td><td class="torrent-view-td torrent-info-data">{{if ne .WebsiteLink ""}}<a href="{{.WebsiteLink}}">{{.WebsiteLink}}</a>{{else}}<a href="//nyaa.pantsu.cat">nyaa.pantsu.cat{{end}}</td>
+          <td class="torrent-info-td torrent-info-label">{{ call $.T "website_link" }}:</td><td class="torrent-view-td torrent-info-data">{{if ne .WebsiteLink ""}}<a href="{{.WebsiteLink}}">{{.WebsiteLink}}</a>{{else}}<a href="{{$.Config.WebAddress.Nyaa}}">{{GetHostname $.Config.WebAddress.Nyaa}}{{end}}</td>
           <td class="torrent-info-td torrent-info-label">{{call $.T "leechers"}}:</td><td class="tr-le torrent-info-td">{{if .LastScrape.IsZero}}{{call $.T "unknown"}}{{else}}{{.Leechers}}{{end}}</td>
       </tr>
     <tr class="torrent-info-row">

--- a/util/format.go
+++ b/util/format.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"net/url"
 )
 
 // FormatFilesize : format file size
@@ -25,4 +26,13 @@ func FormatFilesize(bytes int64) string {
 		value = float64(bytes)
 	}
 	return fmt.Sprintf("%.1f %s", value, unit)
+}
+
+// GetHostname : Returns the host of a URL, without any scheme or port number.
+func GetHostname(rawurl string) string {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return rawurl
+	}
+	return u.Hostname()
 }


### PR DESCRIPTION
* This allows changing the nyaa, sukebei and status URL via config.
  Previously only the nyaa address was configurable
* This helps testing changes locally without having to set up
  a TLS terminating proxy
* Also refactored uses of hardcoded URLs in the html templates
  The html templates will now also use the configured urls