### PR TITLE
Make refine button submit form if refine dropdown doesn't exist

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -88,6 +88,7 @@ function playVoice() {
 
 function toggleRefine() {
 	var refine_form = document.getElementsByClassName("box refine")[0];
+	refine_form.type = "button";
 	if(refine_form != "undefined") refine.style.display = refine.style.display == "none" ? "block" : "none";
 	else document.getElementById("header-form").submit();
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -87,7 +87,8 @@ function playVoice() {
 }
 
 function toggleRefine() {
-	document.getElementsByClassName("box refine")[0].style.display = document.getElementsByClassName("box refine")[0].style.display == "none" ? "block" : "none";
-	return 0;	
+	var refine_form = document.getElementsByClassName("box refine")[0];
+	if(refine_form != "undefined") refine.style.display = refine.style.display == "none" ? "block" : "none";
+	else document.getElementById("header-form").submit();
 }
 // @license-end

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -10,7 +10,7 @@
 {{block search_button() }}
     <input class="form-input search-box" name="q" placeholder="{{ T("search")}}" type="text" value="{{Search.NameLike}}">
     <button type="submit" class="form-input icon-search"></button>
-    <button type="submit" class="form-input refine" name="refine" onclick="toggleRefine();" onload="this.type='button';">{{  T("refine")}}</button>
+    <button type="submit" class="form-input refine" name="refine" onclick="toggleRefine();">{{  T("refine")}}</button>
 {{end}}
 {{block search_refine() }}
         <h3>{{ T("refine_search") }}</h3>

--- a/templates/layouts/partials/menu/site.jet.html
+++ b/templates/layouts/partials/menu/site.jet.html
@@ -19,7 +19,7 @@
     <div class="h-right">
         {{ include "layouts/partials/helpers/badgemenu" }}
         <div class="h-search">
-        <form role="search" action="{{URL.Parse("/search")}}" method="get">
+        <form role="search" action="{{URL.Parse("/search")}}" id="header-form" method="get">
             {{ yield search_common() }}
             {{ yield search_button() }}
         </form>


### PR DESCRIPTION
And the submit button will turn itself into a normal button if the function is executed. It's a workaround because i couldn't get onload="" to work, but it werks