### PR TITLE
Remove footer's top margin

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -325,7 +325,7 @@ th { border-bottom-width: 2px; }
 .pagination a:nth-last-child(2) li { border-radius: 0 3px 3px 0; border-right-width: 1px !important}
 
 
-#footer { width: 100%; bottom: 0; left: 0; margin-top: 40px; }
+#footer { width: 100%; bottom: 0; left: 0; }
 
 .footer {
 	text-align: center;


### PR DESCRIPTION
Because why is such a big amount of spacing needed?

Before:

![before](https://user-images.githubusercontent.com/11745692/27645792-4b8e5fbe-5c27-11e7-9f56-75b14c87a6e8.png)

After:

![after](https://user-images.githubusercontent.com/11745692/27645798-4e6e44a6-5c27-11e7-9216-083a4a458453.png)
