### PR TITLE
Proper sizing & padding for tr-links and tr-cs

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -452,7 +452,7 @@ html, body {
 	}
 	.tr-cat { width: 73px; }
 	.torrent-preview-table .tr-cat { width: 74px; }
-	.tr-links { width: 50px; }
+	.tr-links { width: 48px; }
 	.header .h-search input { width: 90px !important; }
 	.header .h-search input:focus { width: 150px !important; }
 	.box { padding: 9px; }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -331,8 +331,8 @@ th { border-bottom-width: 2px; }
 .tr-cat { width: 90px; text-align: center; }
 .tr-flag { white-space: initial!important; }
 .tr-name { width: auto; text-align: left; white-space: normal; word-break: break-word; font-weight: bold; }
-.tr-links { width: 66px; overflow:initial; }
-.tr-cs { width: 5px; overflow: initial; text-overflow: initial; }
+.tr-links { width: 55px; overflow:initial; text-align: left; padding-left: 2px; }
+.tr-cs { width: 15px; overflow: initial; text-overflow: initial; padding: 0; }
 .tr-cs .comment-icon { margin-bottom: 4px; }
 .tr-size { width: 90px; }
 .tr-se, .tr-le { font-weight: bold; }


### PR DESCRIPTION
tr-cs was 100% padding before so it didn't display anywhere where it should be, and tr-links was way bigger than it needed to be, and the whole thing took much more place than what it should have
Before
![before](https://user-images.githubusercontent.com/11745692/28270227-0a329eee-6b05-11e7-83e3-0b386ea6ef02.png)
After
![after](https://user-images.githubusercontent.com/11745692/28270229-0bb4d05c-6b05-11e7-82ed-db39915349a0.png)

Before
![before](https://user-images.githubusercontent.com/11745692/28270338-70c6f34e-6b05-11e7-8a9f-9bc6d647bdc4.png)
After
![after](https://user-images.githubusercontent.com/11745692/28270343-735b8b74-6b05-11e7-90f0-762b9edca342.png)
