### PR TITLE
API update completely functionnal for app usage

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -55,6 +55,8 @@ type UserJSON struct {
 	ID          uint   `json:"user_id"`
 	Username    string `json:"username"`
 	Status      int    `json:"status"`
+	APIToken    string `json:"token"`
+	MD5         string `json:"md5"`
 	CreatedAt   string `json:"created_at"`
 	LikingCount int    `json:"liking_count"`
 	LikedCount  int    `json:"liked_count"`
@@ -145,6 +147,8 @@ func (u *User) ToJSON() UserJSON {
 	json := UserJSON{
 		ID:          u.ID,
 		Username:    u.Username,
+		APIToken:    u.APIToken,
+		MD5:         u.MD5,
 		Status:      u.Status,
 		CreatedAt:   u.CreatedAt.Format(time.RFC3339),
 		LikingCount: len(u.Followers),

--- a/router/router.go
+++ b/router/router.go
@@ -96,6 +96,9 @@ func init() {
 	api.Handle("/view/{id}", wrapHandler(gzipAPIViewHandler)).Methods("GET")
 	api.HandleFunc("/view/{id}", APIViewHeadHandler).Methods("HEAD")
 	api.HandleFunc("/upload", APIUploadHandler).Methods("POST")
+	api.HandleFunc("/login", APILoginHandler).Methods("POST")
+	api.HandleFunc("/token/check", APICheckTokenHandler).Methods("GET")
+	api.HandleFunc("/token/refresh", APIRefreshTokenHandler).Methods("GET")
 	api.HandleFunc("/search", APISearchHandler)
 	api.HandleFunc("/search/{page}", APISearchHandler)
 	api.HandleFunc("/update", APIUpdateHandler).Methods("PUT")
@@ -145,7 +148,7 @@ func init() {
 	Router.NotFoundHandler = http.HandlerFunc(NotFoundHandler)
 
 	CSRFRouter = nosurf.New(Router)
-	CSRFRouter.ExemptPath("/api")
+	CSRFRouter.ExemptRegexp("/api(?:/.+)*")
 	CSRFRouter.ExemptPath("/mod")
 	CSRFRouter.ExemptPath("/upload")
 	CSRFRouter.ExemptPath("/user/login")

--- a/service/user/form/form_validator.go
+++ b/service/user/form/form_validator.go
@@ -56,8 +56,8 @@ type RegistrationForm struct {
 
 // LoginForm is used when a user logs in.
 type LoginForm struct {
-	Username string `form:"username" needed:"true"`
-	Password string `form:"password" needed:"true"`
+	Username string `form:"username" needed:"true" json:"username"`
+	Password string `form:"password" needed:"true" json:"password"`
 }
 
 // UserForm is used when updating a user.

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -768,6 +768,10 @@
     "translation": "New torrent: \"%s\" from %s"
   },
   {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
+  },
+  {
     "id": "preferences",
     "translation": "Preferences"
   },


### PR DESCRIPTION
The api has been tested and works as intended.
Now users do not have to go on the website to get back their token, they
just have to register.
Torrents show the right stats and username on api request when search is
done
User model when converted to JSON gives us the apitoken and md5 hash of
email (for gravatar)
Verification on upload is done by token and username instead of token
only
Errors are now given in json format in the api
Global api response handler for less code redundancy and same response
pattern
Moved user auth check in cookie_helper to user.go
Fixed bug with CSRF prevention in /api
Added translation strings