### PR TITLE
Deleted obsolete and duplicated translation ids, some other fixes.

### DIFF
--- a/templates/view.html
+++ b/templates/view.html
@@ -91,7 +91,7 @@
     {{/* how do i concat lol */}}
     <table class="table-filelist">
       <thead>
-        <th style="width: 80%">{{call $.T "filename"}}</th>
+        <th style="width: 80%">{{call $.T "file_name"}}</th>
         <th>{{call $.T "size"}}</th>
       </thead>
       <tbody>

--- a/translations/ca-es.json
+++ b/translations/ca-es.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "enllaç"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Verifiqueu la vostra adreça electrònica de Nyaapantsu."
   },
@@ -594,10 +590,6 @@
   {
     "id": "torrent_status",
     "translation": "Estat del torrent"
-  },
-  {
-    "id": "torrent_status_hidden",
-    "translation": "Ocult"
   },
   {
     "id": "torrent_status_normal",

--- a/translations/ca-es.json
+++ b/translations/ca-es.json
@@ -20,127 +20,123 @@
     "translation": "Feu clic a l'enllaç de sota per restablir la contrasenya."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Crea un compte nou"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Registreu-vos <small>És de franc i sempre ho serà.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Nom d'usuari"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Adreça de correu electrònic o nom d'usuari"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Adreça de correu electrònic"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Contrasenya"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Confirmeu la contrasenya"
   },
   {
-    "id":"i_agree",
-    "translation": "Hi estic d'acord"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Si feu clic a <strong class=\"label label-primary\">Registra-m'hi</strong>, accepteu els <a id=\"modal_active\" href=\"#\">termes i condicions</a> definits en aquest lloc, incloent-hi el nostre ús de les galetes."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Inicia la sessió"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registra-m'hi"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Termes i condicions"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Una mica de merda."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Recorda'm"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Heu oblidat la contrasenya?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Inicieu la sessió"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Inicia la sessió"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Registre completat"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Gràcies per registrar-vos!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>El vostre compte ha estat activat!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "La verificació del correu electrònic està desactivada per ara, així que podeu utilitzar el vostre compte immediatament. En el futur, comproveu la vostra safata d'entrada de correu (i la carpeta de correu brossa!) cercant-hi el correu electrònic de verificació."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "El registre s'ha completat, ja podeu fer servir el vostre compte."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Configuració del compte"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Segueix"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Deixa de seguir"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Ara seguiu %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Ja no seguiu %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "Pàgina de perfil de %s"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Mostra més torrents de %s"
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Categoria"
   },
   {
@@ -168,10 +164,6 @@
     "translation": "Error 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Activa/desactiva la navegació"
-  },
-  {
     "id": "upload",
     "translation": "Carrega"
   },
@@ -186,10 +178,6 @@
   {
     "id": "fun",
     "translation": "Diversió"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Cerca avançada"
   },
   {
     "id": "nothing_here",
@@ -214,14 +202,6 @@
   {
     "id": "member",
     "translation": "Membres"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Inicia la sessió"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Registra-t'hi"
   },
   {
     "id": "no_results_found",
@@ -342,10 +322,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "És el llenguatge de programació preferit de l'autor."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Carrega un enllaç magnètic"
   },
   {
     "id": "torrent_file",
@@ -512,22 +488,6 @@
     "translation": "De confiança"
   },
   {
-    "id": "id",
-    "translation": "Identificador"
-  },
-  {
-    "id": "downloads",
-    "translation": "Descàrregues"
-  },
-  {
-    "id": "descending",
-    "translation": "Descendent"
-  },
-  {
-    "id": "ascending",
-    "translation": "Ascendent"
-  },
-  {
     "id": "search",
     "translation": "Cerca"
   },
@@ -690,10 +650,6 @@
   {
     "id": "uploaded_by",
     "translation": "Carregat per"
-  },
-  {
-    "id": "download_btn",
-    "translation": "Descarrega!"
   },
   {
     "id": "report_btn",

--- a/translations/de-de.all.json
+++ b/translations/de-de.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "Link"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Bestätigung der E-Mail-Adresse für NyaaPantsu."
   },

--- a/translations/de-de.all.json
+++ b/translations/de-de.all.json
@@ -20,127 +20,123 @@
     "translation": "Klicke auf den Link, um dein Passwort zurückzusetzen."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Neuen Account erstellen"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Registrierung <small>Es ist kostenlos und wird immer so bleiben.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Benutzername"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "E-Mail oder Benutzername"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "E-Mail"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Passwort"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Passwort-Bestätigung"
   },
   {
-    "id":"i_agree",
-    "translation": "Ich stimme zu"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Durch Klicken auf <strong class=\"label label-primary\">Registrieren</strong> stimmst du den <a id=\"modal_active\" href=\"#\">Nutzungsbedingungen</a> sowie der Nutzung von Cookies zu."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Einloggen"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registrieren"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Nutzungsbedingungen"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Coming sooner than you might expect..."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Eingeloggt bleiben"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Passwort vergessen"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Bitte einloggen"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Login"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Login erfolgreich"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Danke für's Registrieren!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>Dein Account ist jetzt aktiviert!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "Derzeit ist die Verfizierung der E-Mail-Adresse deaktiviert, also kannst du deinen Account direkt nutzen. In Zukunft, überprüfe bitte deinen Posteingang (auch deinen Spam-Ordner!) auf eine Bestätigungsmail."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Die Registrierung war erfolgreich. Du kannst deinen Account jetzt benutzen."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Profil-Einstellungen"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Folgen"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Nicht mehr Folgen"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Du folgst jetzt %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Du folgst %s nicht mehr!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "Profil von %s"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Mehr Torrents von %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Kategorie"
   },
   {
@@ -168,10 +164,6 @@
     "translation": "Fehler 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Navigation umschalten"
-  },
-  {
     "id": "upload",
     "translation": "Hochladen"
   },
@@ -186,10 +178,6 @@
   {
     "id": "fun",
     "translation": "Fun"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Erweiterte Suche"
   },
   {
     "id": "nothing_here",
@@ -214,14 +202,6 @@
   {
     "id": "member",
     "translation": "Mitglied"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Einloggen"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Registrieren"
   },
   {
     "id": "no_results_found",
@@ -342,10 +322,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Weil es die Lieblingsprogrammiersprache des Entwicklers ist."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Magnet hochladen"
   },
   {
     "id": "torrent_file",
@@ -516,22 +492,6 @@
     "translation": "Trusted"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Downloads"
-  },
-  {
-    "id": "descending",
-    "translation": "Absteigend"
-  },
-  {
-    "id": "ascending",
-    "translation": "Aufsteigend"
-  },
-  {
     "id": "search",
     "translation": "Suche"
   },
@@ -644,10 +604,6 @@
     "translation": "Torrent-Status"
   },
   {
-    "id": "torrent_status_hidden",
-    "translation": "Versteckt"
-  },
-  {
     "id": "torrent_status_normal",
     "translation": "Normal"
   },
@@ -700,16 +656,8 @@
     "translation": "Nanu, wo sind denn die Dateien hin?"
   },
   {
-    "id": "filename",
-    "translation": "Dateiname"
-  },
-  {
     "id": "uploaded_by",
     "translation": "Hochgeladen von"
-  },
-  {
-    "id": "download_btn",
-    "translation": "Download!"
   },
   {
     "id": "report_btn",

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "link"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Verify your email address for Nyaapantsu."
   },
@@ -20,131 +16,127 @@
     "translation": "Please click below link to reset your password."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Creating a new account"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Please Sign Up <small>It's free and always will be.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Username"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Email Address or Username"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Email Address"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Password"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Confirm Password"
   },
   {
-    "id":"i_agree",
-    "translation": "I agree"
+    "id": "terms_conditions_confirm",
+    "translation": "By clicking <strong class=\"label label-primary\">Register</strong>, you agree to the <a id=\"modal_active\" href=\"#\">Terms and Conditions</a> set out by this site, including our Cookie Use."
   },
   {
-    "id":"terms_conditions_confirm",
-    "translation": "By checking this box, you agree to the <a id=\"modal_active\" href=\"#\">terms and conditions</a>"
-  },
-  {
-    "id":"signin",
+    "id": "signin",
     "translation": "Sign In"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Register"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Terms and Conditions"
   },
   {
-    "id":"terms_conditions_full",
-    "translation": "Just don't be a dick."
+    "id": "terms_conditions_full",
+    "translation": "Some Shit."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Remember me"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Forgot Password?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Please Sign In"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Sign In"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Sign Up Successful"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Thank you for registering!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>Your account is now activated!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "Email verification is disabled at the moment, so you may use your account immediately. In the future, please check your mail inbox (and spam folder!) for the verification email."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Registration was successful, you may now use your account."
   },
   {
-    "id":"email_placeholder",
-    "translation":"Can be left blank."
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Account Settings"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Follow"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Unfollow"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "You have followed %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "You have unfollowed %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s Profile Page"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "See more torrents from %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Category"
   },
   {
@@ -172,10 +164,6 @@
     "translation": "Error 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Toggle navigation"
-  },
-  {
     "id": "upload",
     "translation": "Upload"
   },
@@ -190,10 +178,6 @@
   {
     "id": "fun",
     "translation": "Fun"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Advanced Search"
   },
   {
     "id": "nothing_here",
@@ -218,14 +202,6 @@
   {
     "id": "member",
     "translation": "Member"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Sign In"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Sign Up"
   },
   {
     "id": "no_results_found",
@@ -346,10 +322,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "It's the author's favorite programming language."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Upload magnet"
   },
   {
     "id": "torrent_file",
@@ -520,22 +492,6 @@
     "translation": "Trusted"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Downloads"
-  },
-  {
-    "id": "descending",
-    "translation": "Descending"
-  },
-  {
-    "id": "ascending",
-    "translation": "Ascending"
-  },
-  {
     "id": "search",
     "translation": "Search"
   },
@@ -648,10 +604,6 @@
     "translation": "Torrent status"
   },
   {
-    "id": "torrent_status_hidden",
-    "translation": "Hidden"
-  },
-  {
     "id": "torrent_status_normal",
     "translation": "Normal"
   },
@@ -708,16 +660,8 @@
     "translation": "No files found? That doesn't even make sense!"
   },
   {
-    "id": "filename",
-    "translation": "Filename"
-  },
-  {
     "id": "uploaded_by",
     "translation": "Uploaded by"
-  },
-  {
-    "id": "download_btn",
-    "translation": "Download!"
   },
   {
     "id": "report_btn",
@@ -1032,11 +976,31 @@
     "translation": "Hide"
   },
   {
-    "id":"show_mod_tools",
+    "id": "Nyaa Pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "Torrents",
+    "translation": "Torrents"
+  },
+  {
+    "id": "Users",
+    "translation": "Users"
+  },
+  {
+    "id": "Comments",
+    "translation": "Comments"
+  },
+  {
+    "id": "Torrent Reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
     "translation": "Show Mod Tools"
   },
   {
-    "id":"hide_mod_tools",
+    "id": "hide_mod_tools",
     "translation": "Hide Mod Tools"
   },
   {
@@ -1212,7 +1176,7 @@
     "translation": "Might take a long time, do <b>NOT</b> abort the request."
   },
   {
-    "id":"reassign_to",
+    "id": "reassign_to",
     "translation": "Reassign to:"
   },
   {

--- a/translations/es-es.all.json
+++ b/translations/es-es.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "enlace"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Verifica tu correo electrónico para Nyaapantsu."
   },
@@ -20,127 +16,123 @@
     "translation": "Por favor, da click en el siguiente enlace para reestablecer tu contraseña."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Creando una nueva cuenta."
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Por favor, regístrate. <small>Es gratis y siempre lo será.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Usuario"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Correo Electrónico o Usuario"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Correo Electrónico"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Contraseña"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Confirmar Contraseña"
   },
   {
-    "id":"i_agree",
-    "translation": "Acepto"
+    "id": "terms_conditions_confirm",
+    "translation": "Al dar click en <strong class=\"label label-primary\">Registrarse</strong>, aceptas los <a href=\"#\" data-toggle=\"modal\" data-target=\"#t_and_c_m\">Términos y Condiciones</a> del sitio, incluyendo nuestro Uso de Cookies."
   },
   {
-    "id":"terms_conditions_confirm",
-    "translation": "Al dar click en <strong class=\"label label-primary\">Registrarse</strong>, aceptas los <a id=\"modal_active\" href=\"#\">Términos y Condiciones</a> del sitio, incluyendo nuestro Uso de Cookies."
-  },
-  {
-    "id":"signin",
+    "id": "signin",
     "translation": "Iniciar Sesión"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registrarse"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Términos y Condiciones"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Por definir."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Mantener sesión iniciada"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "¿Olvidaste tu contraseña?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Por favor, Inicia Sesión"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Iniciar Sesión"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Registro Exitoso"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "¡Gracias por registrarte!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>¡Tu cuenta ha sido activada!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "Por último, revisa en tu bandeja de entrada (¡y en la carpeta de spam!) el correo de verificación."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Te has registrado exitosamente, ahora puedes usar tu cuenta."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Ajustes de la Cuenta"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Seguir"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Dejar de Seguir"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "¡Ahora sigues a %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "¡Has dejado de seguir a %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "Perfil de %s"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Ver más torrents de %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Categoría"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "Error 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Alternar navegación"
-  },
-  {
     "id": "upload",
     "translation": "Subir"
   },
@@ -182,10 +170,6 @@
   {
     "id": "fap",
     "translation": "Fap"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Búsqueda Avanzada"
   },
   {
     "id": "nothing_here",
@@ -210,14 +194,6 @@
   {
     "id": "member",
     "translation": "Miembro"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Iniciar Sesión"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Registrarse"
   },
   {
     "id": "no_results_found",
@@ -330,10 +306,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Es el lenguaje de programación favorito del autor."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Subir Magnet"
   },
   {
     "id": "torrent_file",
@@ -468,22 +440,6 @@
     "translation": "Confiables"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Descargas"
-  },
-  {
-    "id": "descending",
-    "translation": "Descendente"
-  },
-  {
-    "id": "ascending",
-    "translation": "Ascendente"
-  },
-  {
     "id": "search",
     "translation": "Buscar"
   },
@@ -588,7 +544,7 @@
     "translation": "Estado del Torrent"
   },
   {
-    "id": "torrent_status_hidden",
+    "id": <a id=\"modal_active\" href=\"#\">,
     "translation": "Oculto"
   },
   {

--- a/translations/es-es.all.json
+++ b/translations/es-es.all.json
@@ -45,7 +45,7 @@
   },
   {
     "id": "terms_conditions_confirm",
-    "translation": "Al dar click en <strong class=\"label label-primary\">Registrarse</strong>, aceptas los <a href=\"#\" data-toggle=\"modal\" data-target=\"#t_and_c_m\">Términos y Condiciones</a> del sitio, incluyendo nuestro Uso de Cookies."
+    "translation": "Al dar click en <strong class=\"label label-primary\">Registrarse</strong>, aceptas los <a id=\"modal_active\" href=\"#\">Términos y Condiciones</a> del sitio, incluyendo nuestro Uso de Cookies."
   },
   {
     "id": "signin",
@@ -542,10 +542,6 @@
   {
     "id": "torrent_status",
     "translation": "Estado del Torrent"
-  },
-  {
-    "id": <a id=\"modal_active\" href=\"#\">,
-    "translation": "Oculto"
   },
   {
     "id": "torrent_status_normal",

--- a/translations/fr-fr.all.json
+++ b/translations/fr-fr.all.json
@@ -301,7 +301,7 @@
   },
   {
     "id": "no_results_found",
-    "translation": "Aucun résultat trouvé"
+    "translation": "Aucun résultat trouvé."
   },
   {
     "id": "anime",
@@ -484,10 +484,6 @@
     "translation": "Liste des fichiers"
   },
   {
-    "id": "filename",
-    "translation": "Nom du fichier"
-  },
-  {
     "id": "no_files",
     "translation": "Aucun fichier trouvé."
   },
@@ -576,8 +572,12 @@
     "translation": "S'inscrire"
   },
   {
+    "id": "terms_conditions",
+    "translation": "Termes et Conditions"
+  },
+  {
     "id": "terms_conditions_full",
-    "translation": "À définir"
+    "translation": "Ne faites pas le con."
   },
   {
     "id": "register_success_title",
@@ -720,8 +720,8 @@
     "translation": "Authentifieur d'API"
   },
   {
-    "id":"email_placeholder",
-    "translation":"Peut être laissé vide."
+    "id": "email_placeholder",
+    "translation": "Peut être laissé vide."
   },
   {
     "id": "current_password",
@@ -912,11 +912,11 @@
     "translation": "Signalements de torrents"
   },
   {
-    "id":"show_mod_tools",
+    "id": "show_mod_tools",
     "translation": "Afficher les outils de modération"
   },
   {
-    "id":"hide_mod_tools",
+    "id": "hide_mod_tools",
     "translation": "Maquer les outils de modération"
   },
   {
@@ -926,10 +926,6 @@
   {
     "id": "torrent_status_blocked",
     "translation": "Bloqué"
-  },
-  {
-    "id": "torrent_status_hidden",
-    "translation": "Invisible"
   },
   {
     "id": "torrent_status_normal",
@@ -1168,7 +1164,7 @@
     "translation": "La réassignation de torrents à un nouvel utilisateur est difficilement réversible et doit être effectuée avec attention."
   },
   {
-    "id":"reassign_to",
+    "id": "reassign_to",
     "translation": "Réassigner à :"
   },
   {

--- a/translations/hu-hu.all.json
+++ b/translations/hu-hu.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "link"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Erősítsd meg az e-mail címedet a hozzáféréshez."
   },
@@ -46,10 +42,6 @@
   {
     "id": "confirm_password",
     "translation": "Jelszó mégegyszer"
-  },
-  {
-    "id": "i_agree",
-    "translation": "Beleegyezek"
   },
   {
     "id": "terms_conditions_confirm",
@@ -156,10 +148,6 @@
     "translation": "Hiba: 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Navigáció átváltása"
-  },
-  {
     "id": "upload",
     "translation": "Feltöltés"
   },
@@ -170,10 +158,6 @@
   {
     "id": "fap",
     "translation": "Fap"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Részletes Keresés"
   },
   {
     "id": "nothing_here",
@@ -198,14 +182,6 @@
   {
     "id": "member",
     "translation": "Tag"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Bejelentkezés"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Regisztráció"
   },
   {
     "id": "no_results_found",
@@ -318,10 +294,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Ez a dev kedvenc programozási nyelve."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Magnet Feltöltése"
   },
   {
     "id": "torrent_file",
@@ -452,22 +424,6 @@
     "translation": "Megbízható"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Letöltések"
-  },
-  {
-    "id": "descending",
-    "translation": "Csökkenő"
-  },
-  {
-    "id": "ascending",
-    "translation": "Növekvő"
-  },
-  {
     "id": "search",
     "translation": "Keresés"
   },
@@ -572,10 +528,6 @@
     "translation": "Torrent állapota"
   },
   {
-    "id": "torrent_status_hidden",
-    "translation": "Eltüntetett"
-  },
-  {
     "id": "torrent_status_normal",
     "translation": "Normál"
   },
@@ -628,16 +580,8 @@
     "translation": "Nincsenek meg a fájlok? Na, az meg hogy lehet?"
   },
   {
-    "id": "filename",
-    "translation": "Fájlnév"
-  },
-  {
     "id": "uploaded_by",
     "translation": "Feltöltötte: "
-  },
-  {
-    "id": "download_btn",
-    "translation": "Letöltés!"
   },
   {
     "id": "report_btn",

--- a/translations/is-is.all.json
+++ b/translations/is-is.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "tengill"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Staðfestu tölvupóstfang þitt fyrir Nyaapantsu."
   },
@@ -20,127 +16,123 @@
     "translation": "Smelltu á tengilinn fyrir neðan til að endurstilla lykilorðið þitt."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Er að búa til nýjan aðgang"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Vinsamlegast skráðu þig <small>Það er og mun ætíð vera ókeypis.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Notendanafn"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Tölvupóstfang eða notendanafn"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Tölvupóstfang"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Lykilorð"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Staðfesta lykilorð"
   },
   {
-    "id":"i_agree",
-    "translation": "Ég samþykki"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Með því að smella á <strong class=\"label label-primary\">Nýskrá</strong> samþykkir þú <a id=\"modal_active\" href=\"#\">Skilmála</a> síðunnar, þar á meðal notkun hennar á smákökum."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Innskráning"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Nýskráning"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Skilmálar"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Eitthver skítur."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Muna eftir mér"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Týnt lykilorð?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Vinsamlegast skráðu þig inn"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Skrá inn"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Nýskráning gekk upp"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Takk fyrir að nýskrá þig."
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>Aðgangur þinn er nú virkur!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "Staðfesting Tölvupóstfanga er óvirk í augnablikinu og aðgangur þinn er hér með virkur."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Nýskráning tókst, þú getur núna notað aðganginn þinn."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Aðgangsstillingar"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrent"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Fylgja"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Hætta að fylgja"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Þú hefur fylgt %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Þú ert hættur að fylgja %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s Prófílsíða"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Sjá fleiri torrent frá %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Flokkur"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "Villa 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Stilla flakkara af/á"
-  },
-  {
     "id": "upload",
     "translation": "Upphala"
   },
@@ -186,10 +174,6 @@
   {
     "id": "fun",
     "translation": "Skemmtun"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Nákvæmari leit"
   },
   {
     "id": "nothing_here",
@@ -214,14 +198,6 @@
   {
     "id": "member",
     "translation": "Meðlimur"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Innskráning"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Nýskráning"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Því það er í uppáhaldi."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Upphalssegull"
   },
   {
     "id": "torrent_file",
@@ -512,22 +484,6 @@
     "translation": "Treyst"
   },
   {
-    "id": "id",
-    "translation": "Auðkenni"
-  },
-  {
-    "id": "downloads",
-    "translation": "Niðurhöl"
-  },
-  {
-    "id": "descending",
-    "translation": "Minnkandi röðun"
-  },
-  {
-    "id": "ascending",
-    "translation": "Rísandi röðun"
-  },
-  {
     "id": "search",
     "translation": "Leit"
   },
@@ -636,10 +592,6 @@
     "translation": "Staða torrents"
   },
   {
-    "id": "torrent_status_hidden",
-    "translation": "Falið"
-  },
-  {
     "id": "torrent_status_normal",
     "translation": "Venjulegt"
   },
@@ -684,16 +636,8 @@
     "translation": "Skrár"
   },
   {
-    "id": "filename",
-    "translation": "Skrárnafn"
-  },
-  {
     "id": "uploaded_by",
     "translation": "Upphalað af"
-  },
-  {
-    "id": "download_btn",
-    "translation": "Niðurhala!"
   },
   {
     "id": "report_btn",

--- a/translations/it-it.all.json
+++ b/translations/it-it.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "link"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Verifica il tuo indirizzo email per Nyaapantsu."
   },
@@ -20,127 +16,123 @@
     "translation": "Clicca qui per resettare la tua password."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Creazione di un nuovo account"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Iscriviti <small>È gratuito e lo sarà per sempre.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Nome Utente"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Indirizzo Email o Nome Utente"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Indirizzo Email"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Password"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Conferma Password"
   },
   {
-    "id":"i_agree",
-    "translation": "Accetto"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Cliccando <strong class=\"label label-primary\">Registrati</strong>, accetti i <a id=\"modal_active\" href=\"#\">Termini e le condizioni</a> stabilite da questo sito, incluso il nostro Utilizzo dei Cookie."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Entra"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registrati"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Termini e condizioni"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Stronzate varie."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Ricordami"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Dimenticato la password?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Per Favore Entra"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Entra"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Registrato con Successo!"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Grazie per esserti registrato"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>Il tuo account è ora attivo!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "La verifica via email non è abilitata al momento, quindi puoi già usare il tuo account. In futuro, per concludere dovrai controllare la tua casella email (e la cartella spam!) per l'email di verifica."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "La registrazione è avvenuta con successo. Ora puoi usare il tuo account."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Impostazioni Account"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Segui"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Smetti di seguire"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Hai seguito %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Hai smesso di seguire %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "Pagina Profilo di %s"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Guarda altri torrent di %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Categoria"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "Errore 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Alterna la navigazione"
-  },
-  {
     "id": "upload",
     "translation": "Upload"
   },
@@ -182,10 +170,6 @@
   {
     "id": "fap",
     "translation": "Fap"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Ricerca Avanzata"
   },
   {
     "id": "nothing_here",
@@ -210,14 +194,6 @@
   {
     "id": "member",
     "translation": "Utente"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Entra"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Registrati"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "È il linguaggio di programmazione preferito dell'autore."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Carica magnet"
   },
   {
     "id": "torrent_file",
@@ -480,22 +452,6 @@
     "translation": "Fidato"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Downloads"
-  },
-  {
-    "id": "descending",
-    "translation": "Discendente"
-  },
-  {
-    "id": "ascending",
-    "translation": "Ascendente"
-  },
-  {
     "id": "search",
     "translation": "Cerca"
   },
@@ -590,7 +546,7 @@
   {
     "id": "mark_as_remake",
     "translation": "Segnala come remake"
-},
+  },
   {
     "id": "email_changed",
     "translation": "Email cambiata con successo! Tuttavia per confermare dovrai cliccare il link inviato a: %s"
@@ -598,10 +554,6 @@
   {
     "id": "torrent_status",
     "translation": "Torrent status"
-  },
-  {
-    "id": "torrent_status_hidden",
-    "translation": "Nascosto"
   },
   {
     "id": "torrent_status_normal",
@@ -646,10 +598,6 @@
   {
     "id": "uploaded_by",
     "translation": "Caricato da"
-  },
-  {
-    "id": "download_btn",
-    "translation": "Download!"
   },
   {
     "id": "report_btn",

--- a/translations/ja-jp.all.json
+++ b/translations/ja-jp.all.json
@@ -45,7 +45,7 @@
   },
   {
     "id": "terms_conditions_confirm",
-    "translation": "<strong class=\"label label-primary\">登録</strong> をクリックすることにより、Cookie の使用を含む、本サイトの <a href=\"#\" data-toggle=\"modal\" data-target=\"#t_and_c_m\">利用規約</a> に同意したものとみなします。"
+    "translation": "<strong class=\"label label-primary\">登録</strong> をクリックすることにより、Cookie の使用を含む、本サイトの <a id=\"modal_active\" href=\"#\">利用規約</a> に同意したものとみなします。"
   },
   {
     "id": "signin",
@@ -598,10 +598,6 @@
   {
     "id": "torrent_status",
     "translation": "Torrent の状態"
-  },
-  {
-    "id": <a id=\"modal_active\" href=\"#\">,
-    "translation": "非表示"
   },
   {
     "id": "torrent_status_normal",

--- a/translations/ja-jp.all.json
+++ b/translations/ja-jp.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "リンク"
-  },
-  {
     "id": "verify_email_title",
     "translation": "【Nyaapantsu】メールアドレスの認証"
   },
@@ -20,127 +16,123 @@
     "translation": "パスワードをリセットするには、以下のリンクをクリックします。"
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "新しいアカウントの作成"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "アカウント登録 <small>ずっと無料です</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "ユーザー名"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "メールアドレスまたはユーザー名"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "メールアドレス"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "パスワード"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "パスワードの再入力"
   },
   {
-    "id":"i_agree",
-    "translation": "同意する"
+    "id": "terms_conditions_confirm",
+    "translation": "<strong class=\"label label-primary\">登録</strong> をクリックすることにより、Cookie の使用を含む、本サイトの <a href=\"#\" data-toggle=\"modal\" data-target=\"#t_and_c_m\">利用規約</a> に同意したものとみなします。"
   },
   {
-    "id":"terms_conditions_confirm",
-    "translation": "<strong class=\"label label-primary\">登録</strong> をクリックすることにより、Cookie の使用を含む、本サイトの <a id=\"modal_active\" href=\"#\">利用規約</a> に同意したものとみなします。"
-  },
-  {
-    "id":"signin",
+    "id": "signin",
     "translation": "ログイン"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "登録"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "利用規約"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "ダミー"
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "ログイン情報を記憶する"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "パスワードをお忘れですか？"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "ログイン"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "ログイン"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "登録完了"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "ご登録いただきありがとうございます。"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>お使いのアカウントは有効になりました。"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "現在は一時的にメールアドレスの認証が無効になっているので、すぐにアカウントを使うことができます。後日、メールボックスを確認してください。迷惑メールフォルダーの確認もお忘れなく。"
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "認証が完了しました。今からこのアカウントを使えるようになります。"
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "アカウント設定"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrent"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "フォロー"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "フォロー解除"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "%s さんをフォローしました。"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "%s さんのフォローを解除しました。"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s さんのプロフィールページ"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "%s さんの Torrent をもっと表示"
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "カテゴリー"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "404 エラー"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "ナビゲーションの切り替え"
-  },
-  {
     "id": "upload",
     "translation": "アップロード"
   },
@@ -186,10 +174,6 @@
   {
     "id": "fun",
     "translation": "にゃあ"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "高度な検索"
   },
   {
     "id": "nothing_here",
@@ -214,14 +198,6 @@
   {
     "id": "member",
     "translation": "アカウント"
-  },
-  {
-    "id": "sign_in",
-    "translation": "ログイン"
-  },
-  {
-    "id": "sign_up",
-    "translation": "登録"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "作者の一番好きなプログラミング言語だからです。"
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "magnet リンクのアップロード"
   },
   {
     "id": "torrent_file",
@@ -516,22 +488,6 @@
     "translation": "高信頼のみ"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "ダウンロード数"
-  },
-  {
-    "id": "descending",
-    "translation": "降順"
-  },
-  {
-    "id": "ascending",
-    "translation": "昇順"
-  },
-  {
     "id": "search",
     "translation": "検索"
   },
@@ -596,7 +552,7 @@
     "translation": "モデレーター"
   },
   {
-    "id":" api_token",
+    "id": " api_token",
     "translation": "API トークン"
   },
   {
@@ -644,7 +600,7 @@
     "translation": "Torrent の状態"
   },
   {
-    "id": "torrent_status_hidden",
+    "id": <a id=\"modal_active\" href=\"#\">,
     "translation": "非表示"
   },
   {
@@ -700,16 +656,8 @@
     "translation": "ファイル一覧が見つからない？もー！意味わかんない！"
   },
   {
-    "id": "filename",
-    "translation": "ファイル名"
-  },
-  {
     "id": "uploaded_by",
     "translation": "アップロード者"
-  },
-  {
-    "id": "download_btn",
-    "translation": "ダウンロード"
   },
   {
     "id": "report_btn",
@@ -1008,11 +956,11 @@
     "translation": "非表示"
   },
   {
-    "id":"show_mod_tools",
+    "id": "show_mod_tools",
     "translation": "Mod Tools を表示"
   },
   {
-    "id":"hide_mod_tools",
+    "id": "hide_mod_tools",
     "translation": "Mod Tools を非表示"
   },
   {
@@ -1188,7 +1136,7 @@
     "translation": "処理には時間がかかることがあります。<b>絶対に</b>リクエストを中止しないでください。"
   },
   {
-    "id":"reassign_to",
+    "id": "reassign_to",
     "translation": "再割り当て先:"
   },
   {

--- a/translations/ko-kr.all.json
+++ b/translations/ko-kr.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "링크"
-  },
-  {
     "id": "verify_email_title",
     "translation": "고양이를 위해 이메일을 확인해주세요"
   },
@@ -20,115 +16,111 @@
     "translation": "암호를 리셋하려면 아래의 링크를 눌러주세요"
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "새 계정 만들기"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "회원가입 해주세요! <small>가입은 무료이며 언제나 그럴 것입니다</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "아이디"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "이메일 주소 또는 아이디"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "이메일 주소"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "비밀번호"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "비밀번호 재확인"
   },
   {
-    "id":"i_agree",
-    "translation": "동의"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "<strong class=\"label label-primary\">회원가입</strong>을 하시면, 쿠키 사용과 더불어 <a id=\"modal_active\" href=\"#\">약관</a>에 동의하신 것으로 간주합니다."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "로그인"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "회원가입"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "이용약관"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "ㅅㅂ"
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "로그인 상태 유지"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "비밀번호 찾기"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "로그인 하세요"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "로그인"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "성공적으로 가입했습니다!"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "가입해주셔서 고마워요!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>계정이 활성화 되었습니다!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "마지막으로 이메일 인증을 완료해 주세요! 이메일이 도착하지 않았다면 스팸 메일함도 확인해 주세요."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "계정 설정"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "토렌트"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "팔로우"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "언팔로우"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s 프로필 페이지"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "%s 에서 더 많은 토렌트 보기"
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "카테고리"
   },
   {
@@ -156,10 +148,6 @@
     "translation": "에러 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "네비게이션 토글"
-  },
-  {
     "id": "upload",
     "translation": "업로드"
   },
@@ -170,10 +158,6 @@
   {
     "id": "fap",
     "translation": "자위"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "고급 검색"
   },
   {
     "id": "nothing_here",
@@ -198,14 +182,6 @@
   {
     "id": "member",
     "translation": "멤버"
-  },
-  {
-    "id": "sign_in",
-    "translation": "로그인"
-  },
-  {
-    "id": "sign_up",
-    "translation": "회원가입"
   },
   {
     "id": "no_results_found",
@@ -318,10 +294,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "제일 좋아하는 언어입니다. >__- 찡긋"
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "마그넷 업로드"
   },
   {
     "id": "torrent_file",
@@ -450,22 +422,6 @@
   {
     "id": "trusted",
     "translation": "신뢰된"
-  },
-  {
-    "id": "id",
-    "translation": "아이디"
-  },
-  {
-    "id": "downloads",
-    "translation": "다운로드"
-  },
-  {
-    "id": "descending",
-    "translation": "내림차순"
-  },
-  {
-    "id": "ascending",
-    "translation": "오름차순"
   },
   {
     "id": "search",

--- a/translations/nb-no.all.json
+++ b/translations/nb-no.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "lenke"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Bekreft epost-addressen din."
   },
@@ -20,127 +16,123 @@
     "translation": "For å bytte passordet ditt, klikk på lenken nedenfor."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Opprett konto"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Registrer deg her! <small>Gratis, nå og for alltid.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Brukernavn"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Epost eller brukernavn"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Epost-addresse"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Passord"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Bekreft passord"
   },
   {
-    "id":"i_agree",
-    "translation": "Aksepter"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Ved å klikke på <strong class=\"label label-primary\">Registrer</strong> godtar du <a id=\"modal_active\" href=\"#\">Vilkår og Betingelser</a> som gjelder for denne siden, samt vår bruk av Cookies."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Logg inn"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registrer"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Vilkår og Betingelser"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Pess og mannskit"
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Husk meg"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Glemt passordet?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Vennligst logg inn."
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Logg inn"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Registrering fullført"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Takk og velkommen!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>Din konto er nå aktivert!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "Du har fått post! Sjekk innboksen din (muligens spam-kassa) for å bekrefte epost-addressen."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Ferdig! Ikkeno epost-piss her, bare kjør på."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Innstillinger"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrenter"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Følg"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Avfølg"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Du følger nå %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Du har sluttet å følge %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s profilside"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Se flere torrenter fra %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Kategori"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "Ikke funnet"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Vis meny"
-  },
-  {
     "id": "upload",
     "translation": "Last opp"
   },
@@ -182,10 +170,6 @@
   {
     "id": "fap",
     "translation": "Snusk"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Avansert"
   },
   {
     "id": "nothing_here",
@@ -210,14 +194,6 @@
   {
     "id": "member",
     "translation": "Medlem"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Logg inn"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Registrer"
   },
   {
     "id": "no_results_found",
@@ -330,10 +306,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Favorittspråket til karen som dro sulamitten i gang."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Last opp magnet"
   },
   {
     "id": "torrent_file",
@@ -462,22 +434,6 @@
   {
     "id": "trusted",
     "translation": "Fra kjentfolk"
-  },
-  {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Nedlastinger"
-  },
-  {
-    "id": "descending",
-    "translation": "Synkende"
-  },
-  {
-    "id": "ascending",
-    "translation": "Stigende"
   },
   {
     "id": "search",

--- a/translations/nl-nl.all.json
+++ b/translations/nl-nl.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "link"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Bevestig je e-mailadres voor Nyaapantsu."
   },
@@ -20,115 +16,111 @@
     "translation": "Klik op de onderstaande link om je wachtwoord opnieuw in te stellen."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Een nieuw account aanmaken"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Registreren <small>Het is gratis en dat blijft het ook.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Gebruikersnaam"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "E-mailadres of Gebruikersnaam"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "E-mailadres"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Wachtwoord"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Bevestig wachtwoord"
   },
   {
-    "id":"i_agree",
-    "translation": "Ik ga akkoord"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Door te klikken op <strong class=\"label label-primary\">Registreren</strong>, ga je akkoord met de <a id=\"modal_active\" href=\"#\">Algemene voorwaarden</a> die deze site hanteert, waaronder ons Cookiebeleid."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Aanmelden"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registreren"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Algemene voorwaarden"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Wat onzin."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Onthou mij"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Wachtwoord vergeten?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Meld je aan"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Aanmelden"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Registratie gelukt"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Bedankt voor het registreren!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>Je account is nu geactiveerd!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "Controleer tot slot je inbox (en je map met ongewenste e-mail!) voor het bevestigingsbericht."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Registratie is gelukt, je kunt nu je account gebruiken."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Accountinstellingen"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Volgen"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s Profielpagina"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Meer torrents van %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Categorie"
   },
   {
@@ -156,10 +148,6 @@
     "translation": "Error 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Nagiveren inschakelen"
-  },
-  {
     "id": "upload",
     "translation": "Uploaden"
   },
@@ -170,10 +158,6 @@
   {
     "id": "fap",
     "translation": "Fap"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Geavanceerd Zoeken"
   },
   {
     "id": "nothing_here",
@@ -198,14 +182,6 @@
   {
     "id": "member",
     "translation": "Lid"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Aanmelden"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Registreren"
   },
   {
     "id": "no_results_found",
@@ -318,10 +294,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Het is de favoriete programmeertaal van de bedenker."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Magnet uploaden"
   },
   {
     "id": "torrent_file",
@@ -450,22 +422,6 @@
   {
     "id": "trusted",
     "translation": "Vertrouwd"
-  },
-  {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Downloads"
-  },
-  {
-    "id": "descending",
-    "translation": "Aflopend"
-  },
-  {
-    "id": "ascending",
-    "translation": "Oplopend"
   },
   {
     "id": "search",

--- a/translations/pt-br.all.json
+++ b/translations/pt-br.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "link"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Verifique o seu endereço de e-mail do Nyaapantsu."
   },
@@ -20,127 +16,123 @@
     "translation": "Clique no link abaixo para redefinir a sua senha."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Criar conta"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Por favor, cadastre-se <small>(é de graça e sempre será)</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Nome de usuário"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Endereço de e-mail ou nome de usuário"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Endereço de e-mail"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Senha"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Confirmar senha"
   },
   {
-    "id":"i_agree",
-    "translation": "Eu aceito"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Ao clicar em <strong class=\"label label-primary\">Registrar</strong>, você concorda com os <a id=\"modal_active\" href=\"#\">Termos e Condições</a> estabelecidos pelo site, incluindo o nosso uso de cookies."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Iniciar sessão"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registrar"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Termos e Condições"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Algumas coisas."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Lembre-se de mim"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Esqueceu sua senha?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Por favor, inicie a sessão"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Iniciar sessão"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Cadastro bem-sucedido"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Obrigado por se cadastrar!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>A sua conta foi ativada!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "No momento, a verificação por e-mail está desabilitada, então você já pode usar a sua conta. Futuramente, verifique a sua caixa de entrada (e pasta de spam!) pelo e-mail de verificação."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Cadastro bem-sucedido, você já pode usar a sua conta."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Configurações de conta"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Seguir"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Deixar de seguir"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Você seguiu %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Você deixou de seguir %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "Perfil de %s"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Ver mais torrents de %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Categoria"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "Erro 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Alternar navegação"
-  },
-  {
     "id": "upload",
     "translation": "Enviar"
   },
@@ -186,10 +174,6 @@
   {
     "id": "fun",    
     "translation": "Fun"
-  },  
-  {
-    "id": "advanced_search",
-    "translation": "Pesquisa avançada"
   },
   {
     "id": "nothing_here",
@@ -214,14 +198,6 @@
   {
     "id": "member",
     "translation": "Membro"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Iniciar sessão"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Cadastrar-se"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "É a linguagem de programação favorita do autor."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Enviar link magnético"
   },
   {
     "id": "torrent_file",
@@ -516,22 +488,6 @@
     "translation": "Confiável"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Downloads"
-  },
-  {
-    "id": "descending",
-    "translation": "Decrescente"
-  },
-  {
-    "id": "ascending",
-    "translation": "Crescente"
-  },
-  {
     "id": "search",
     "translation": "Buscar"
   },
@@ -644,10 +600,6 @@
     "translation": "Status do torrent"
   },
   {
-    "id": "torrent_status_hidden",
-    "translation": "Oculto"
-  },
-  {
     "id": "torrent_status_normal",
     "translation": "Normal"
   },
@@ -700,16 +652,8 @@
     "translation": "Nenhum arquivo encontrado? Isto sequer faz sentido!"
   },
   {
-    "id": "filename",
-    "translation": "Nome do arquivo"
-  },
-  {
     "id": "uploaded_by",
     "translation": "Enviado por"
-  },
-  {
-    "id": "download_btn",
-    "translation": "Download!"
   },
   {
     "id": "report_btn",

--- a/translations/pt-pt.all.json
+++ b/translations/pt-pt.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "link"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Verifique o seu endereço de e-mail do Nyaapantsu."
   },
@@ -20,127 +16,123 @@
     "translation": "Clique no link abaixo para redefinir a sua senha."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Criar conta"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Por favor, registe-se <small>(é de graça e sempre será)</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Nome de usuário"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Endereço de e-mail ou nome de usuário"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Endereço de e-mail"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Senha"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Confirmar senha"
   },
   {
-    "id":"i_agree",
-    "translation": "Eu aceito"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Ao clicar em <strong class=\"label label-primary\">Registar</strong>, estará a concordar com os <a id=\"modal_active\" href=\"#\">Termos e Condições</a> estabelecidos pelo site, incluindo o nosso uso de cookies."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Iniciar sessão"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registar"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Termos e Condições"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Algumas coisas."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Lembre-se de mim"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Esqueceu-se da sua senha?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Por favor, inicie a sessão"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Iniciar sessão"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Registo bem-sucedido"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Obrigado por se registar!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>A sua conta foi ativada!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "Por fim, procure o e-mail de verificação na sua caixa de entrada (e pasta de spam!)."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Registo bem-sucedido. Já pode usar a sua conta."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Configurações de conta"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Seguir"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Deixar de seguir"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Seguiu %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Deixou de seguir %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "Perfil de %s"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Ver mais torrents de %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Categoria"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "Erro 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Alternar navegação"
-  },
-  {
     "id": "upload",
     "translation": "Enviar"
   },
@@ -182,10 +170,6 @@
   {
     "id": "fap",
     "translation": "Fap"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Pesquisa avançada"
   },
   {
     "id": "nothing_here",
@@ -210,14 +194,6 @@
   {
     "id": "member",
     "translation": "Membro"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Iniciar sessão"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Registar-se"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "É a linguagem de programação favorita do autor."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Enviar link magnético"
   },
   {
     "id": "torrent_file",
@@ -474,22 +446,6 @@
   {
     "id": "trusted",
     "translation": "Confiável"
-  },
-  {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Downloads"
-  },
-  {
-    "id": "descending",
-    "translation": "Decrescente"
-  },
-  {
-    "id": "ascending",
-    "translation": "Crescente"
   },
   {
     "id": "search",

--- a/translations/ro-ro.all.json
+++ b/translations/ro-ro.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "link"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Verifică adresa ta de email pentru Nyaapantsu."
   },
@@ -20,127 +16,123 @@
     "translation": "Vă rog să daţi click pe link-ul de dedesupt pentru a reseta parola dumneavoastră."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Crează un cont nou"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Vă rog înregistraţi-vă <small>E gratuit şi va fi întotdeauna.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Nume de utilizator"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Adresă de email sau Nume de utilizator"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Adresă de email"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Parola"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Confirmă parola"
   },
   {
-    "id":"i_agree",
-    "translation": "Sunt de acord"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Dacă daţi click <strong class=\"label label-primary\">Register</strong>, sunteţi de acord cu <a id=\"modal_active\" href=\"#\">Termenii şi Condiţiile</a> acestui site, incluzând folosirea noastra de Cookie-uri."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Autentificare"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Înregistrare"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Termeni şi Condiţii"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Some Shit."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Ţine-mă minte"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Ai uitat parola?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Vă rog să vă autentificați"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Autentificare"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Înregistrare reuşită"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Mulţumim pentru înregistrare!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>Contul tău este acum activat!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "Verificarea prin email nu funcţionează în acest moment, aşa că puteţi folosi contul imediat. În viitor, vă rog să verificaţi inbox-ul(şi folderul de spam!) pentru emailul de verificare."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Înregistrarea a fost reuşită, acum îţi poţi folosi contul."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Setări cont"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrente"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Urmăreşte"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Nu mai urmări"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Ai urmărit %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Nu mai urmăreşti %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "Pagina de profil a lui %s"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Vezi mai multe torrente de la %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Categorie"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "Eroare 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Alternează navigaţia"
-  },
-  {
     "id": "upload",
     "translation": "Upload"
   },
@@ -186,10 +174,6 @@
   {
     "id": "fun",
     "translation": "Distracţie"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Căutare avansată"
   },
   {
     "id": "nothing_here",
@@ -214,14 +198,6 @@
   {
     "id": "member",
     "translation": "Membru"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Autentificare"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Înregistrare"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Este limbajul de programare favorit al autorului."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Upload magnet"
   },
   {
     "id": "torrent_file",
@@ -512,22 +484,6 @@
     "translation": "De încredere"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Downloads"
-  },
-  {
-    "id": "descending",
-    "translation": "Descrescător"
-  },
-  {
-    "id": "ascending",
-    "translation": "Crescător"
-  },
-  {
     "id": "search",
     "translation": "Caută"
   },
@@ -636,10 +592,6 @@
     "translation": "Status torrent"
   },
   {
-    "id": "torrent_status_hidden",
-    "translation": "Ascuns"
-  },
-  {
     "id": "torrent_status_normal",
     "translation": "Normal"
   },
@@ -684,16 +636,8 @@
     "translation": "Fişiere"
   },
   {
-    "id": "filename",
-    "translation": "Nume fişier"
-  },
-  {
     "id": "uploaded_by",
     "translation": "Uploadat de"
-  },
-  {
-    "id": "download_btn",
-    "translation": "Download!"
   },
   {
     "id": "report_btn",
@@ -742,21 +686,21 @@
   {
     "id": "please_include_our_tracker",
     "translation": "Te rog include udp://tracker.doko.moe:6969 la trackerele tale."
-   },
-   {
+  },
+  {
     "id": "unknown",
     "translation": "Necunoscut"
-   },
-   {
+  },
+  {
     "id": "last_scraped",
     "translation": "Ultimul scrape: "
-   },
-   {
+  },
+  {
     "id": "server_status_link",
     "translation": "Statusul servărului poate fi găsit aici"
-   },
-   {
+  },
+  {
     "id": "no_database_dumps_available",
     "translation": "Dumpurile bazei de date nu sunt disponibile în acest moment."
-    }
+  }
 ]

--- a/translations/ru-ru.all.json
+++ b/translations/ru-ru.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "ссылка"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Подтвердите свой Email адрес для Nyaapantsu."
   },
@@ -46,10 +42,6 @@
   {
     "id": "confirm_password",
     "translation": "Подтвердите пароль"
-  },
-  {
-    "id": "i_agree",
-    "translation": "Я согласен"
   },
   {
     "id": "terms_conditions_confirm",
@@ -168,10 +160,6 @@
     "translation": "Ошибка 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Включить навигацию"
-  },
-  {
     "id": "upload",
     "translation": "Загрузить"
   },
@@ -186,10 +174,6 @@
   {
     "id": "fap",
     "translation": "Fap"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Расширенный поиск"
   },
   {
     "id": "nothing_here",
@@ -214,14 +198,6 @@
   {
     "id": "member",
     "translation": "Пользователь"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Вход"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Регистрация"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Это любимый язык программирования автора."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Загрузить магнит"
   },
   {
     "id": "torrent_file",
@@ -516,22 +488,6 @@
     "translation": "Надёжные"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Загрузки"
-  },
-  {
-    "id": "descending",
-    "translation": "Нисходящий"
-  },
-  {
-    "id": "ascending",
-    "translation": "Восходящий"
-  },
-  {
     "id": "search",
     "translation": "Поиск"
   },
@@ -640,10 +596,6 @@
     "translation": "Статус торрента"
   },
   {
-    "id": "torrent_status_hidden",
-    "translation": "Скрытый"
-  },
-  {
     "id": "torrent_status_normal",
     "translation": "Обычный"
   },
@@ -688,16 +640,8 @@
     "translation": "Файлы"
   },
   {
-    "id": "filename",
-    "translation": "Имя файла"
-  },
-  {
     "id": "uploaded_by",
     "translation": "Загрузил"
-  },
-  {
-    "id": "download_btn",
-    "translation": "Загрузить!"
   },
   {
     "id": "report_btn",

--- a/translations/sv-se.all.json
+++ b/translations/sv-se.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "länk"
-  },
-  {
     "id": "verify_email_title",
     "translation": "Bekräfta din mailadress för Nyaapantsu."
   },
@@ -20,127 +16,123 @@
     "translation": "Var vänlig klicka länken nedan för att återställa ditt lösenord."
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "Skapa ett nytt konto"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "Registrera dig <small>Det är gratis och kommer alltid att vara det.</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "Användarnamn"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "Mailadress eller användarnamn"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "Mailadress"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "Lösenord"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "Bekräfta lösenord"
   },
   {
-    "id":"i_agree",
-    "translation": "Jag accepterar"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "Genom att klicka på <strong class=\"label label-primary\">Registrera</strong> accepterar du denna webbsidas <a id=\"modal_active\" href=\"#\">användarvillkor</a>, samt vår användning av kakor (cookies)."
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "Logga in"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "Registrera"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "Användarvillkor"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Nån skit."
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "Kom ihåg mig"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "Glömt lösenordet?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "Logga in"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "Logga in"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "Registrering lyckades"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "Tack för att du registrerat dig!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>Ditt konto är nu aktiverat!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "För att slutföra, var vänlig se verifikationsmailet i din inkorg (eller din skräppost)."
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "Registreringen var lyckad. Du kan nu använda ditt konto."
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "Kontoinställningar"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "Torrents"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "Följ"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "Sluta följ"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "Du följer nu %s!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "Du har slutat följa %s!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s profil"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "Se flera torrents från %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "Kategori"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "Error 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Öppna/stäng navigering"
-  },
-  {
     "id": "upload",
     "translation": "Ladda upp"
   },
@@ -182,10 +170,6 @@
   {
     "id": "fap",
     "translation": "Onanera"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "Avancerad sökning"
   },
   {
     "id": "nothing_here",
@@ -210,14 +194,6 @@
   {
     "id": "member",
     "translation": "Medlem"
-  },
-  {
-    "id": "sign_in",
-    "translation": "Logga in"
-  },
-  {
-    "id": "sign_up",
-    "translation": "Registrera"
   },
   {
     "id": "no_results_found",
@@ -330,10 +306,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "Det är skaparens favoritspråk."
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "Ladda upp magnet"
   },
   {
     "id": "torrent_file",
@@ -462,22 +434,6 @@
   {
     "id": "trusted",
     "translation": "Endast pålitliga medlemmar"
-  },
-  {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "Nedladdningar"
-  },
-  {
-    "id": "descending",
-    "translation": "Fallande"
-  },
-  {
-    "id": "ascending",
-    "translation": "Stigande"
   },
   {
     "id": "search",

--- a/translations/th-th.all.json
+++ b/translations/th-th.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "ลิงค์"
-  },
-  {
     "id": "verify_email_title",
     "translation": "ยืนยันอีเมลสำหรับ NyaaPantsu"
   },
@@ -20,127 +16,123 @@
     "translation": "กรุณากดลิงค์ข้างล่างเพื่อรีเซ็ทรหัสผ่าน"
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "สร้างแอคเคาท์ใหม่"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "กรุณาลงทะเบียน <small>ฟรีตลอดชาติ</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "ชื่อผู้ใช้"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "อีเมลหรือชื่อผู้ใช้"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "อีเมล"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "รหัสผ่าน"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "ยืนยันรหัสผ่าน"
   },
   {
-    "id":"i_agree",
-    "translation": "ฉันยอมรับ"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "หากคุณกด <strong class=\"label label-primary\">ลงทะเบียน</strong> คุณต้องยอมรับ<a id=\"modal_active\" href=\"#\">เงื่อนไขและข้อตกลง</a>ของเว็บนี้ รวมถึงการใช้งาน Cookie ของทางเรา"
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "เข้าสู่ระบบ"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "ลงทะเบียน"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "เงื่อนไขและข้อตกลง"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "Nope.avi"
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "จดจำฉันไว้"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "ลืมรหัสผ่าน?"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "กรุณาเข้าสู่ระบบ"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "เข้าสู่ระบบ"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "ลงทะเบียนเรียบร้อย"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "ขอบคุณที่ลงทะเบียน!"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>แอคเคาท์ของคุณถูกเปิดใช้งานแล้ว!"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "ขณะนี้การยืนยันอีเมลถูกปิดใช้งาน ฉะนั้นคุณสามารถใช้งานแอคเคาท์ได้ทันที แต่ในอนาคตกรุณาเช็คอีเมล (และในโฟลเดอร์เมลขยะ!) สำหรับเมลยืนยันตัวตน"
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "การลงทะเบียนเสร็จเรียบร้อย คุณสามารถใช้งานแอคเคาท์ของคุณได้ในตอนนี้"
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "ตั้งค่าแอคเคาท์"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "ทอร์เรนท์"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "ติดตาม"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "ไม่ติดตาม"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "คุณติดตาม %s แล้ว!"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "คุณไม่ได้ติดตาม %s แล้ว!"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "หน้าโปรไฟล์ของ %s"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "ดูทอร์เรนท์อื่นๆ ของ %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "หมวดหมู่"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "ข้อผิดพลาด 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "Toggle navigation"
-  },
-  {
     "id": "upload",
     "translation": "อัพโหลด"
   },
@@ -186,10 +174,6 @@
   {
     "id": "fun",
     "translation": "ไม่กาม"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "การค้นหาระดับสูง"
   },
   {
     "id": "nothing_here",
@@ -214,14 +198,6 @@
   {
     "id": "member",
     "translation": "สมาชิก"
-  },
-  {
-    "id": "sign_in",
-    "translation": "เข้าสู่ระบบ"
-  },
-  {
-    "id": "sign_up",
-    "translation": "ลงทะเบียน"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "เพราะเป็นภาษาที่ผู้พัฒนาชอบ"
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "อัพโหลด Magnet"
   },
   {
     "id": "torrent_file",
@@ -516,22 +488,6 @@
     "translation": "Trusted"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "ดาวน์โหลด"
-  },
-  {
-    "id": "descending",
-    "translation": "เรียงจากบนลงล่าง"
-  },
-  {
-    "id": "ascending",
-    "translation": "เรียงจากล่างขึ้นบน"
-  },
-  {
     "id": "search",
     "translation": "ค้นหา"
   },
@@ -596,7 +552,7 @@
     "translation": "Moderator"
   },
   {
-    "id":" api_token",
+    "id": " api_token",
     "translation": "API Token"
   },
   {
@@ -642,10 +598,6 @@
   {
     "id": "torrent_status",
     "translation": "สถานะทอร์เรนท์"
-  },
-  {
-    "id": "torrent_status_hidden",
-    "translation": "ถูกซ่อน"
   },
   {
     "id": "torrent_status_normal",
@@ -700,16 +652,8 @@
     "translation": "ไม่เจอไฟล์? บ้าน่า!"
   },
   {
-    "id": "filename",
-    "translation": "ชื่อไฟล์"
-  },
-  {
     "id": "uploaded_by",
     "translation": "อัพโหลดโดย"
-  },
-  {
-    "id": "download_btn",
-    "translation": "ดาวน์โหลด!"
   },
   {
     "id": "report_btn",

--- a/translations/zh-cn.all.json
+++ b/translations/zh-cn.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "链接"
-  },
-  {
     "id": "verify_email_title",
     "translation": "请验证您的电子邮箱喵~"
   },
@@ -20,127 +16,123 @@
     "translation": "请点击下面的链接重置密码喵~"
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "注册账号"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "请注册 <small>我们永久免费</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "用户名"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "电子邮箱或用户名"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "电子邮箱"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "密码"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "确认密码"
   },
   {
-    "id":"i_agree",
-    "translation": "我同意"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "按下 <strong class=\"label label-primary\">注册账号</strong> 即表示您同意本网站的 <a id=\"modal_active\" href=\"#\">条款与条件</a> 以及浏览器Cookie喵~"
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "登录"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "注册"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "条款与条件"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "一些扯淡"
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "记住我"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "忘记密码？"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "请登录"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "登录"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "注册完成"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "恭喜您注册成功喵！"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>您的账号已可以使用了喵！"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "请检查您的电子邮箱（或垃圾邮件）找到账号确认邮件喵~"
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "注册成功喵，账号已经可以使用了！"
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "账号设置"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "种子列表"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "关注"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "取消关注"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "您已经关注了 %s 喵！"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "您已经取消了对 %s 的关注喵！"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s 用户资料"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "更多种子来自 %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "分类"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "纳尼？ 是 404 喵！"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "切换索引"
-  },
-  {
     "id": "upload",
     "translation": "上传"
   },
@@ -186,10 +174,6 @@
   {
     "id": "fun",
     "translation": "贤者模式"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "高级搜索"
   },
   {
     "id": "nothing_here",
@@ -214,14 +198,6 @@
   {
     "id": "member",
     "translation": "会员"
-  },
-  {
-    "id": "sign_in",
-    "translation": "登录"
-  },
-  {
-    "id": "sign_up",
-    "translation": "注册"
   },
   {
     "id": "no_results_found",
@@ -342,10 +318,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "这是作者的信仰！"
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "上传磁力链接"
   },
   {
     "id": "torrent_file",
@@ -512,22 +484,6 @@
     "translation": "受信任的资源"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "下载量"
-  },
-  {
-    "id": "descending",
-    "translation": "降序"
-  },
-  {
-    "id": "ascending",
-    "translation": "升序"
-  },
-  {
     "id": "search",
     "translation": "搜索"
   },
@@ -636,10 +592,6 @@
     "translation": "种子状态"
   },
   {
-    "id": "torrent_status_hidden",
-    "translation": "隐藏"
-  },
-  {
     "id": "torrent_status_normal",
     "translation": "普通"
   },
@@ -684,16 +636,8 @@
     "translation": "文件"
   },
   {
-    "id": "filename",
-    "translation": "文件名"
-  },
-  {
     "id": "uploaded_by",
     "translation": "上传者"
-  },
-  {
-    "id": "download_btn",
-    "translation": "下载！"
   },
   {
     "id": "report_btn",

--- a/translations/zh-tw.all.json
+++ b/translations/zh-tw.all.json
@@ -1,9 +1,5 @@
 [
   {
-    "id": "link",
-    "translation": "連結"
-  },
-  {
     "id": "verify_email_title",
     "translation": "喵 請驗證您的電子郵件"
   },
@@ -20,127 +16,123 @@
     "translation": "請按下面連結重設密碼"
   },
   {
-    "id":"register_title",
+    "id": "register_title",
     "translation": "建立新帳號"
   },
   {
-    "id":"signup_box_title",
+    "id": "signup_box_title",
     "translation": "請註冊 <small>永遠免費</small>"
   },
   {
-    "id":"username",
+    "id": "username",
     "translation": "使用者名稱"
   },
   {
-    "id":"email_address_or_username",
+    "id": "email_address_or_username",
     "translation": "電子郵件或使用者名稱"
   },
   {
-    "id":"email_address",
+    "id": "email_address",
     "translation": "電子郵件"
   },
   {
-    "id":"password",
+    "id": "password",
     "translation": "密碼"
   },
   {
-    "id":"confirm_password",
+    "id": "confirm_password",
     "translation": "密碼確認"
   },
   {
-    "id":"i_agree",
-    "translation": "我同意"
-  },
-  {
-    "id":"terms_conditions_confirm",
+    "id": "terms_conditions_confirm",
     "translation": "按下 <strong class=\"label label-primary\">註冊</strong> 表示您同意此網站之 <a id=\"modal_active\" href=\"#\">條款和條件</a> 以及瀏覽器 Cookie 之使用"
   },
   {
-    "id":"signin",
+    "id": "signin",
     "translation": "登入"
   },
   {
-    "id":"register",
+    "id": "register",
     "translation": "註冊"
   },
   {
-    "id":"terms_conditions",
+    "id": "terms_conditions",
     "translation": "條款和條件"
   },
   {
-    "id":"terms_conditions_full",
+    "id": "terms_conditions_full",
     "translation": "一些扯淡"
   },
   {
-    "id":"remember_me",
+    "id": "remember_me",
     "translation": "請記住我"
   },
   {
-    "id":"forgot_password",
+    "id": "forgot_password",
     "translation": "忘記密碼嗎？"
   },
   {
-    "id":"sign_in_box_title",
+    "id": "sign_in_box_title",
     "translation": "請登入"
   },
   {
-    "id":"sign_in_title",
+    "id": "sign_in_title",
     "translation": "登入"
   },
   {
-    "id":"register_success_title",
+    "id": "register_success_title",
     "translation": "註冊成功"
   },
   {
-    "id":"sign_up_success",
+    "id": "sign_up_success",
     "translation": "感謝您的註冊！"
   },
   {
-    "id":"verify_success",
+    "id": "verify_success",
     "translation": "<i style=\"color:limegreen\" class=\"glyphicon glyphicon-ok-circle\"></i>您的帳號已啟用！"
   },
   {
-    "id":"signup_verification_email",
+    "id": "signup_verification_email",
     "translation": "最後請檢查您的電子信箱 （與垃圾郵件）直到找到帳號確認郵件"
   },
   {
-    "id":"signup_verification_noemail",
+    "id": "signup_verification_noemail",
     "translation": "註冊成功，帳號已可供使用"
   },
   {
-    "id":"settings",
+    "id": "settings",
     "translation": "帳號設定"
   },
   {
-    "id":"torrents",
+    "id": "torrents",
     "translation": "種子種子"
   },
   {
-    "id":"follow",
+    "id": "follow",
     "translation": "跟隨"
   },
   {
-    "id":"unfollow",
+    "id": "unfollow",
     "translation": "取消跟隨"
   },
   {
-    "id":"user_followed_msg",
+    "id": "user_followed_msg",
     "translation": "您已經跟隨 %s！"
   },
   {
-    "id":"user_unfollowed_msg",
+    "id": "user_unfollowed_msg",
     "translation": "您已經取消跟隨 %s！"
   },
   {
-    "id":"profile_page",
+    "id": "profile_page",
     "translation": "%s 使用者資料"
   },
   {
-    "id":"see_more_torrents_from",
+    "id": "see_more_torrents_from",
     "translation": "更多種子來自 %s "
   },
   {
-    "id":"category",
+    "id": "category",
     "translation": "分類"
   },
   {
@@ -168,10 +160,6 @@
     "translation": "糟糕！ 是 404"
   },
   {
-    "id": "toggle_navigation",
-    "translation": "切換導覽列"
-  },
-  {
     "id": "upload",
     "translation": "上傳"
   },
@@ -182,10 +170,6 @@
   {
     "id": "fap",
     "translation": "尻尻"
-  },
-  {
-    "id": "advanced_search",
-    "translation": "進階搜尋"
   },
   {
     "id": "nothing_here",
@@ -210,14 +194,6 @@
   {
     "id": "member",
     "translation": "會員"
-  },
-  {
-    "id": "sign_in",
-    "translation": "登入"
-  },
-  {
-    "id": "sign_up",
-    "translation": "註冊"
   },
   {
     "id": "no_results_found",
@@ -334,10 +310,6 @@
   {
     "id": "authors_favorite_language",
     "translation": "作者尬意"
-  },
-  {
-    "id": "upload_magnet",
-    "translation": "上傳磁力連結"
   },
   {
     "id": "torrent_file",
@@ -472,22 +444,6 @@
     "translation": "受信任"
   },
   {
-    "id": "id",
-    "translation": "ID"
-  },
-  {
-    "id": "downloads",
-    "translation": "下載數"
-  },
-  {
-    "id": "descending",
-    "translation": "降序"
-  },
-  {
-    "id": "ascending",
-    "translation": "升序"
-  },
-  {
     "id": "search",
     "translation": "搜尋"
   },
@@ -548,7 +504,7 @@
     "translation": "管理員"
   },
   {
-    "id":" api_token",
+    "id": " api_token",
     "translation": "API Token"
   },
   {
@@ -594,10 +550,6 @@
   {
     "id": "torrent_status",
     "translation": "種子狀態"
-  },
-  {
-    "id": "torrent_status_hidden",
-    "translation": "隱藏"
   },
   {
     "id": "torrent_status_normal",


### PR DESCRIPTION
Obsolete/duplicated ids:
"link"
"i_agree"
"toggle_navigation"
"advanced_search"
"sign_in"
"sign_up"
"upload_magnet"
"id"
"downloads"
"descending"
"ascending"
"torrent_status_hidden"
"filename"
"download_btn"