### PR TITLE
change torrent fixed height to min-height

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -553,7 +553,7 @@ input#show-filelist:checked ~ #filelist {
 .table-filelist {
 	width: 100%;
 }
-tr.torrentinfo { height: 38px; }
+tr.torrentinfo { min-height: 38px; }
 .tr-filelist {
 	--nest-level: 0;
 }


### PR DESCRIPTION
it was fine for torrents that were two lines high but i suspect it would've broken 3 lines high (or 4+) torrents