### PR TITLE
Make "other" flag invisible

### DIFF
--- a/public/css/flags/custom_flags.css
+++ b/public/css/flags/custom_flags.css
@@ -1,5 +1,5 @@
 .flag-other {
-    background: url('flag_other.png') no-repeat;
+    background: none;
 }
 
 .flag-multiple {


### PR DESCRIPTION
![ss](https://user-images.githubusercontent.com/11745692/27583316-3b34208e-5b34-11e7-9a80-2e1e123f4b68.png)

What's the point of this flag outside of cluttering? No flag is better than other flag
Should also delete flag_other.png in public\css\flags