### PR TITLE
fix link display in user torrent view

### DIFF
--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -39,11 +39,11 @@
               </td>
               <td class="tr-links">
                   <a href="{{torrent.Magnet}}" title="{{  T("magnet_link") }}">
-                        <div class="magnet-icon"></div>
+                        <div class="icon-magnet"></div>
                   </a>
                   {{if torrent.TorrentLink != ""}}
                   <a href="{{torrent.TorrentLink}}" title="{{  T("torrent_file") }}">
-                        <div class="download-icon"></div>
+                        <div class="icon-floppy"></div>
                   </a>
                   {{end}}
               </td>


### PR DESCRIPTION
idk which stupid made change to class name but didn't change it here
![pic](https://user-images.githubusercontent.com/11745692/28001148-ca400d7e-652a-11e7-8655-5cb583e98adb.png)
Links invisible as a result even though the code is there