### PR TITLE
[WIP] Multiple torrent language (flags)

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -137,15 +137,20 @@ select.form-input {
 }
 
 .form-input.language {
-	width: 53%;
+	width: 45%;
 	height: auto;
 	border-radius: 5px;
 	background: hsl(193, 15%; 97%);
-	padding: 15px 21px 15px 21px;	
+	padding: 13px 20px 9px 28px;	
 }
 
-.language > img.flag {
-	margin: 0 10px 1px 0;
+.language > input {
+	margin: 0 0 5px 0;
+	padding: 0;
+}
+
+.language > label {
+	margin: 0 10px 2px -1;
 }
 
 .header .h-user {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -137,7 +137,7 @@ select.form-input {
 }
 
 .form-input.language {
-	width: 45.3%;
+	max-width: 469px;
 	height: auto;
 	border-radius: 5px;
 	background: hsl(193, 15%; 97%);

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -144,6 +144,10 @@ select.form-input {
 	padding: 15px 21px 15px 21px;	
 }
 
+.language > img.flag {
+	margin: 0 10px 1px 0;
+}
+
 .header .h-user {
 	display: inline-block;
 	max-width: 160px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -476,6 +476,9 @@ html, body {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }
+.torrent-info-data > img {
+	margin-right: 3px;	
+}
 .torrent-info-row {
 	text-align: left;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -141,7 +141,7 @@ select.form-input {
 	height: auto;
 	border-radius: 5px;
 	background: hsl(193, 15%; 97%);
-	padding: 13px 20px 9px 28px;	
+	padding: 13px 20px 8px 28px;	
 }
 
 .language > input {
@@ -150,7 +150,7 @@ select.form-input {
 }
 
 .language > label {
-	margin: 0 10px 2px -1;
+	margin: 0 10px 2px 0;
 }
 
 .header .h-user {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -137,20 +137,20 @@ select.form-input {
 }
 
 .form-input.language {
-	width: 45%;
+	width: 45.3%;
 	height: auto;
 	border-radius: 5px;
 	background: hsl(193, 15%; 97%);
-	padding: 13px 20px 8px 28px;	
+	padding: 12px 0 7px 14px;	
 }
 
 .language > input {
-	margin: 0 0 5px 0;
+	margin: 0 3px 6px 0;
 	padding: 0;
 }
 
 .language > label {
-	margin: 0 10px 2px 0;
+	margin: 0 9px 2px 0;
 }
 
 .header .h-user {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -136,6 +136,14 @@ select.form-input {
 	vertical-align: middle;
 }
 
+.form-input.language {
+	width: 53%;
+	height: auto;
+	border-radius: 5px;
+	background: hsl(193, 15%; 97%);
+	padding: 15px 21px 15px 21px;	
+}
+
 .header .h-user {
 	display: inline-block;
 	max-width: 160px;

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -46,7 +46,7 @@
 		<div name="language" class="form-input language">
 			{{ range _, language := GetTorrentLanguages() }}
 			<input type="checkbox" name="lang-{{ language }}" id="lang-{{ language }}">
-			<img src="img/blank.gif" alt="{{LanguageName(language, T)}}" class="flag flag-{{language}}" title="{{LanguageName(language, T)}}>
+			<label for="lang-{{ language }}" class="flag flag-{{ language }}" title="{{LanguageName(language, T)}}"></label>
 			{{ end }}
 		</div>
 		{{ yield errors(name="language")}}

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -43,7 +43,7 @@
 			</option>
 			{{ end }}
 		</select>
-		<div name="language" id="language">
+		<div name="language" class="form-input language">
 			{{ range _, language := GetTorrentLanguages() }}
 			<input type="checkbox" name="lang-{{ language }}" id="lang-{{ language }}">
 			<img src="img/blank.gif" alt="{{LanguageName(language, T)}}" class="flag flag-{{language}}" title="{{LanguageName(language, T)}}>

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -34,15 +34,6 @@
 		{{ yield errors(name="c")}}
 
 		<h3>{{  T("torrent_language") }}</h3>
-		<select name="language" id="language" class="form-input up-input">
-			<option value="other" {{if Form.Language == "other"}}selected{{end}}>{{ T("select_a_torrent_language")}}</option>
-			<option value="multiple" {{if Form.Language == "multiple"}}selected{{end}}>{{ T("language_multiple_name")}}</option>
-			{{ range _, language := GetTorrentLanguages() }}
-			<option value="{{ language }}" {{if Form.Language == language}}selected{{end}}>
-				{{LanguageName(language, T)}}
-			</option>
-			{{ end }}
-		</select>
 		<div name="language" class="form-input language">
 			{{ range _, language := GetTorrentLanguages() }}
 			<input type="checkbox" name="lang-{{ language }}" id="lang-{{ language }}">

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -5,7 +5,6 @@
 {{block additional_header()}}
 <link rel="stylesheet" href="/css/flags/flags.min.css">
 {{end}}
-
 {{block content_body()}}
 <div style="text-align: left;" class="box">
 	<form enctype="multipart/form-data" role="upload" method="POST">
@@ -36,8 +35,8 @@
 		<h3>{{  T("torrent_language") }}</h3>
 		<div name="language" class="form-input language">
 			{{ range _, language := GetTorrentLanguages() }}
-			<input type="checkbox" name="lang-{{ language }}" id="lang-{{ language }}">
-			<label for="lang-{{ language }}" class="flag flag-{{ language }}" title="{{LanguageName(language, T)}}"></label>
+			<input type="checkbox" name="languages" id="lang-{{ language }}" value="{{language}}">
+			<label for="lang-{{ language }}" class="flag flag-{{ FlagCode(language) }}" title="{{LanguageName(language, T)}}"></label>
 			{{ end }}
 		</div>
 		{{ yield errors(name="language")}}
@@ -51,7 +50,7 @@
 		{{ if User.ID > 0 }}
 		<p>
 			<input type="checkbox" name="hidden" id="hidden" >
-			<label for="hidden">{{ T("mark_as_hidden")}}</label>
+			<label for="hidden">{{ T("upload_as_anon")}}</label>
 		</p>
 		{{ yield errors(name="hidden")}}
 		{{ end }}

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -2,6 +2,10 @@
 {{ import "layouts/partials/helpers/csrf" }}
 {{ import "layouts/partials/helpers/captcha" }}
 {{block title()}}{{ T("upload")}}{{end}}
+{{block additional_header()}}
+<link rel="stylesheet" href="/css/flags/flags.min.css">
+{{end}}
+
 {{block content_body()}}
 <div style="text-align: left;" class="box">
 	<form enctype="multipart/form-data" role="upload" method="POST">
@@ -39,6 +43,12 @@
 			</option>
 			{{ end }}
 		</select>
+		<div name="language" id="language">
+			{{ range _, language := GetTorrentLanguages() }}
+			<input type="checkbox" name="lang-{{ language }}" id="lang-{{ language }}">
+			<img src="img/blank.gif" alt="{{LanguageName(language, T)}}" class="flag flag-{{language}}" title="{{LanguageName(language, T)}}>
+			{{ end }}
+		</div>
 		{{ yield errors(name="language")}}
 
 		<p>


### PR DESCRIPTION
I did the html & css stuff for upload.html, it should be like this:

![pic](https://user-images.githubusercontent.com/11745692/27757616-1098188a-5e04-11e7-9b6b-98d01e43b4c1.png)

Image are clickeable to select the checkbox of course. Oh and i haven't tested the Go part of this code.
Doesn't look pretty on phone screens because of how narrow they are (less than 470px, the div's width):

![pic](https://user-images.githubusercontent.com/11745692/27757666-b5fe0532-5e04-11e7-972a-caaffb793535.png)

Putting a width: 34.3% fixes this for phone (makes it into 3 column aligned) but breaks it on desktop
It gets fucked on narrow screen because it's a max-width, so it's width is reduced when there's not enough room for it, someone use css sorcery to fix this please

**Need to do the backend stuff, need to show each flag in view.html, need to show the "2+ flags" when multiple flags in torrent list**