### PR TITLE
Add uploaded torrent count in user page & wider box for aesthethics

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -583,8 +583,8 @@ html, body {
 }
 .profile-content h3 { margin-bottom: 6px; margin-top: 4px;}
 .profile-content .pagination { margin-bottom: 9px;}
-.div.profile-content.box > nav > ul > li { width: 100%; }
-div.profile-content.box > nav > ul > li, nav.adminNav > ul > li {
+.div.profile-content.box > nav > ul > a > li { width: 100%; }
+div.profile-content.box > nav > ul > a > li, nav.adminNav > ul > li {
 	border-right-width: 1px;
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -478,9 +478,13 @@ html, body {
 	border-radius: 3px;
 }
 
+.profile-usertitle-name { margin-bottom: 2px; }
+.profile-usertitle-uploadcount span { font-weight: bold; }
 .profile-usertitle-job {
 	font-style: italic;
+	margin: 0;
 }
+
 .profile-userpic img {
 	border-radius: 6px;
 }
@@ -582,6 +586,7 @@ html, body {
 }
 .profile-content h3 { margin-bottom: 6px; margin-top: 4px;}
 .profile-content .pagination { margin-bottom: 9px;}
+.div.profile-content.box > nav > ul > li { width: 100%; }
 div.profile-content.box > nav > ul > li, nav.adminNav > ul > li {
 	border-right-width: 1px;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -479,11 +479,8 @@ html, body {
 }
 
 .profile-usertitle-name { margin-bottom: 2px; }
-.profile-usertitle-uploadcount span { font-weight: bold; }
-.profile-usertitle-job {
-	font-style: italic;
-	margin: 0;
-}
+.profile-usertitle-uploadcount span { font-weight: bold; margin-left: 2px;}
+.profile-usertitle-job { font-style: italic; margin: 0; }
 
 .profile-userpic img {
 	border-radius: 6px;

--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -13,6 +13,7 @@
 		<p class="profile-usertitle-job">
 			{{UserProfile.GetRole()}}
 		</p>
+		<p class="profile-usertitle-uploadcount">Torrents uploaded: <span>{{ UserProfile.Torrents }}</span></p>
 	</div>
 	<!-- END SIDEBAR USER TITLE -->
 	<!-- SIDEBAR BUTTONS -->

--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -13,7 +13,7 @@
 		<p class="profile-usertitle-job">
 			{{UserProfile.GetRole()}}
 		</p>
-		<p class="profile-usertitle-uploadcount">Torrents uploaded: <span>{{ UserProfile.Torrents }}</span></p>
+		<p class="profile-usertitle-uploadcount">Torrents uploaded:<span>{{ UserProfile.Torrents }}</span></p>
 	</div>
 	<!-- END SIDEBAR USER TITLE -->
 	<!-- SIDEBAR BUTTONS -->

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -57,7 +57,7 @@
       </table>
       <nav class="torrentNav" aria-label="Page navigation">
           <ul class="pagination">
-              <li><a href="/search?userID={{ UserProfile.ID }}" aria-label="Next"><span class="glyphicon glyphicon-add"></span> {{  T("see_more_torrents_from", UserProfile.Username) }}</a></li>
+              <a href="/search?userID={{ UserProfile.ID }}" aria-label="Next"><li><span class="glyphicon glyphicon-add"></span> {{  T("see_more_torrents_from", UserProfile.Username) }}</li></a>
           </ul>
       </nav>
     {{else}}


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/11745692/28115630-0069cade-6706-11e7-9ef6-a8732db40c4f.png)

After:

![after](https://user-images.githubusercontent.com/11745692/28115618-f21c26d4-6705-11e7-8cb7-b07823fe883b.png)

The count also includes hidden ones, someone might want to work on that
You'll also notice the profile-sidebear is off by a few pixels, i can't fix it
Also, the "See more torrents from" \<li\> is now entirely clickeable instead of just the part with text to go along with the "make it wider" change