### PR TITLE
Transparency log for mods

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -181,6 +181,8 @@ models:
   files_table_name: files
 # NotificationTableName : Name of notifications table in DB
   notifications_table_name: notifications
+# ActivitiesTableName : Name of activitis log table in DB
+  activities_table_name: activities
 # for sukebei:
 #	LastOldTorrentID    = 2303945
 #	TorrentsTableName   = "sukebei_torrents"

--- a/config/types.go
+++ b/config/types.go
@@ -180,6 +180,7 @@ type ModelsConfig struct {
 	UploadsOldTableName    string `yaml:"uploads_old_table_name,omitempty"`
 	FilesTableName         string `yaml:"files_table_name,omitempty"`
 	NotificationsTableName string `yaml:"notifications_table_name,omitempty"`
+	ActivityTableName      string `yaml:"activities_table_name,omitempty"`
 }
 
 // SearchConfig : Config struct for search

--- a/db/gorm.go
+++ b/db/gorm.go
@@ -82,7 +82,7 @@ func GormInit(conf *config.Config, logger Logger) (*gorm.DB, error) {
 		db.SetLogger(logger)
 	}
 
-	db.AutoMigrate(&model.User{}, &model.UserFollows{}, &model.UserUploadsOld{}, &model.Notification{})
+	db.AutoMigrate(&model.User{}, &model.UserFollows{}, &model.UserUploadsOld{}, &model.Notification{}, &model.Activity{})
 	if db.Error != nil {
 		return db, db.Error
 	}

--- a/model/activity.go
+++ b/model/activity.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"strings"
+
+	"github.com/NyaaPantsu/nyaa/config"
+)
+
+// Activity model
+type Activity struct {
+	ID         uint
+	Content    string
+	Identifier string
+	Filter     string
+	UserID     uint
+	User       *User
+}
+
+// NewActivity : Create a new activity log
+func NewActivity(identifier string, filter string, c ...string) Activity {
+	return Activity{Identifier: identifier, Content: strings.Join(c, ","), Filter: filter}
+}
+
+// TableName : Return the name of activity table
+func (a *Activity) TableName() string {
+	return config.Conf.Models.ActivityTableName
+}

--- a/router/activity_handler.go
+++ b/router/activity_handler.go
@@ -1,0 +1,53 @@
+package router
+
+import (
+	"html"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/NyaaPantsu/nyaa/service/activity"
+	"github.com/NyaaPantsu/nyaa/service/user/permission"
+	"github.com/NyaaPantsu/nyaa/util/log"
+	msg "github.com/NyaaPantsu/nyaa/util/messages"
+
+	"github.com/gorilla/mux"
+)
+
+// ActivityListHandler : Show a list of activity
+func ActivityListHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	page := vars["page"]
+	pagenum := 1
+	offset := 100
+	userid := r.URL.Query().Get("userid")
+	filter := r.URL.Query().Get("filter")
+	defer r.Body.Close()
+	var err error
+	messages := msg.GetMessages(r)
+	currentUser := getUser(r)
+	if page != "" {
+		pagenum, err = strconv.Atoi(html.EscapeString(page))
+		if !log.CheckError(err) {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	var conditions []string
+	var values []interface{}
+	if userid != "" && userPermission.HasAdmin(currentUser) {
+		conditions = append(conditions, "user_id = ?")
+		values = append(values, userid)
+	}
+	if filter != "" {
+		conditions = append(conditions, "filter = ?")
+		values = append(values, filter)
+	}
+
+	activities, nbActivities := activity.GetAllActivities(offset, (pagenum-1)*offset, strings.Join(conditions, " AND "), values...)
+	common := newCommonVariables(r)
+	common.Navigation = navigation{nbActivities, offset, pagenum, "activity_list"}
+	htv := modelListVbs{common, activities, messages.GetAllErrors(), messages.GetAllInfos()}
+	err = activityList.ExecuteTemplate(w, "index.html", htv)
+	log.CheckError(err)
+}

--- a/router/api_handler.go
+++ b/router/api_handler.go
@@ -269,7 +269,7 @@ func APIUpdateHandler(w http.ResponseWriter, r *http.Request) {
 			messages.ImportFromError("errors", apiService.ErrRights)
 		}
 		update.UpdateTorrent(&torrent, user)
-		torrentService.UpdateTorrent(torrent)
+		torrentService.UpdateTorrent(&torrent)
 	}
 	apiResponseHandler(w, r)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -54,6 +54,7 @@ func init() {
 	Router.HandleFunc("/search/{page}", SearchHandler).Name("search_page")
 	Router.HandleFunc("/verify/email/{token}", UserVerifyEmailHandler).Name("user_verify").Methods("GET")
 	Router.HandleFunc("/faq", FaqHandler).Name("faq")
+	Router.HandleFunc("/activities", ActivityListHandler).Name("activity_list")
 	Router.HandleFunc("/feed", RSSHandler).Name("feed")
 	Router.HandleFunc("/feed/{page}", RSSHandler).Name("feed_page")
 

--- a/router/template.go
+++ b/router/template.go
@@ -14,6 +14,7 @@ const ModeratorDir = "admin"
 var homeTemplate,
 	searchTemplate,
 	faqTemplate,
+	activityList,
 	uploadTemplate,
 	viewTemplate,
 	viewRegisterTemplate,
@@ -71,6 +72,11 @@ func ReloadTemplates() {
 			templ: &faqTemplate,
 			name:  "FAQ",
 			file:  "FAQ.html",
+		},
+		{
+			templ: &activityList,
+			name:  "activityList",
+			file:  "activity_list.html",
 		},
 		{
 			templ: &viewTemplate,
@@ -132,7 +138,6 @@ func ReloadTemplates() {
 			name:  "change_settings",
 			file:  "public_settings.html",
 		},
-
 	}
 	for idx := range pubTempls {
 		pubTempls[idx].indexFile = filepath.Join(TemplateDir, "index.html")

--- a/router/template_functions.go
+++ b/router/template_functions.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/model"
+	"github.com/NyaaPantsu/nyaa/service/activity"
+	"github.com/NyaaPantsu/nyaa/service/torrent"
 	"github.com/NyaaPantsu/nyaa/service/user/permission"
 	"github.com/NyaaPantsu/nyaa/util"
 	"github.com/NyaaPantsu/nyaa/util/categories"
@@ -257,18 +259,17 @@ var FuncMap = template.FuncMap{
 		return string(T(d))
 	},
 	"genUploaderLink": func(uploaderID uint, uploaderName template.HTML, torrentHidden bool) template.HTML {
-
-		if torrentHidden {
-			return template.HTML("れんちょん")
-		}
+		uploaderID, username := torrentService.HideTorrentUser(uploaderID, string(uploaderName), torrentHidden)
 		if uploaderID == 0 {
-			return template.HTML("れんちょん")
+			return template.HTML(username)
 		}
-		url, err := Router.Get("user_profile").URL("id", strconv.Itoa(int(uploaderID)), "username", string(uploaderName))
+		url, err := Router.Get("user_profile").URL("id", strconv.Itoa(int(uploaderID)), "username", username)
 		if err != nil {
 			return "error"
 		}
-		return template.HTML("<a href=\"" + url.String() + "\">" + string(uploaderName) + "</a>")
-
+		return template.HTML("<a href=\"" + url.String() + "\">" + username + "</a>")
+	},
+	"genActivityContent": func(a model.Activity, T publicSettings.TemplateTfunc) template.HTML {
+		return activity.ToLocale(&a, T)
 	},
 }

--- a/service/activity/activity.go
+++ b/service/activity/activity.go
@@ -1,0 +1,41 @@
+package activity
+
+import (
+	"html/template"
+	"strings"
+
+	"github.com/NyaaPantsu/nyaa/db"
+	"github.com/NyaaPantsu/nyaa/model"
+	"github.com/NyaaPantsu/nyaa/util/publicSettings"
+)
+
+// Log : log an activity from a user to his own id (System user id is 0)
+func Log(user *model.User, name string, filter string, msg ...string) {
+	activity := model.NewActivity(name, filter, msg...)
+	activity.UserID = user.ID
+	db.ORM.Create(&activity)
+}
+
+// DeleteAll : Erase aticities from a user (System user id is 0)
+func DeleteAll(id uint) {
+	db.ORM.Where("user_id = ?", id).Delete(&model.Activity{})
+}
+
+// ToLocale : Convert list of parameters to message in local language
+func ToLocale(a *model.Activity, T publicSettings.TemplateTfunc) template.HTML {
+	c := strings.Split(a.Content, ",")
+	d := make([]interface{}, len(c)-1)
+	for i, s := range c[1:] {
+		d[i] = s
+	}
+	return T(c[0], d...)
+}
+
+// GetAllActivities : Get All activities
+func GetAllActivities(limit int, offset int, conditions string, values ...interface{}) ([]model.Activity, int) {
+	var activities []model.Activity
+	var nbActivities int
+	db.ORM.Model(&activities).Where(conditions, values...).Count(&nbActivities)
+	db.ORM.Preload("User").Limit(limit).Offset(offset).Order("id DESC").Where(conditions, values...).Find(&activities)
+	return activities, nbActivities
+}

--- a/service/comment/comment.go
+++ b/service/comment/comment.go
@@ -13,19 +13,19 @@ func GetAllComments(limit int, offset int, conditions string, values ...interfac
 	var comments []model.Comment
 	var nbComments int
 	db.ORM.Model(&comments).Where(conditions, values...).Count(&nbComments)
-	db.ORM.Preload("User").Limit(limit).Offset(offset).Where(conditions, values...).Find(&comments)
+	db.ORM.Limit(limit).Offset(offset).Where(conditions, values...).Preload("User").Find(&comments)
 	return comments, nbComments
 }
 
 // DeleteComment : Delete a comment
 // FIXME : move this to comment service
-func DeleteComment(id string) (int, error) {
+func DeleteComment(id string) (*model.Comment, int, error) {
 	var comment model.Comment
-	if db.ORM.First(&comment, id).RecordNotFound() {
-		return http.StatusNotFound, errors.New("Comment is not found")
+	if db.ORM.Where("comment_id = ?", id).Preload("User").Preload("Torrent").Find(&comment).RecordNotFound() {
+		return &comment, http.StatusNotFound, errors.New("Comment is not found")
 	}
 	if db.ORM.Delete(&comment).Error != nil {
-		return http.StatusInternalServerError, errors.New("Comment is not deleted")
+		return &comment, http.StatusInternalServerError, errors.New("Comment is not deleted")
 	}
-	return http.StatusOK, nil
+	return &comment, http.StatusOK, nil
 }

--- a/service/report/report.go
+++ b/service/report/report.go
@@ -20,15 +20,15 @@ func CreateTorrentReport(torrentReport model.TorrentReport) error {
 }
 
 // DeleteTorrentReport : Delete a torrent report by id
-func DeleteTorrentReport(id uint) (error, int) {
+func DeleteTorrentReport(id uint) (*model.TorrentReport, error, int) {
 	var torrentReport model.TorrentReport
 	if db.ORM.First(&torrentReport, id).RecordNotFound() {
-		return errors.New("Trying to delete a torrent report that does not exists"), http.StatusNotFound
+		return &torrentReport, errors.New("Trying to delete a torrent report that does not exists"), http.StatusNotFound
 	}
 	if err := db.ORM.Delete(&torrentReport).Error; err != nil {
-		return err, http.StatusInternalServerError
+		return &torrentReport, err, http.StatusInternalServerError
 	}
-	return nil, http.StatusOK
+	return &torrentReport, nil, http.StatusOK
 }
 
 // DeleteDefinitelyTorrentReport : Delete definitely a torrent report by id

--- a/service/torrent/metainfoFetcher/metainfo_fetcher.go
+++ b/service/torrent/metainfoFetcher/metainfo_fetcher.go
@@ -41,10 +41,10 @@ func New(fetcherConfig *config.MetainfoFetcherConfig) (*MetainfoFetcher, error) 
 
 	// Well, it seems this is the right way to convert speed -> rate.Limiter
 	// https://github.com/anacrolix/torrent/blob/master/cmd/torrent/main.go
-	const uploadBurst = 0x40000 // 256K
+	const uploadBurst = 0x40000    // 256K
 	const downloadBurst = 0x100000 // 1M
-	uploadLimit := fetcherConfig.UploadRateLimitKiB*1024
-	downloadLimit := fetcherConfig.DownloadRateLimitKiB*1024
+	uploadLimit := fetcherConfig.UploadRateLimitKiB * 1024
+	downloadLimit := fetcherConfig.DownloadRateLimitKiB * 1024
 	if uploadLimit > 0 {
 		limit := rate.Limit(uploadLimit)
 		limiter := rate.NewLimiter(limit, uploadBurst)
@@ -170,7 +170,7 @@ func (fetcher *MetainfoFetcher) gotResult(r Result) {
 		if r.operation.torrent.Filesize != r.info.TotalLength() {
 			log.Infof("Got length %d for torrent TID: %d. Updating.", r.info.TotalLength(), r.operation.torrent.ID)
 			r.operation.torrent.Filesize = r.info.TotalLength()
-			_, err := torrentService.UpdateTorrent(r.operation.torrent)
+			_, err := torrentService.UpdateTorrent(&r.operation.torrent)
 			if err != nil {
 				log.Infof("Failed to update torrent TID: %d with new filesize", r.operation.torrent.ID)
 				lengthOK = false
@@ -217,7 +217,7 @@ func (fetcher *MetainfoFetcher) removeOldFailures() {
 		// | 3       | 8 * base
 		// integers inside fetcher.numFails are never less than or equal to zero
 		mul := 1 << uint(fetcher.numFails[id]-1)
-		cd := time.Duration(mul * fetcher.baseFailCooldown) * time.Second
+		cd := time.Duration(mul*fetcher.baseFailCooldown) * time.Second
 		if cd > max {
 			cd = max
 		}

--- a/templates/activity_list.html
+++ b/templates/activity_list.html
@@ -1,0 +1,22 @@
+{{define "title"}}{{ call $.T "activity_list" }}{{end}}
+{{define "contclass"}}cont-home{{end}}
+{{define "content"}}
+<div class="results box">
+    <table>
+        <thead class="torrent-info">
+            <tr>
+                <th class="tr-name">{{ call $.T "activities" }}</th>
+                <th class="tr-size">{{ call $.T "filter" }}</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{ range .Models}}
+        <tr>
+            <td class="tr-name home-td"><a>{{ genActivityContent . $.T }}</a></td>
+            <td class="tr-actions home-td"><a href="{{ genRoute "activity_list" }}?filter={{.Filter}}" class="form-input">{{ call $.T .Filter }}</a></td>
+            </tr>
+        {{end}}
+        </tbody>
+    </table>
+</div>
+{{end}}

--- a/templates/admin/commentlist.html
+++ b/templates/admin/commentlist.html
@@ -17,7 +17,7 @@
             <!-- TODO: add href="{{ genRoute "mod_cedit" }}?id={{.ID}}" for comment editing -->
             <td class="tr-name home-td"><a>{{ .Content }}</a></td>
             <td class="tr-size home-td"><a href="{{ genViewTorrentRoute .TorrentID }}">{{ .TorrentID }}</a></td>
-            <td class="tr-size home-td">{{ .UserID }}</td>
+            <td class="tr-size home-td">{{if .User }}{{ .User.Username }}{{else}}れんちょん{{end}}</td>
             <td class="tr-actions home-td"><a href="{{ genRoute "mod_cdelete" }}?id={{.ID}}" class="form-input btn-red" onclick="if (!confirm('{{ call $.T "are_you_sure" }}')) return false;"><i class="trash-icon"></i> {{ call $.T "delete" }}</a></td>
             </tr>
         {{end}}

--- a/templates/admin/panelindex.html
+++ b/templates/admin/panelindex.html
@@ -92,7 +92,7 @@
     {{range .Comments}}
     <tr>
         <td class="tr-name home-td"><a href="{{ genRoute "mod_cedit" }}?id={{.ID}}">{{ .Content }}</a></td>
-        <td class="tr-size home-td"><a href="{{ genRoute "mod_cedit" }}?id={{.ID}}">{{.UserID}}</a></td>
+        <td class="tr-size home-td"><a href="{{ genRoute "mod_cedit" }}?id={{.ID}}">{{if .User }}{{ .User.Username }}{{else}}れんちょん{{end}}</a></td>
         <td class="tr-size home-td"><a href="{{ genRoute "mod_cdelete" }}?id={{ .ID }}" class="form-input btn-red" onclick="if (!confirm('{{ call $.T "are_you_sure" }}')) return false;"><i class="trash-icon"></i> {{ call $.T "delete" }}</a></td>
     </tr>
     {{end}}

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -860,6 +860,22 @@
     "translation": "Torrent %s deleted!"
   },
   {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%s from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%s from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%s from %s has been unlocked by %s."
+  },
+  {
     "id": "torrents_deleted",
     "translation": "Torrents Deleted"
   },
@@ -870,6 +886,14 @@
   {
     "id": "delete_report",
     "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%s from %s has been edited by %s."
   },
   {
     "id": "no_action_exist",
@@ -1334,5 +1358,17 @@
   {
     "id": "language_multiple_name",
     "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
   }
 ]


### PR DESCRIPTION
List Torrent delete log
Torrent edit log
Comment delete log
And every other logged activities
Can be filtered out by a filter tag ("edit" or "delete" supported)
Pages navigation

Can be accessed by /activities

Added some translation string
Fixed hidden username on api request
Fixed comments username on modpanel
New Activity model
New Activity handler
New Activity Service
Fixed some updating issue for ES when moderating torrents

Be aware deleting torrents and comments return the model now!