### PR TITLE
Better padding in user settings

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -572,7 +572,9 @@ html, body {
 	width: 77%;
 	border-radius: 0 4px 4px 0;
 	text-align: left;
+	padding: 10px 10px 15px 10px;
 }
+.profile-content h3 { margin-bottom: 6px; margin-top: 4px;}
 div.profile-content.box > nav > ul > li, nav.adminNav > ul > li {
 	border-right-width: 1px;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -575,6 +575,7 @@ html, body {
 	padding: 10px 10px 15px 10px;
 }
 .profile-content h3 { margin-bottom: 6px; margin-top: 4px;}
+.profile-content .pagination { margin-bottom: 9px;}
 div.profile-content.box > nav > ul > li, nav.adminNav > ul > li {
 	border-right-width: 1px;
 }


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/11745692/28002469-c175f068-6535-11e7-8491-278020380f69.png)

After:
![after](https://user-images.githubusercontent.com/11745692/28002471-c5933d36-6535-11e7-92ed-16422a9b2800.png)

Torrent list padding unchanged