### PR TITLE
Remove "flag" translation

### DIFF
--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -1232,10 +1232,6 @@
     "translation": "Select a Torrent Language"
   },
   {
-    "id": "flag",
-    "translation": "gb"
-  },
-  {
     "id": "language_en-us_name",
     "translation": "English"
   },

--- a/translations/ja-jp.all.json
+++ b/translations/ja-jp.all.json
@@ -1232,10 +1232,6 @@
     "translation": "-- Torrent の言語を選択 --"
   },
   {
-    "id": "flag",
-    "translation": "gb"
-  },
-  {
     "id": "language_en-us_name",
     "translation": "英語"
   },


### PR DESCRIPTION
This was supposed to provide a way to override the flag that would appear for the respective language, but it ended up unused.