### PR TITLE
Move scrape results to separate table

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -181,12 +181,7 @@ models:
   files_table_name: files
 # NotificationTableName : Name of notifications table in DB
   notifications_table_name: notifications
-# ActivitiesTableName : Name of activitis log table in DB
+# ActivitiesTableName : Name of activities log table in DB
   activities_table_name: activities
-# for sukebei:
-#	LastOldTorrentID    = 2303945
-#	TorrentsTableName   = "sukebei_torrents"
-#	ReportsTableName    = "sukebei_torrent_reports"
-#	CommentsTableName   = "sukebei_comments"
-#	UploadsOldTableName = "sukebei_user_uploads_old"
-#	FilesTableName      = "sukebei_files"
+# NotificationTableName : Name of scrape table in DB
+  scrape_table_name: scrape

--- a/config/sukebei.yml
+++ b/config/sukebei.yml
@@ -18,3 +18,5 @@ models:
   files_table_name: sukebei_files
 # NotificationTableName : Name of notifications table in DB
   notifications_table_name: sukebei_notifications
+# NotificationTableName : Name of scrape table in DB
+  scrape_table_name: sukebei_scrape

--- a/config/types.go
+++ b/config/types.go
@@ -181,6 +181,7 @@ type ModelsConfig struct {
 	FilesTableName         string `yaml:"files_table_name,omitempty"`
 	NotificationsTableName string `yaml:"notifications_table_name,omitempty"`
 	ActivityTableName      string `yaml:"activities_table_name,omitempty"`
+	ScrapeTableName        string `yaml:"scrape_table_name,omitempty"`
 }
 
 // SearchConfig : Config struct for search

--- a/database/postgres/statements.go
+++ b/database/postgres/statements.go
@@ -29,7 +29,7 @@ const queryDeleteUserFollowing = "DeleteUserFollowing"
 const torrentSelectColumnsFull = `torrent_id, torrent_name, torrent_hash, category, sub_category, status, date, uploader, downloads, stardom, description, website_link, deleted_at, seeders, leechers, completed, last_scrape`
 
 func scanTorrentColumnsFull(rows *sql.Rows, t *model.Torrent) {
-	rows.Scan(&t.ID, &t.Name, &t.Hash, &t.Category, &t.SubCategory, &t.Status, &t.Date, &t.UploaderID, &t.Downloads, &t.Stardom, &t.Description, &t.WebsiteLink, &t.DeletedAt, &t.Seeders, &t.Leechers, &t.Completed, &t.LastScrape)
+	rows.Scan(&t.ID, &t.Name, &t.Hash, &t.Category, &t.SubCategory, &t.Status, &t.Date, &t.UploaderID, &t.Downloads, &t.Stardom, &t.Description, &t.WebsiteLink, &t.DeletedAt, &t.Scrape.Seeders, &t.Scrape.Leechers, &t.Scrape.Completed, &t.Scrape.LastScrape)
 }
 
 const commentSelectColumnsFull = `comment_id, torrent_id, user_id, content, created_at, updated_at, deleted_at`

--- a/db/gorm.go
+++ b/db/gorm.go
@@ -86,7 +86,7 @@ func GormInit(conf *config.Config, logger Logger) (*gorm.DB, error) {
 	if db.Error != nil {
 		return db, db.Error
 	}
-	db.AutoMigrate(&model.Torrent{}, &model.TorrentReport{})
+	db.AutoMigrate(&model.Torrent{}, &model.TorrentReport{}, &model.Scrape{})
 	if db.Error != nil {
 		return db, db.Error
 	}

--- a/model/torrent.go
+++ b/model/torrent.go
@@ -78,7 +78,6 @@ type Scrape struct{
 	Leechers   uint32    `gorm:"column:leechers"`
 	Completed  uint32    `gorm:"column:completed"`
 	LastScrape time.Time `gorm:"column:last_scrape"`
-	FileList   []File    `gorm:"ForeignKey:torrent_id"`
 }
 
 // Size : Returns the total size of memory recursively allocated for this struct
@@ -282,7 +281,7 @@ func (t *TorrentJSON) ToTorrent() Torrent {
 		// Comments: TODO
 		// LastScrape not stored in ES, counts won't show without a value however
 		Scrape:      &Scrape{Seeders: t.Seeders, Leechers: t.Leechers, Completed: t.Completed, LastScrape: time.Now()},
-		Language:   t.Language,
+		Language:    t.Language,
 		//FileList: TODO
 	}
 	return torrent

--- a/model/torrent.go
+++ b/model/torrent.go
@@ -345,6 +345,10 @@ func (t *Torrent) ToJSON() TorrentJSON {
 	} else if t.ID > config.Conf.Models.LastOldTorrentID && len(config.Conf.Torrents.StorageLink) > 0 {
 		torrentlink = fmt.Sprintf(config.Conf.Torrents.StorageLink, t.Hash)
 	}
+	scrape := Scrape{}
+	if t.Scrape != nil {
+		scrape = *t.Scrape
+	}
 	res := TorrentJSON{
 		ID:           t.ID,
 		Name:         t.Name,
@@ -364,10 +368,10 @@ func (t *Torrent) ToJSON() TorrentJSON {
 		Language:     t.Language,
 		Magnet:       template.URL(magnet),
 		TorrentLink:  util.Safe(torrentlink),
-		Leechers:     t.Scrape.Leechers,
-		Seeders:      t.Scrape.Seeders,
-		Completed:    t.Scrape.Completed,
-		LastScrape:   t.Scrape.LastScrape,
+		Leechers:     scrape.Leechers,
+		Seeders:      scrape.Seeders,
+		Completed:    scrape.Completed,
+		LastScrape:   scrape.LastScrape,
 		FileList:     fileListJSON,
 	}
 

--- a/service/scraper/scraper.go
+++ b/service/scraper/scraper.go
@@ -1,6 +1,7 @@
 package scraperService
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"time"
@@ -188,7 +189,26 @@ func (sc *Scraper) Scrape(packets uint) {
 	now := time.Now().Add(0 - sc.interval)
 	// only scrape torretns uploaded within 90 days
 	oldest := now.Add(0 - (time.Hour * 24 * 90))
-	rows, err := db.ORM.Raw("SELECT torrent_id, torrent_hash FROM "+config.Conf.Models.TorrentsTableName+" WHERE ( last_scrape IS NULL OR  last_scrape < ? ) AND date > ? ORDER BY torrent_id DESC LIMIT ?", now, oldest, packets*ScrapesPerPacket).Rows()
+
+	query := fmt.Sprintf(
+		"SELECT * FROM ("+
+
+		// previously scraped torrents that will be scraped again:
+		"SELECT %[1]s.torrent_id, torrent_hash FROM %[1]s, %[2]s WHERE "+
+		"date > ? AND "+
+		"%[1]s.torrent_id = %[2]s.torrent_id AND "+
+		"last_scrape < ?"+
+
+		// torrents that weren't scraped before:
+		" UNION "+
+		"SELECT torrent_id, torrent_hash FROM %[1]s WHERE "+
+		"date > ? AND "+
+		"torrent_id NOT IN (SELECT torrent_id FROM %[2]s)"+
+
+		") ORDER BY torrent_id DESC LIMIT ?", 
+		config.Conf.Models.TorrentsTableName, config.Conf.Models.ScrapeTableName)
+	rows, err := db.ORM.Raw(query, oldest, now, oldest, packets*ScrapesPerPacket).Rows()
+
 	if err == nil {
 		counter := 0
 		var scrape [ScrapesPerPacket]model.Torrent
@@ -212,7 +232,6 @@ func (sc *Scraper) Scrape(packets uint) {
 		}
 		log.Infof("scrape %d", counter)
 		rows.Close()
-
 	} else {
 		log.Warnf("failed to select torrents for scrape: %s", err)
 	}

--- a/service/scraper/transaction.go
+++ b/service/scraper/transaction.go
@@ -44,19 +44,20 @@ func (t *Transaction) handleScrapeReply(data []byte) {
 	data = data[8:]
 	now := time.Now()
 	for idx := range t.swarms {
-		t.swarms[idx].Seeders = binary.BigEndian.Uint32(data)
+		t.swarms[idx].Scrape = &model.Scrape{}
+		t.swarms[idx].Scrape.Seeders = binary.BigEndian.Uint32(data)
 		data = data[4:]
-		t.swarms[idx].Completed = binary.BigEndian.Uint32(data)
+		t.swarms[idx].Scrape.Completed = binary.BigEndian.Uint32(data)
 		data = data[4:]
-		t.swarms[idx].Leechers = binary.BigEndian.Uint32(data)
+		t.swarms[idx].Scrape.Leechers = binary.BigEndian.Uint32(data)
 		data = data[4:]
-		t.swarms[idx].LastScrape = now
+		t.swarms[idx].Scrape.LastScrape = now
 		idx++
 	}
 }
 
-var pgQuery = "UPDATE " + config.Conf.Models.TorrentsTableName + " SET seeders = $1 , leechers = $2 , completed = $3 , last_scrape = $4 WHERE torrent_id = $5"
-var sqliteQuery = "UPDATE " + config.Conf.Models.TorrentsTableName + " SET seeders = ? , leechers = ? , completed = ? , last_scrape = ? WHERE torrent_id = ?"
+var pgQuery = "UPDATE " + config.Conf.Models.ScrapeTableName + " SET seeders = $1 , leechers = $2 , completed = $3 , last_scrape = $4 WHERE torrent_id = $5"
+var sqliteQuery = "UPDATE " + config.Conf.Models.ScrapeTableName + " SET seeders = ? , leechers = ? , completed = ? , last_scrape = ? WHERE torrent_id = ?"
 
 // Sync syncs models with database
 func (t *Transaction) Sync() (err error) {
@@ -68,7 +69,7 @@ func (t *Transaction) Sync() (err error) {
 	err = e
 	if err == nil {
 		for idx := range t.swarms {
-			_, err = tx.Exec(q, t.swarms[idx].Seeders, t.swarms[idx].Leechers, t.swarms[idx].Completed, t.swarms[idx].LastScrape, t.swarms[idx].ID)
+			_, err = tx.Exec(q, t.swarms[idx].Scrape.Seeders, t.swarms[idx].Scrape.Leechers, t.swarms[idx].Scrape.Completed, t.swarms[idx].Scrape.LastScrape, t.swarms[idx].ID)
 		}
 		tx.Commit()
 	}

--- a/service/scraper/transaction.go
+++ b/service/scraper/transaction.go
@@ -56,8 +56,9 @@ func (t *Transaction) handleScrapeReply(data []byte) {
 	}
 }
 
-var pgQuery = "UPDATE " + config.Conf.Models.ScrapeTableName + " SET seeders = $1 , leechers = $2 , completed = $3 , last_scrape = $4 WHERE torrent_id = $5"
-var sqliteQuery = "UPDATE " + config.Conf.Models.ScrapeTableName + " SET seeders = ? , leechers = ? , completed = ? , last_scrape = ? WHERE torrent_id = ?"
+
+var pgQuery     = "REPLACE INTO " + config.Conf.Models.ScrapeTableName + " (torrent_id, seeders, leechers, completed, last_scrape) VALUES ($1, $2, $3, $4, $5)"
+var sqliteQuery = "REPLACE INTO " + config.Conf.Models.ScrapeTableName + " (torrent_id, seeders, leechers, completed, last_scrape) VALUES (?, ?, ?, ?, ?)"
 
 // Sync syncs models with database
 func (t *Transaction) Sync() (err error) {
@@ -69,7 +70,7 @@ func (t *Transaction) Sync() (err error) {
 	err = e
 	if err == nil {
 		for idx := range t.swarms {
-			_, err = tx.Exec(q, t.swarms[idx].Scrape.Seeders, t.swarms[idx].Scrape.Leechers, t.swarms[idx].Scrape.Completed, t.swarms[idx].Scrape.LastScrape, t.swarms[idx].ID)
+			_, err = tx.Exec(q, t.swarms[idx].ID, t.swarms[idx].Scrape.Seeders, t.swarms[idx].Scrape.Leechers, t.swarms[idx].Scrape.Completed, t.swarms[idx].Scrape.LastScrape)
 		}
 		tx.Commit()
 	}

--- a/service/torrent/torrent.go
+++ b/service/torrent/torrent.go
@@ -35,7 +35,7 @@ func GetTorrentByID(id string) (torrent model.Torrent, err error) {
 		return
 	}
 
-	tmp := db.ORM.Where("torrent_id = ?", id).Preload("Comments")
+	tmp := db.ORM.Where("torrent_id = ?", id).Preload("Scrape").Preload("Comments")
 	if idInt > int64(config.Conf.Models.LastOldTorrentID) {
 		tmp = tmp.Preload("FileList")
 	}
@@ -142,10 +142,6 @@ func getTorrentsOrderBy(parameters *serviceBase.WhereParams, orderBy string, lim
 	if conditions != "" {
 		dbQuery = dbQuery + " WHERE " + conditions
 	}
-	/* This makes all queries take roughly the same amount of time (lots)...
-	if strings.Contains(conditions, "torrent_name") && offset > 0 {
-		dbQuery = "WITH t AS (SELECT * FROM torrents WHERE " + conditions + ") SELECT * FROM t"
-	}*/
 
 	if orderBy == "" { // default OrderBy
 		orderBy = "torrent_id DESC"
@@ -154,7 +150,7 @@ func getTorrentsOrderBy(parameters *serviceBase.WhereParams, orderBy string, lim
 	if limit != 0 || offset != 0 { // if limits provided
 		dbQuery = dbQuery + " LIMIT " + strconv.Itoa(limit) + " OFFSET " + strconv.Itoa(offset)
 	}
-	dbQ := db.ORM
+	dbQ := db.ORM.Preload("Scrape")
 	if withUser {
 		dbQ = dbQ.Preload("Uploader")
 	}


### PR DESCRIPTION
-> #943

page display and scraper tested and works
anything related to ES is <b>untested</b>

schema:
```sql
CREATE TABLE scrape (
	torrent_id       INTEGER NOT NULL,
	seeders          INTEGER NOT NULL,
	leechers         INTEGER NOT NULL,
	completed        INTEGER NOT NULL,
	last_scrape      TIMESTAMP NOT NULL,
	PRIMARY KEY (torrent_id),
	FOREIGN KEY (torrent_id) REFERENCES torrents(torrent_id)
);

CREATE TABLE sukebei_scrape (
	torrent_id       INTEGER NOT NULL,
	seeders          INTEGER NOT NULL,
	leechers         INTEGER NOT NULL,
	completed        INTEGER NOT NULL,
	last_scrape      TIMESTAMP NOT NULL,
	PRIMARY KEY (torrent_id),
	FOREIGN KEY (torrent_id) REFERENCES sukebei_torrents(torrent_id)
);

CREATE INDEX scrape_torrent_id_idx ON scrape (torrent_id);
CREATE INDEX sukebei_scrape_torrent_id_idx ON sukebei_scrape (torrent_id);
```

migration: (unsupported on sqlite)
```sql
INSERT INTO scrape(torrent_id, seeders, leechers, completed, last_scrape) SELECT torrent_id, seeders, leechers, completed, last_scrape FROM torrents WHERE last_scrape IS NOT NULL;
ALTER TABLE torrents DROP COLUMN seeders;
ALTER TABLE torrents DROP COLUMN leechers;
ALTER TABLE torrents DROP COLUMN completed;

INSERT INTO sukebei_scrape(torrent_id, seeders, leechers, completed, last_scrape) SELECT torrent_id, seeders, leechers, completed, last_scrape FROM sukebei_torrents WHERE last_scrape IS NOT NULL;
ALTER TABLE sukebei_torrents DROP COLUMN seeders;
ALTER TABLE sukebei_torrents DROP COLUMN leechers;
ALTER TABLE sukebei_torrents DROP COLUMN completed;
```