### PR TITLE
Automatically add flag based on keyword

### DIFF
--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -96,12 +96,25 @@ var Kilo = function (params) {
   var updatePreviewTorrentName = function (e) {
     var el = e.target
     self.setName(el.value)
+
+    var Keywords_flags= [
+	    ["vostfr","[ita]"],
+	    ["fr", "it"] ];
 	  
-    if(el.value.toLowerCase().includes("vostfr")) {
-		document.getElementById("upload-lang-fr").checked = true;
-		updateTorrentLang();
+    var torrentLowerCaseName = el.value.toLowerCase(),
+	updateLang = false;  
+	//we don't want to be running the updateLang function for every time the loop loops
+	//same for lower case
+	  
+    for(var KeywordIndex = 0; KeywordIndex < Keywords_flags[0].length; KeywordIndex++)
+	if(torrentLowerCaseName.includes(Keywords_flags[0][KeywordIndex])) {
+	   document.getElementById("upload-lang-" + Keywords_flags[1][KeywordIndex]).checked = true;
+	   updateLang = true;
 	}
+  
+     if(updateLang) updateTorrentLang();
   }
+
   var updateHidden = function (e) {
     var el = e.target
     self.setHidden(el.checked)

--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -110,8 +110,8 @@ var Kilo = function (params) {
   
   var addKeywordFlags = debounce(function(e) {
 	 var Keywords_flags= [
-	    ["vostfr","vosfr", "[ita]", "[eng]", "[jp]", "[jpn]"],
-	    ["fr","fr", "it", "en", "ja", "ja"];
+	    ["vostfr","vosfr", "[ita]", "[eng]", " eng ", "[english]", "[jp]", "[jpn]"],
+	    ["fr","fr", "it", "en", "en", "en", "ja", "ja"];
 	  
     var torrentLowerCaseName = e.toLowerCase(),
 	updateLang = false;  

--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -110,8 +110,8 @@ var Kilo = function (params) {
   
   var addKeywordFlags = debounce(function(e) {
 	 var Keywords_flags= [
-	    ["vostfr","vosfr", "[ita]"],
-	    ["fr","fr", "it"] ];
+	    ["vostfr","vosfr", "[ita]", "[eng]"],
+	    ["fr","fr", "it", "en"];
 	  
     var torrentLowerCaseName = e.toLowerCase(),
 	updateLang = false;  

--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -110,8 +110,8 @@ var Kilo = function (params) {
   
   var addKeywordFlags = debounce(function(e) {
 	 var Keywords_flags= [
-	    ["vostfr","vosfr", "[ita]", "[eng]", "[jp]"],
-	    ["fr","fr", "it", "en", "ja"];
+	    ["vostfr","vosfr", "[ita]", "[eng]", "[jp]", "[jpn]"],
+	    ["fr","fr", "it", "en", "ja", "ja"];
 	  
     var torrentLowerCaseName = e.toLowerCase(),
 	updateLang = false;  

--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -93,28 +93,30 @@ var Kilo = function (params) {
     var el = e.target
     self.setRemake(el.checked)
   }
+  
   var updatePreviewTorrentName = function (e) {
     var el = e.target
     self.setName(el.value)
-
-    var Keywords_flags= [
-	    ["vostfr","[ita]"],
-	    ["fr", "it"] ];
+	addKeywordFlags(el.value);
+  }
+  
+  var addKeywordFlags = debounce(function(e) {
+	 var Keywords_flags= [
+	    ["vostfr","vosfr", "[ita]"],
+	    ["fr","fr", "it"] ];
 	  
-    var torrentLowerCaseName = el.value.toLowerCase(),
+    var torrentLowerCaseName = e.toLowerCase(),
 	updateLang = false;  
-	//we don't want to be running the updateLang function for every time the loop loops
-	//same for lower case
-	  
+
     for(var KeywordIndex = 0; KeywordIndex < Keywords_flags[0].length; KeywordIndex++)
-	if(torrentLowerCaseName.includes(Keywords_flags[0][KeywordIndex])) {
-	   document.getElementById("upload-lang-" + Keywords_flags[1][KeywordIndex]).checked = true;
-	   updateLang = true;
-	}
+		if(torrentLowerCaseName.includes(Keywords_flags[0][KeywordIndex])) {
+		   document.getElementById("upload-lang-" + Keywords_flags[1][KeywordIndex]).checked = true;
+		   updateLang = true;
+		}
   
      if(updateLang) updateTorrentLang();
-  }
-
+  }, 300);
+  
   var updateHidden = function (e) {
     var el = e.target
     self.setHidden(el.checked)
@@ -143,3 +145,18 @@ var Kilo = function (params) {
     document.getElementsByClassName('table-torrent-flag')[0].title = langTitle
   }
 }
+
+function debounce(func, wait, immediate) {
+	var timeout;
+	return function() {
+		var context = this, args = arguments;
+		var later = function() {
+			timeout = null;
+			if (!immediate) func.apply(context, args);
+		};
+		var callNow = immediate && !timeout;
+		clearTimeout(timeout);
+		timeout = setTimeout(later, wait);
+		if (callNow) func.apply(context, args);
+	};
+};

--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -96,6 +96,11 @@ var Kilo = function (params) {
   var updatePreviewTorrentName = function (e) {
     var el = e.target
     self.setName(el.value)
+	  
+    if(el.value.toLowerCase().includes("vostfr")) {
+		document.getElementById("upload-lang-fr").checked = true;
+		updateTorrentLang();
+	}
   }
   var updateHidden = function (e) {
     var el = e.target

--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -110,8 +110,8 @@ var Kilo = function (params) {
   
   var addKeywordFlags = debounce(function(e) {
 	 var Keywords_flags= [
-	    ["vostfr","vosfr", "[ita]", "[eng]"],
-	    ["fr","fr", "it", "en"];
+	    ["vostfr","vosfr", "[ita]", "[eng]", "[jp]"],
+	    ["fr","fr", "it", "en", "ja"];
 	  
     var torrentLowerCaseName = e.toLowerCase(),
 	updateLang = false;  


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/11745692/28265678-43c3bc88-6af1-11e7-9317-8f5b575d738f.png)
We get a pretty decent amount of french torrents and i'm fairly sure the "VOSTFR" keyword is unique enough to automatically put the french flag should the user add this keyword to his torrent
Same goes for [ITA], unique enough and gets enough uploads to make it into there
We could do this in Go, but i very much hate the idea of adding flags to a torrent without the user being aware of it. You can do that on scraped torrents if you want but don't on user-uploaded ones.
Removing the keywords does not remove the flags as it would be annoying afterward should an user copy paste a torrent name and modify it to his liking