### PR TITLE
Remove flags showing up on Sukebei

### DIFF
--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -54,7 +54,7 @@
               <div class="nyaa-cat nyaa-cat-{{ .SubCategory}}">
 			  {{end}}
                   <a href="{{ URL.Parse("/search?c="+.Category+"_"+ .SubCategory) }}" title="{{ T(CategoryName(.Category, .SubCategory)) }}">
-              {{if len(.Languages) == 1 && .Languages[0] != "" }}
+              {{if !Sukebei && len(.Languages) == 1 && .Languages[0] != "" }}
                   <img src="img/blank.gif" alt="{{ LanguageName(.Languages[0], T) }}" class="flag flag-{{FlagCode(.Languages[0])}}" title="{{ LanguageName(.Languages[0], T) }}">
               {{end}}
                   </a>


### PR DESCRIPTION
In the past month, as people were forced to upload with flags (remember i did a commit for that but it's still not on prod) which caused a fuckton of people uploading with random flags
And the vast majority of torrents on Sukebei are in japanese so it's not really an issue

![sukebei](https://user-images.githubusercontent.com/11745692/27988703-f3fd417a-6428-11e7-9419-c802a1241b27.png)
