### PR TITLE
Slightly brighter flags when hovered

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -286,12 +286,15 @@ th, .home-td {
 	height: 100%;
 	display: block; 
 }
-.tr-cat img { margin-top: 2px; }
 .tr-cat .nyaa-cat img {
 	position: absolute;
 	bottom: -2px;
 	display: block;
 	left: 11px;
+}
+.nyaa-cat > a > img.flag:hover { 
+	-webkit-filter: brightness(1.2);
+	filter: brightness(1.2);
 }
 
 


### PR DESCRIPTION
That way would an user hover the flag to see the title text, he would see it as a visual cue indicating that the flags and category icons are two different elements and would most likely try to click it, ending up in the flag search
mind games!
![1449050537097](https://user-images.githubusercontent.com/11745692/27850215-50cd655c-6153-11e7-983b-061a2d8e6b48.png)

also removed a line that didn't do anything