### PR TITLE
Better looking flag list on torrent page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -150,14 +150,8 @@ select.form-input {
 	padding: 10px 0 9px 7px;	
 }
 
-.language > input {
-	margin: 0 3px 6px 0;
-	padding: 0;
-}
-
-.language > label {
-	margin: 0 9px 2px 0;
-}
+.language .input-group label { margin-bottom: 1px; }
+.language span.input-group { display: inline-block; }
 
 .not-important {
 	font-size: 9pt;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -510,6 +510,9 @@ html, body {
 }
 .torrent-info-data > span { 
 	margin-right: 5px; 
+	display: inline-block;
+	width: 31%;
+	min-width: 160px;
 }
 .torrent-info-data > span > img {
 	margin-right: 3px;	

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -509,13 +509,16 @@ html, body {
 	text-overflow: ellipsis;
 }
 .torrent-info-data > span { 
-	margin-right: 5px; 
+	margin-right: 3px; 
 	display: inline-block;
+	min-width: 80px;
+}
+.torrent-info-data > span.big { 
 	width: 31%;
 	min-width: 160px;
 }
 .torrent-info-data > span > img {
-	margin-right: 3px;	
+	margin-right: 2px;	
 }
 .torrent-info-row {
 	text-align: left;

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -36,7 +36,7 @@
         <td class="tr-flag torrent-view-td torrent-info-data">
     {{ range _, language := Torrent.Languages}}
             {{ if language != "" }}
-        <span {{ if len(Torrent.Languages) > 3) }}class="big"{{ end }}><img src="/img/blank.gif" alt="{{ LanguageNameFromCode(language, T) }}" class="flag flag-{{ FlagCode(language) }}" title="{{ LanguageNameFromCode(language, T) }}"></img> {{ LanguageNameFromCode(language, T) }}</span>
+        <span {{ if len(Torrent.Languages) > 3 }}class="big"{{ end }}><img src="/img/blank.gif" alt="{{ LanguageNameFromCode(language, T) }}" class="flag flag-{{ FlagCode(language) }}" title="{{ LanguageNameFromCode(language, T) }}"></img> {{ LanguageNameFromCode(language, T) }}</span>
             {{end}}
     {{end}}
         </td>

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -36,7 +36,7 @@
         <td class="tr-flag torrent-view-td torrent-info-data">
     {{ range _, language := Torrent.Languages}}
             {{ if language != "" }}
-        <span {{ Torrent.Languages > 3 ? "class=\"big\"" : "" }}><img src="/img/blank.gif" alt="{{ LanguageNameFromCode(language, T) }}" class="flag flag-{{ FlagCode(language) }}" title="{{ LanguageNameFromCode(language, T) }}"></img> {{ LanguageNameFromCode(language, T) }}</span>
+        <span {{ if len(Torrent.Languages) > 3 }}class="big"{{ end }}><img src="/img/blank.gif" alt="{{ LanguageNameFromCode(language, T) }}" class="flag flag-{{ FlagCode(language) }}" title="{{ LanguageNameFromCode(language, T) }}"></img> {{ LanguageNameFromCode(language, T) }}</span>
             {{end}}
     {{end}}
         </td>

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -36,7 +36,7 @@
         <td class="tr-flag torrent-view-td torrent-info-data">
     {{ range _, language := Torrent.Languages}}
             {{ if language != "" }}
-        <span><img src="/img/blank.gif" alt="{{ LanguageNameFromCode(language, T) }}" class="flag flag-{{ FlagCode(language) }}" title="{{ LanguageNameFromCode(language, T) }}"></img> {{ LanguageNameFromCode(language, T) }}</span>
+        <span {{ if len(Torrent.Languages) > 3) }}class="big"{{ end }}><img src="/img/blank.gif" alt="{{ LanguageNameFromCode(language, T) }}" class="flag flag-{{ FlagCode(language) }}" title="{{ LanguageNameFromCode(language, T) }}"></img> {{ LanguageNameFromCode(language, T) }}</span>
             {{end}}
     {{end}}
         </td>

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -36,7 +36,7 @@
         <td class="tr-flag torrent-view-td torrent-info-data">
     {{ range _, language := Torrent.Languages}}
             {{ if language != "" }}
-        <span {{ if len(Torrent.Languages) > 3 }}class="big"{{ end }}><img src="/img/blank.gif" alt="{{ LanguageNameFromCode(language, T) }}" class="flag flag-{{ FlagCode(language) }}" title="{{ LanguageNameFromCode(language, T) }}"></img> {{ LanguageNameFromCode(language, T) }}</span>
+        <span {{ Torrent.Languages > 3 ? "class=\"big\"" : "" }}><img src="/img/blank.gif" alt="{{ LanguageNameFromCode(language, T) }}" class="flag flag-{{ FlagCode(language) }}" title="{{ LanguageNameFromCode(language, T) }}"></img> {{ LanguageNameFromCode(language, T) }}</span>
             {{end}}
     {{end}}
         </td>


### PR DESCRIPTION
**flag list on torrent page**: pls merge it cant post screenshots but it look good i promsie very good improvement

**flag list on upload / refine**: always look good now instead of breaking at certain specific very low res
Before:
![before](https://user-images.githubusercontent.com/11745692/28119009-9ff23368-6713-11e7-9fab-b451ed1e5d60.png)
After:
![after](https://user-images.githubusercontent.com/11745692/28119015-a324d77a-6713-11e7-8e6d-decf6074f01c.png)
