### PR TITLE
Make torrent language on "other" by default

### DIFF
--- a/templates/admin/paneltorrentedit.html
+++ b/templates/admin/paneltorrentedit.html
@@ -27,8 +27,7 @@
       <div class="form-group">
           <label for="language">{{ call $.T "torrent_language" }}</label>
           <select name="language" id="language" class="form-input up-input" required>
-			<option value="">{{call $.T "select_a_torrent_language"}}</option>
-            <option value="other" {{if eq $.Form.Language "other"}}selected{{end}}>{{call $.T "language_other_name"}}</option>
+			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/admin/paneltorrentedit.html
+++ b/templates/admin/paneltorrentedit.html
@@ -27,7 +27,7 @@
       <div class="form-group">
           <label for="language">{{ call $.T "torrent_language" }}</label>
           <select name="language" id="language" class="form-input up-input" required>
-			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
+			<option value="other" {{if eq $.Form.Language "other"}}selected{{end}}>{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/admin/paneltorrentedit.html
+++ b/templates/admin/paneltorrentedit.html
@@ -27,7 +27,7 @@
       <div class="form-group">
           <label for="language">{{ call $.T "torrent_language" }}</label>
           <select name="language" id="language" class="form-input up-input" required>
-			<option value="other" selected>{{call $.T "select_a_torrent_language"}}</option>
+			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/admin/paneltorrentedit.html
+++ b/templates/admin/paneltorrentedit.html
@@ -27,7 +27,7 @@
       <div class="form-group">
           <label for="language">{{ call $.T "torrent_language" }}</label>
           <select name="language" id="language" class="form-input up-input" required>
-			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
+			<option value="other" selected>{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -29,7 +29,7 @@
 
 		<h3>{{ call $.T "torrent_language" }}</h3>
 		<select name="language" id="language" class="form-input up-input" required>
-			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
+			<option value="other" selected>{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -29,8 +29,7 @@
 
 		<h3>{{ call $.T "torrent_language" }}</h3>
 		<select name="language" id="language" class="form-input up-input" required>
-			<option value="">{{call $.T "select_a_torrent_language"}}</option>
-			<option value="other" {{if eq $.Form.Language "other"}}selected{{end}}>{{call $.T "language_other_name"}}</option>
+			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -29,7 +29,7 @@
 
 		<h3>{{ call $.T "torrent_language" }}</h3>
 		<select name="language" id="language" class="form-input up-input" required>
-			<option value="other" selected>{{call $.T "select_a_torrent_language"}}</option>
+			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -29,7 +29,7 @@
 
 		<h3>{{ call $.T "torrent_language" }}</h3>
 		<select name="language" id="language" class="form-input up-input" required>
-			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
+			<option value="other" {{if eq $.Form.Language "other"}}selected{{end}}>{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/user/torrent_edit.html
+++ b/templates/user/torrent_edit.html
@@ -27,8 +27,7 @@
       <div class="form-group">
           <label for="language">{{ call $.T "torrent_language" }}</label>
           <select name="language" id="language" class="form-input up-input" required>
-			<option value="">{{call $.T "select_a_torrent_language"}}</option>
-            <option value="other" {{if eq $.Form.Language "other"}}selected{{end}}>{{call $.T "language_other_name"}}</option>
+			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>

--- a/templates/user/torrent_edit.html
+++ b/templates/user/torrent_edit.html
@@ -27,7 +27,7 @@
       <div class="form-group">
           <label for="language">{{ call $.T "torrent_language" }}</label>
           <select name="language" id="language" class="form-input up-input" required>
-			<option value="other">{{call $.T "select_a_torrent_language"}}</option>
+			<option value="other" {{if eq $.Form.Language "other"}}selected{{end}}>{{call $.T "select_a_torrent_language"}}</option>
 			<option value="multiple" {{if eq $.Form.Language "multiple"}}selected{{end}}>{{call $.T "language_multiple_name"}}</option>
 			{{ range $_, $language := (GetTorrentLanguages) }}
 			<option value="{{ $language }}" {{if eq $.Form.Language $language}}selected{{end}}>


### PR DESCRIPTION
So that you do not need to pick a torrent language to upload.
Also, should delete {{call $.T "language_other_name"}} from translations as i removed the "Other" option: by default it is on other, although it shows the "Select a torrent language" translation