### PR TITLE
Remove unwanted torrent name spacing in user torrents

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -276,7 +276,6 @@ th { height: 40px;}
 	padding: 4px 5px 4px 1px;
 	min-width: 74px!important;
 }
-.user-torrent .tr-name a { margin-left: 5px; }
 
 th, .home-td {
 	border-bottom:  1px solid;

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -14,7 +14,7 @@
           {{ range i, t := UserProfile.Torrents }}
           {{ if DisplayTorrent(t, User) }}
           {{ torrent := t.ToJSON() }}
-          <tr class="user-torrent torrent-info 
+          <tr class="torrent-info 
               {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}">
               <!-- forced width because the <td> gets bigger randomly otherwise -->
 		<td class="tr-cat user-td">


### PR DESCRIPTION
Was causing things to be not aligned

Before:
![before](https://user-images.githubusercontent.com/11745692/28002099-369a4712-6532-11e7-909b-28defc8921d6.png)

After:
![after](https://user-images.githubusercontent.com/11745692/28002106-38a4710e-6532-11e7-8b59-529ab3b32a49.png)
