### PR TITLE
 #1191

### DIFF
--- a/controllers/template_functions.go
+++ b/controllers/template_functions.go
@@ -148,9 +148,6 @@ func templateFunctions(vars jet.VarMap) jet.VarMap {
 		return "https://www.gravatar.com/avatar/" + hash + "?s=" + strconv.Itoa(size)
 	})
 
-	vars.Set("DisplayTorrent", func(t models.Torrent, u *models.User) bool {
-		return (!t.Hidden && t.Status != 0) || u.CurrentOrAdmin(t.UploaderID)
-	})
 	vars.Set("NoEncode", func(str string) template.HTML {
 		return template.HTML(str)
 	})

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -152,7 +152,7 @@ select.form-input {
 
 .language span.input-group { display: inline-block; }
 .language .input-group label { margin-bottom: 1px; }
-.language .input-group input { margin-right: 0; }
+.language .input-group input { margin-right: 4px; }
 
 .not-important {
 	font-size: 9pt;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -177,7 +177,6 @@ select.form-input {
 
 .header .h-user button:focus {outline:none; background-color: rgba(0,0,0, 0.3);}::-moz-focus-inner {border:0;}
 
-
 .header .h-user .user-avatar {
 	float: right;
 	height: 40px; width: 40px;
@@ -285,9 +284,6 @@ table {
 	table-layout: fixed;
 }
 
-
-th { height: 40px;}
-
 th,.home-td,.user-td { 
 	height: 37px; 
 	text-align: center;
@@ -329,6 +325,7 @@ th, .home-td { border-bottom:  1px solid; }
 
 th { border-bottom-width: 2px; }
 
+.hidden { opacity: 0.5; filter: grayscale(20%);}
 .tr-cat { width: 90px; text-align: center; }
 .tr-flag { white-space: initial!important; }
 .tr-name { width: auto; text-align: left; white-space: normal; word-break: break-word; font-weight: bold; }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -332,7 +332,7 @@ th { border-bottom-width: 2px; }
 .tr-cat { width: 90px; text-align: center; }
 .tr-flag { white-space: initial!important; }
 .tr-name { width: auto; text-align: left; white-space: normal; word-break: break-word; font-weight: bold; }
-.tr-links { width: 66px; overflow:initial;' }
+.tr-links { width: 66px; overflow:initial; }
 .tr-cs { width: 5px; overflow: initial; text-overflow: initial; }
 .tr-cs .comment-icon { margin-bottom: 4px; }
 .tr-size { width: 90px; }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -630,6 +630,7 @@ input#show-filelist:checked ~ #filelist {
 	width: 100%;
 }
 tr.torrentinfo { min-height: 38px; }
+thead.torrentinfo { min-height: 40px; }
 .tr-filelist {
 	--nest-level: 0;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -332,7 +332,7 @@ th { border-bottom-width: 2px; }
 .tr-cat { width: 90px; text-align: center; }
 .tr-flag { white-space: initial!important; }
 .tr-name { width: auto; text-align: left; white-space: normal; word-break: break-word; font-weight: bold; }
-.tr-links { width: 66px; }
+.tr-links { width: 66px; overflow:initial;' }
 .tr-cs { width: 5px; overflow: initial; text-overflow: initial; }
 .tr-cs .comment-icon { margin-bottom: 4px; }
 .tr-size { width: 90px; }
@@ -453,8 +453,9 @@ html, body {
 		width: 100%;
 		height: auto;
 	}
-	.tr-cat { width: 77px; }
-	.form-input.refine { display: none;}
+	.tr-cat { width: 73px; }
+	.form-input.refine { display: none; }
+	.tr-links { width: 50px; }
 }
 
 @media (maw-width: 520px) {

--- a/templates/layouts/partials/helpers/flags.jet.html
+++ b/templates/layouts/partials/helpers/flags.jet.html
@@ -2,8 +2,7 @@
 {{ if isset(languages) }}
     {{ range _, language := languages }}
         <span class="input-group">
-        <input type="checkbox" name="{{inputname}}" id="lang-{{ language.Code }}" value="{{language.Code}}"{{ range _, v := selected}}{{ if contains(v, language.Code) }} checked{{end}}{{end}}>
-        <label for="lang-{{ language.Code }}" class="flag flag-{{ language.Flag(false) }}" title="{{LanguageName(language, T)}}"></label>
+        <input type="checkbox" name="{{inputname}}" id="lang-{{ language.Code }}" value="{{language.Code}}"{{ range _, v := selected}}{{ if contains(v, language.Code) }} checked{{end}}{{end}}><label for="lang-{{ language.Code }}" class="flag flag-{{ language.Flag(false) }}" title="{{LanguageName(language, T)}}"></label>
         </span>
     {{ end }}
 {{ end }}

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -15,7 +15,7 @@
           {{ torrent := t.ToJSON() }}
           <tr class="torrent-info 
               {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}{{ if torrent.hidden }} hidden{{end}}"
-	      {{if torrent.hidden }}title="Uploaded as Anonymous"{{end}}>
+	      {{if torrent.hidden }}title="{{T("upload_as_anon")}}: {{T("yes")}}"{{end}}>
 		<td class="tr-cat user-td">
 		{{ if Sukebei }}
 			<div class="nyaa-cat sukebei-cat-{{ torrent.Category }}{{ torrent.SubCategory}}">

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -14,8 +14,7 @@
           {{ range i, t := UserProfile.Torrents }}
           {{ torrent := t.ToJSON() }}
           <tr class="torrent-info 
-              {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}">
-              <!-- forced width because the <td> gets bigger randomly otherwise -->
+              {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}{{ if t.hidden }} hidden{{end}}">
 		<td class="tr-cat user-td">
 		{{ if Sukebei }}
 			<div class="nyaa-cat sukebei-cat-{{ torrent.Category }}{{ torrent.SubCategory}}">

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -12,7 +12,6 @@
             <th class="tr-date user-td hide-xs">{{ T("date")}}</th>
           </tr>
           {{ range i, t := UserProfile.Torrents }}
-          {{ if DisplayTorrent(t, User) }}
           {{ torrent := t.ToJSON() }}
           <tr class="torrent-info 
               {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}">
@@ -52,7 +51,6 @@
               </td>
               <td class="tr-date user-td date-short hide-xs">{{torrent.Date}}</td>
           </tr>
-          {{end}}
           {{end}}
       </table>
       <nav class="torrentNav" aria-label="Page navigation">

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -14,7 +14,8 @@
           {{ range i, t := UserProfile.Torrents }}
           {{ torrent := t.ToJSON() }}
           <tr class="torrent-info 
-              {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}{{ if t.hidden }} hidden{{end}}">
+              {{if torrent.Status == 2}}remake{{else if torrent.Status == 3}}trusted{{else if torrent.Status == 4}}aplus{{end}}{{ if torrent.hidden }} hidden{{end}}"
+	      {{if torrent.hidden }}title="Uploaded as Anonymous"{{end}}>
 		<td class="tr-cat user-td">
 		{{ if Sukebei }}
 			<div class="nyaa-cat sukebei-cat-{{ torrent.Category }}{{ torrent.SubCategory}}">


### PR DESCRIPTION
Proper spacing for flags, look unchanged
Removal of useless function
Fix visual artifact for the magnet download link on listing when low <td> width
Lower \<td\> width for cat & links on mobile

Before:
![before](https://user-images.githubusercontent.com/11745692/28223427-b4eccf94-68cb-11e7-888d-4170d6861542.png)

After:
![after](https://user-images.githubusercontent.com/11745692/28223432-b9effa16-68cb-11e7-941c-c82e71a1dbae.png)

Visual cue for torrents uploaded as anonymous
![hidden](https://user-images.githubusercontent.com/11745692/28225092-b71c8a1a-68d1-11e7-9d14-e40aef489237.png)
