### PR TITLE
Prettier color for /g/'s theme user menu

### DIFF
--- a/public/css/g.css
+++ b/public/css/g.css
@@ -23,10 +23,10 @@ a:hover { color:  #444; }
 	border-color: #1d6d90;
 }
 .header .h-user .user-menu {
-	background: #99BFD0;
-	background:    -moz-linear-gradient(top, #99BFD0 0%, #ABCFDF 100%);
-	background: -webkit-linear-gradient(top, #99BFD0 0%, #ABCFDF 100%);
-	background:         linear-gradient(to bottom, #99BFD0 0%, #ABCFDF 100%);
+	background: #BDE0EF;
+	background:    -moz-linear-gradient(top, #BDE0EF 0%, #ABCFDF 100%);
+	background: -webkit-linear-gradient(top, #BDE0EF 0%, #ABCFDF 100%);
+	background:         linear-gradient(to bottom, #BDE0EF 0%, #ABCFDF 100%);
 	border-color: #1d6d90;
 }
 


### PR DESCRIPTION
It's very ugly at the time being

Before:

![before](https://cloud.githubusercontent.com/assets/11745692/26760903/fc3893dc-4923-11e7-8905-f3d2efa9f101.png)

After:

![after](https://cloud.githubusercontent.com/assets/11745692/26760905/ff888844-4923-11e7-9a9d-d7bbbaf27de9.png)
