### PR TITLE
Reduce MaxOpenConn to increase performance

### DIFF
--- a/db/gorm.go
+++ b/db/gorm.go
@@ -57,15 +57,13 @@ func GormInit(conf *config.Config, logger Logger) (*gorm.DB, error) {
 		return nil, connectionErr
 	}
 
-	// Negative MaxIdleConns means don't retain any idle connection
-	maxIdleConns := -1
-	if IsSqlite {
-		// sqlite doesn't like having a negative maxIdleConns
-		maxIdleConns = 10
-	}
-
-	db.DB().SetMaxIdleConns(maxIdleConns)
-	db.DB().SetMaxOpenConns(400)
+	db.DB().SetMaxIdleConns(1)
+	// This should be about the number of cores the machine has (and should
+	// be lower than the max_connection specified by postgresql.conf)
+	// Since we have two applications running, this should really be 
+	// number of cores / 2
+	// TODO Make configurable
+	db.DB().SetMaxOpenConns(4)
 
 	if config.Conf.Environment == "DEVELOPMENT" {
 		db.LogMode(true)


### PR DESCRIPTION
Removing pgpool resulted in increase in performance.
EDIT: Don't forget to not use pgpool (I'll remove it later in ansible)
From #postgresql@freenode 
```
MatheusOl| tomleb: Looks like the overhead of pgpool managing 
                    those caches are worst then the queries themselves
 MatheusOl| tomleb: If you are not using pgpool for load 
                    balancing, I'd remove it
```

Gorm seems to do connection pooling by itself (confirmation?). Otherwise we could use pooling by using an external application such as pgbouncer. (They also recommended not to use pgpool to do pooling)

Before
```
16:17 $ siege -c255 -r5 http://localhost:8080/view/937324
** SIEGE 4.0.2
** Preparing 255 concurrent users for battle.
The server is now under siege...
Transactions:		       14820 hits
Availability:		       99.73 %
Elapsed time:		       82.21 secs
Data transferred:	      106.52 MB
Response time:		        0.94 secs
Transaction rate:	      180.27 trans/sec
Throughput:		        1.30 MB/sec
Concurrency:		      169.63
Successful transactions:       14820
Failed transactions:	          40
Longest transaction:	       30.03
Shortest transaction:	        0.00

16:27 $ siege -c100 -r5 http://localhost:8080/view/937324
** SIEGE 4.0.2
** Preparing 100 concurrent users for battle.
The server is now under siege...
Transactions:		        6000 hits
Availability:		      100.00 %
Elapsed time:		       28.64 secs
Data transferred:	       43.13 MB
Response time:		        0.43 secs
Transaction rate:	      209.50 trans/sec
Throughput:		        1.51 MB/sec
Concurrency:		       90.48
Successful transactions:        6000
Failed transactions:	           0
Longest transaction:	        6.01
Shortest transaction:	        0.00

16:30 $ siege -c50 -r10 http://localhost:8080/view/937324
** SIEGE 4.0.2
** Preparing 50 concurrent users for battle.
The server is now under siege...
Transactions:		        6000 hits
Availability:		      100.00 %
Elapsed time:		       28.81 secs
Data transferred:	       43.13 MB
Response time:		        0.21 secs
Transaction rate:	      208.26 trans/sec
Throughput:		        1.50 MB/sec
Concurrency:		       44.09
Successful transactions:        6000
Failed transactions:	           0
Longest transaction:	        3.21
Shortest transaction:	        0.00

```

After
```
16:21 $ siege -c255 -r5 http://localhost:8080/view/937324
** SIEGE 4.0.2
** Preparing 255 concurrent users for battle.
The server is now under siege...
Transactions:		       15288 hits
Availability:		       99.99 %
Elapsed time:		       35.57 secs
Data transferred:	      109.89 MB
Response time:		        0.44 secs
Transaction rate:	      429.80 trans/sec
Throughput:		        3.09 MB/sec
Concurrency:		      189.52
Successful transactions:       15288
Failed transactions:	           1
Longest transaction:	       30.07
Shortest transaction:	        0.00

16:24 $ siege -c100 -r5 http://localhost:8080/view/937324
** SIEGE 4.0.2
** Preparing 100 concurrent users for battle.
The server is now under siege...
Transactions:		        6000 hits
Availability:		      100.00 %
Elapsed time:		       13.51 secs
Data transferred:	       43.13 MB
Response time:		        0.16 secs
Transaction rate:	      444.12 trans/sec
Throughput:		        3.19 MB/sec
Concurrency:		       72.32
Successful transactions:        6000
Failed transactions:	           0
Longest transaction:	        8.68
Shortest transaction:	        0.00

16:25 $ siege -c50 -r10 http://localhost:8080/view/937324
** SIEGE 4.0.2
** Preparing 50 concurrent users for battle.
The server is now under siege...
Transactions:		        6000 hits
Availability:		      100.00 %
Elapsed time:		       13.06 secs
Data transferred:	       43.13 MB
Response time:		        0.08 secs
Transaction rate:	      459.42 trans/sec
Throughput:		        3.30 MB/sec
Concurrency:		       34.79
Successful transactions:        6000
Failed transactions:	           0
Longest transaction:	        2.64
Shortest transaction:	        0.00

```