### PR TITLE
Change link of "Torrents" user page button if not own profile or not admin

### DIFF
--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -38,7 +38,6 @@
 		{{ else }}
 			<a class="form-input btn-green" href="/search?userID={{ UserProfile.ID }}"><div class="icon-floppy"></div>{{ T("torrents")}}</a> <br>
 		{{ end }}
-		<a class="form-input btn-green" href="{{ (User.CurrentUserIdentical(UserProfile.ID) || User.CurrentOrAdmin(UserProfile.ID)) ? ("/user/" + UserProfile.ID} + "/" + UserProfile.Username) : ("/search?userID=" + UserProfile.ID) }}"><div class="icon-floppy"></div>{{ T("torrents")}}</a> <br>
 		{{if User.ID > 0 }}
 			{{ if User.CurrentUserIdentical(UserProfile.ID) }}
 				<a class="form-input" href="/notifications">{{  T("my_notifications")}}</a> <br>

--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -33,6 +33,11 @@
 	<!-- END SIDEBAR BUTTONS -->
 	<!-- SIDEBAR MENU -->
 	<div class="profile-usermenu">
+		{{ if User.ID > 0 && (User.CurrentUserIdentical(UserProfile.ID) || User.CurrentOrAdmin(UserProfile.ID)) }}
+			<a class="form-input btn-green" href="/user/{{ UserProfile.ID }}/{{ UserProfile.Username }}"><div class="icon-floppy"></div>{{ T("torrents")}}</a> <br>
+		{{ else }}
+			<a class="form-input btn-green" href="/search?userID={{ UserProfile.ID }}"><div class="icon-floppy"></div>{{ T("torrents")}}</a> <br>
+		{{ end }}
 		<a class="form-input btn-green" href="{{ (User.CurrentUserIdentical(UserProfile.ID) || User.CurrentOrAdmin(UserProfile.ID)) ? ("/user/" + UserProfile.ID} + "/" + UserProfile.Username) : ("/search?userID=" + UserProfile.ID) }}"><div class="icon-floppy"></div>{{ T("torrents")}}</a> <br>
 		{{if User.ID > 0 }}
 			{{ if User.CurrentUserIdentical(UserProfile.ID) }}

--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -33,7 +33,7 @@
 	<!-- END SIDEBAR BUTTONS -->
 	<!-- SIDEBAR MENU -->
 	<div class="profile-usermenu">
-		<a class="form-input btn-green" href="/user/{{UserProfile.ID}}/{{UserProfile.Username}}"><div class="icon-floppy"></div>{{ T("torrents")}}</a> <br>
+		<a class="form-input btn-green" href="{{ (User.CurrentUserIdentical(UserProfile.ID) || User.CurrentOrAdmin(UserProfile.ID)) ? ("/user/" + UserProfile.ID} + "/" + UserProfile.Username) : ("/search?userID=" + UserProfile.ID) }}"><div class="icon-floppy"></div>{{ T("torrents")}}</a> <br>
 		{{if User.ID > 0 }}
 			{{ if User.CurrentUserIdentical(UserProfile.ID) }}
 				<a class="form-input" href="/notifications">{{  T("my_notifications")}}</a> <br>


### PR DESCRIPTION
Because what is the point of this button
https://nyaa.pantsu.cat/user/12830/Mar974
If all it will do is refresh the page?
Now if you click it if 1. it's not your profile and 2. you aren't an admin, then you'll get to the torrent search per userID
That way it won't be an useless button and in the case the profile page's data isn't up to date (torrents not showing up), you can still do a search by user ID