### PR TITLE
Add spacing for <div> in description

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -685,7 +685,9 @@ input.filelist-checkbox:checked + table.table-filelist {
 #description-box {
 	padding-right: 14px;
 	padding-left: 14px;
+	margin-bottom: 10px;
 }
+
 #description-box div {
 	margin-top: 14px;
 	margin-bottom: 14px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -686,6 +686,10 @@ input.filelist-checkbox:checked + table.table-filelist {
 	padding-right: 14px;
 	padding-left: 14px;
 }
+#description-box div {
+	margin-top: 14px;
+	margin-bottom: 14px;
+}
 
 /* Markdown editor fixes */
 .editor-toolbar.fullscreen {


### PR DESCRIPTION
Old torrents have their description in a \<div\> instead of a \<p\>, as such the css that applied to \<p\> didn't apply to it and we'd get poor spacing like here:
![pic](https://user-images.githubusercontent.com/11745692/28048336-945b2e16-65f0-11e7-98d6-5df00960ccdc.png)

Also added some spacing after the description so that the file list wouldn't be as close