### PR TITLE
Fix hidden on User Profile

### DIFF
--- a/common/search.go
+++ b/common/search.go
@@ -244,6 +244,7 @@ type SearchParam struct {
 	TorrentID uint
 	FromID    uint // Search for torrentID > FromID
 	Order     bool // True means acsending
+	Hidden    bool // True means filter hidden torrents
 	Status    Status
 	Sort      SortMode
 	Category  Categories

--- a/common/torrent.go
+++ b/common/torrent.go
@@ -20,6 +20,7 @@ type TorrentParam struct {
 	All       bool // True means ignore everything but Max and Offset
 	Full      bool // True means load all members
 	Order     bool // True means ascending
+	Hidden    bool // True means filter hidden torrents
 	Status    Status
 	Sort      SortMode
 	Category  Categories
@@ -140,6 +141,10 @@ func (p *TorrentParam) ToFilterQuery() string {
 
 	if p.UserID != 0 {
 		query += " uploader_id:" + strconv.FormatInt(int64(p.UserID), 10)
+	}
+
+	if p.Hidden {
+		query += " hidden:false"
 	}
 
 	if p.Status != ShowAll {

--- a/deploy/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
+++ b/deploy/ansible/roles/elasticsearch/files/elasticsearch_settings.yml
@@ -66,6 +66,8 @@ mappings:
         type: long
       seeders:
         type: long
+      hidden:
+        type: boolean
       leechers:
         type: long
       completed:

--- a/deploy/ansible/roles/elasticsearch/files/index_nyaapantsu.py
+++ b/deploy/ansible/roles/elasticsearch/files/index_nyaapantsu.py
@@ -21,7 +21,7 @@ es = Elasticsearch()
 pgconn = psycopg2.connect(dbparams)
 
 cur = pgconn.cursor()
-cur.execute("""SELECT torrent_id, torrent_name, category, sub_category, status, 
+cur.execute("""SELECT torrent_id, torrent_name, hidden, category, sub_category, status, 
                       torrent_hash, date, uploader, downloads, filesize, seeders, leechers, completed, language
                FROM {torrent_tablename}
                WHERE deleted_at IS NULL""".format(torrent_tablename=torrent_tablename))
@@ -29,7 +29,7 @@ cur.execute("""SELECT torrent_id, torrent_name, category, sub_category, status,
 fetches = cur.fetchmany(CHUNK_SIZE)
 while fetches:
     actions = list()
-    for torrent_id, torrent_name, category, sub_category, status, torrent_hash, date, uploader, downloads, filesize, seeders, leechers, completed, language in fetches:
+    for torrent_id, torrent_name, hidden, category, sub_category, status, torrent_hash, date, uploader, downloads, filesize, seeders, leechers, completed, language in fetches:
         doc = {
           'id': torrent_id,
           'name': torrent_name.decode('utf-8'),
@@ -37,6 +37,7 @@ while fetches:
           'sub_category': str(sub_category),
           'status': status,
           'hash': torrent_hash,
+          'hidden': hidden,
           'date': date,
           'uploader_id': uploader,
           'downloads': downloads,

--- a/deploy/ansible/roles/elasticsearch/files/reindex_nyaapantsu.py
+++ b/deploy/ansible/roles/elasticsearch/files/reindex_nyaapantsu.py
@@ -38,17 +38,18 @@ while fetches:
         }
         if action == 'index':
             select_cur = pgconn.cursor()
-            select_cur.execute("""SELECT torrent_id, torrent_name, category, sub_category, status,
+            select_cur.execute("""SELECT torrent_id, torrent_name, hidden, category, sub_category, status,
                                   torrent_hash, date, uploader, downloads, filesize, seeders, leechers, completed, language
                            FROM {torrent_tablename}
                            WHERE torrent_id = {torrent_id}""".format(torrent_id=torrent_id, torrent_tablename=torrent_tablename))
-            torrent_id, torrent_name, category, sub_category, status, torrent_hash, date, uploader, downloads, filesize, seeders, leechers, completed, language = select_cur.fetchone()
+            torrent_id, torrent_name, hidden, category, sub_category, status, torrent_hash, date, uploader, downloads, filesize, seeders, leechers, completed, language = select_cur.fetchone()
             doc = {
               'id': torrent_id,
               'name': torrent_name.decode('utf-8'),
               'category': str(category),
               'sub_category': str(sub_category),
               'status': status,
+              'hidden': hidden,
               'hash': torrent_hash,
               'date': date,
               'uploader_id': uploader,

--- a/router/template_functions.go
+++ b/router/template_functions.go
@@ -161,6 +161,9 @@ var FuncMap = template.FuncMap{
 	"NeedsCaptcha":         userPermission.NeedsCaptcha,
 	"GetRole":              userPermission.GetRole,
 	"IsFollower":           userPermission.IsFollower,
+	"DisplayTorrent": func(t model.Torrent, u model.User) bool {
+		return ((!t.Hidden && t.Status != 0) || userPermission.CurrentOrAdmin(&u, t.UploaderID))
+	},
 	"NoEncode": func(str string) template.HTML {
 		return template.HTML(str)
 	},

--- a/templates/_user_list_torrents.html
+++ b/templates/_user_list_torrents.html
@@ -10,7 +10,7 @@
             <th class="tr-date hide-xs">{{call $.T "date"}}</th>
           </tr>
           {{ range $i, $t := .Torrents }}
-          {{ if lt $i 16 }}
+          {{ if DisplayTorrent $t $.User }}
           {{ with $t.ToJSON }}
           <tr class="torrent-info
               {{if eq .Status 2}}remake{{end}}


### PR DESCRIPTION
When a user had hidden torrents, they were still listed on his user page even if it's not the actual user who is viewing it.
That's why I added a new function for searching which filter out hidden torrents.
Now when a user go to his own page (or a moderator), he can see all his torrents.
However if another person visit the page, only non hidden torrents will be listed.
I added the hidden parameter in ES database, it permits also to use the search instead of SQL when listing torrents on the user page. Less load time, go with the idea that we should use ES everywhere when needed.