### PR TITLE
Better width distribution for profile panel

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -421,6 +421,8 @@ html, body {
 		display: inline-grid !important;
 	}
 	.profile-panel, .profile-content {
+		border-radius: 4px;
+		border-right: 1px solid;
 		width: 100% !important;
 		margin-bottom: 20px;
 	}
@@ -544,14 +546,17 @@ html, body {
 }
 
 .profile-panel {
-	width: 30%;
+	width: 23%;
+	border-right: none;
+	border-radius: 4px 0 0 4px;
 }
 .profile-main {
 	display: flex;
 	justify-content: space-between;
 }
 .profile-content {
-	width: 70%;
+	width: 77%;
+	border-radius: 0 4px 4px 0;
 	text-align: left;
 }
 div.profile-content.box > nav > ul > li, nav.adminNav > ul > li {


### PR DESCRIPTION
It had way too much empty space

Before: 
![before](https://user-images.githubusercontent.com/11745692/28001975-41e9104a-6531-11e7-8e81-d021c9a73e13.png)

After:
![after](https://user-images.githubusercontent.com/11745692/28001977-44899ca2-6531-11e7-8323-d851e6e07135.png)

Mobile view unchanged as seen here:

![after](https://user-images.githubusercontent.com/11745692/28002019-8342bffa-6531-11e7-8e7b-14d7f0ff2a9b.png)
