### PR TITLE
Prettier color for texts in red button

### DIFF
--- a/public/css/g.css
+++ b/public/css/g.css
@@ -48,6 +48,7 @@ td.tr-le, .error-text { color: #E84C4C; }
 
 .btn-red {
 	background-color: #E84C4C;
+	color: #E8E8E8;
 }
 
 .aplus, .btn-blue { background: hsla(200, 100%, 50%, 0.2) !important; }


### PR DESCRIPTION
Current one was dark grey on red which is pretty ugly, i changed it into white (light grey) on red to make it prettier

Before:

![before](https://user-images.githubusercontent.com/11745692/27368416-b5ec1c46-5652-11e7-9779-2322cddfd086.png)

After:

![after](https://user-images.githubusercontent.com/11745692/27368417-b86d8f36-5652-11e7-97f0-f8f57a2edc52.png)
