### PR TITLE
Prettier color for red button when hovered and .h-user when focused

### DIFF
--- a/public/css/classic.css
+++ b/public/css/classic.css
@@ -55,6 +55,11 @@ td.tr-le, .error-text { color: #E84C4C; }
 
 .btn-red {
 	background-color: #E84C4C;
+	color: #E8E8E8;
+}
+
+.btn-red:hover {
+	color: #E8E8E8;
 }
 
 /* Original Nyaa colors, do NOT change! */

--- a/public/css/g.css
+++ b/public/css/g.css
@@ -51,6 +51,8 @@ td.tr-le, .error-text { color: #E84C4C; }
 	color: #E8E8E8;
 }
 
+.btn-red:hover { color: #E8E8E8; }
+
 .aplus, .btn-blue { background: hsla(200, 100%, 50%, 0.2) !important; }
 .trusted, .btn-green { background: hsla(100, 100%, 50%, 0.2) !important; }
 .remake, .btn-orange { background: hsla(30, 100%, 50%, 0.2) !important; }
@@ -77,4 +79,4 @@ td.tr-le, .error-text { color: #E84C4C; }
 	border-color: #C48CBE;
 }
 
-.header .h-user button:focus {background-color: rgba(0,0,255, 0.2);}
+.header .h-user button:focus {background-color: rgba(0,100,200, 0.15);}


### PR DESCRIPTION
Prettier color for .h-user when focused on /g/'s theme

.h-user before:
![before](https://user-images.githubusercontent.com/11745692/27472499-e111b4e4-57fb-11e7-9d89-5375a5e72dd4.png)

.h-user after:
![after](https://user-images.githubusercontent.com/11745692/27472513-ee1e72bc-57fb-11e7-80d3-d23389db930c.png)

And prettier color for red button when hovered
Red button hovered before:
![before2](https://user-images.githubusercontent.com/11745692/27472589-2d3fd558-57fc-11e7-9fe7-183b67f37e80.png)

Red button hovered after:
![after2](https://user-images.githubusercontent.com/11745692/27472595-3364fba2-57fc-11e7-8151-24da565eab59.png)
