### PR TITLE
Fix displaying of user-torrents

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -271,7 +271,11 @@ table {
 
 
 th { height: 40px;}
-.home-td { height: 37px; }
+.home-td,.user-td { height: 37px; }
+.user-td { 
+	padding: 4px 5px 4px 1px;
+	min-width: 74px!important;
+}
 
 th, .home-td {
 	border-bottom:  1px solid;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -276,7 +276,7 @@ th { height: 40px;}
 	padding: 4px 5px 4px 1px;
 	min-width: 74px!important;
 }
-.user-torrent .tr-name a { margin-left: 4px; }
+.user-torrent .tr-name a { margin-left: 5px; }
 
 th, .home-td {
 	border-bottom:  1px solid;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -276,6 +276,7 @@ th { height: 40px;}
 	padding: 4px 5px 4px 1px;
 	min-width: 74px!important;
 }
+.user-torrent .tr-name a { margin-left: 4px; }
 
 th, .home-td {
 	border-bottom:  1px solid;

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -17,14 +17,20 @@
           <tr class="torrent-info
               {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}">
               <!-- forced width because the <td> gets bigger randomly otherwise -->
-              <td>
-                  <a href="{{URL.Parse ("/search?c="+ torrent.Category + "_" +torrent.SubCategory) }}">
-                      {{ if Sukebei }}
-                      <img src="{{URL.Parse("/img/torrents/sukebei/"+ torrent.Category+ torrent.SubCategory+".png") }}" title="{{ T(CategoryName(torrent.Category, torrent.SubCategory)) }}">
-                      {{ else }}
-                      <img src="{{URL.Parse ("/img/torrents/"+ torrent.SubCategory+".png") }}" title="{{ T(CategoryName(torrent.Category, torrent.SubCategory)) }}">
-                      {{ end}}
-                  </a>
+              <td class="tr-cat user-td">
+                    {{ if Sukebei }}
+                    <div class="nyaa-cat sukebei-cat-{{ .Category }}{{ .SubCategory }}">
+		{{ else}}
+                    <div class="nyaa-cat nyaa-cat-{{ .SubCategory}}">
+	          {{end}}
+                              <a href="{{ URL.Parse("/search?c="+.Category+"_"+ .SubCategory) }}" title="{{ T(CategoryName(.Category, .SubCategory)) }}" class="category">
+                              {{if .Languages[0] != "" }}
+                                        <a href="{{ URL.Parse("/search?c="+.Category+"_"+ .SubCategory +"&lang=") }}{{ range key, language := .Languages }}{{ language }}{{ if len(.Languages) > 1 && (key+1) < len(.Languages) }},{{ end }}{{ end }}">
+                                                  <img src="/img/blank.gif" alt="{{ LanguageName(.Languages[0], T) }}" class="flag flag-{{ (len(.Languages) == 1) ?  FlagCode(.Languages[0]) : "multiple" }}" title=" {{ range key, language := .Languages }}{{ LanguageName(language, T) }}{{ if len(.Languages) > 1 && (key+1) < len(.Languages) }},{{ end }}{{ end }}">
+                                        </a>
+                              {{end}}
+                              </a>
+                    </div>
               </td>
               <td class="tr-name">
                   <a href="/view/{{torrent.ID}}">

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -19,14 +19,14 @@
               <!-- forced width because the <td> gets bigger randomly otherwise -->
               <td class="tr-cat user-td">
                     {{ if Sukebei }}
-                    <div class="nyaa-cat sukebei-cat-{{ .Category }}{{ .SubCategory }}">
+                    <div class="nyaa-cat sukebei-cat-{{ torrent.Category }}{{ torrent.SubCategory }}">
 		{{ else}}
-                    <div class="nyaa-cat nyaa-cat-{{ .SubCategory}}">
+                    <div class="nyaa-cat nyaa-cat-{{ torrent.SubCategory}}">
 	          {{end}}
-                              <a href="{{ URL.Parse("/search?c="+.Category+"_"+ .SubCategory) }}" title="{{ T(CategoryName(.Category, .SubCategory)) }}" class="category">
-                              {{if .Languages[0] != "" }}
-                                        <a href="{{ URL.Parse("/search?c="+.Category+"_"+ .SubCategory +"&lang=") }}{{ range key, language := .Languages }}{{ language }}{{ if len(.Languages) > 1 && (key+1) < len(.Languages) }},{{ end }}{{ end }}">
-                                                  <img src="/img/blank.gif" alt="{{ LanguageName(.Languages[0], T) }}" class="flag flag-{{ (len(.Languages) == 1) ?  FlagCode(.Languages[0]) : "multiple" }}" title=" {{ range key, language := .Languages }}{{ LanguageName(language, T) }}{{ if len(.Languages) > 1 && (key+1) < len(.Languages) }},{{ end }}{{ end }}">
+                              <a href="{{ URL.Parse("/search?c="+torrent.Category+"_"+ .torrentSubCategory) }}" title="{{ T(CategoryName(.Category, .SubCategory)) }}" class="category">
+                              {{if torrent.Languages[0] != "" }}
+                                        <a href="{{ URL.Parse("/search?c="+torrent.Category+"_"+ .SubCategory +"&lang=") }}{{ range key, language := torrent.Languages }}{{ language }}{{ if len(torrent.Languages) > 1 && (key+1) < len(torrent.Languages) }},{{ end }}{{ end }}">
+                                                  <img src="/img/blank.gif" alt="{{ LanguageName(torrent.Languages[0], T) }}" class="flag flag-{{ (len(torrent.Languages) == 1) ?  FlagCode(.Languages[0]) : "multiple" }}" title=" {{ range key, language := torrent.Languages }}{{ LanguageName(language, T) }}{{ if len(torrent.Languages) > 1 && (key+1) < len(torrent.Languages) }},{{ end }}{{ end }}">
                                         </a>
                               {{end}}
                               </a>

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -14,7 +14,7 @@
           {{ range i, t := UserProfile.Torrents }}
           {{ if DisplayTorrent(t, User) }}
           {{ torrent := t.ToJSON() }}
-          <tr class="torrent-info
+          <tr class="torrent-info user-torrent
               {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}">
               <!-- forced width because the <td> gets bigger randomly otherwise -->
               <td class="tr-cat user-td">


### PR DESCRIPTION
Had been broken by category icons being turned into sprites

![pic](https://user-images.githubusercontent.com/11745692/27994671-9df06826-64c2-11e7-9cad-13b40e62e501.png)

Top torrent is how it will be now, the rest is how it is right now