### PR TITLE
Update .gitattibutes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-*.dia binary 
+*.dia		binary 
+*.sh		text eol=lf


### PR DESCRIPTION
Prevent CRLF line endings in shell scripts when checking out on windows.