### PR TITLE
Lower size for date row & some other css stuff

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -331,7 +331,7 @@ th { border-bottom-width: 2px; }
 .tr-cat { width: 90px; text-align: center; }
 .tr-flag { white-space: initial!important; }
 .tr-name { width: auto; text-align: left; white-space: normal; word-break: break-word; font-weight: bold; }
-.tr-links { width: 55px; overflow:initial; text-align: left; padding-left: 2px; }
+.tr-links { width: 50px; overflow:initial; text-align: left; padding: 0 2px!important; }
 .tr-cs { width: 15px; overflow: initial; text-overflow: initial; padding: 0; }
 .tr-cs .comment-icon { margin-bottom: 4px; }
 .tr-size { width: 90px; }
@@ -339,6 +339,7 @@ th { border-bottom-width: 2px; }
 .tr-se, .tr-le, .tr-dl { width: 50px; }
 .tr-date { width: 124px; }
 
+.tr-links >a > div { width: 17.63px; }
 .tr-se > a > .sort-arrows,
 .tr-le > a > .sort-arrows,
 .tr-dl > a > .sort-arrows { margin-left: 0; }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -337,7 +337,7 @@ th { border-bottom-width: 2px; }
 .tr-size { width: 90px; }
 .tr-se, .tr-le { font-weight: bold; }
 .tr-se, .tr-le, .tr-dl { width: 50px; }
-.tr-date { width: 130px; }
+.tr-date { width: 124px; }
 
 .tr-se > a > .sort-arrows,
 .tr-le > a > .sort-arrows,

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -424,6 +424,8 @@ html, body {
 	.visible-md { display: block }
 }
 
+.results.box > table > thead.torrent-info > tr  { height: 40px; }
+
 @media (max-width: 810px) {
 	.torrent-info-row > td {
 		display: block;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -331,7 +331,7 @@ th { border-bottom-width: 2px; }
 .tr-cat { width: 90px; text-align: center; }
 .tr-flag { white-space: initial!important; }
 .tr-name { width: auto; text-align: left; white-space: normal; word-break: break-word; font-weight: bold; }
-.tr-links { width: 50px; overflow:initial; text-align: left; padding: 0 2px!important; }
+.tr-links { width: 51px; overflow:initial; text-align: left; padding: 0 2px!important; }
 .tr-cs { width: 15px; overflow: initial; text-overflow: initial; padding: 0; }
 .tr-cs .comment-icon { margin-bottom: 4px; }
 .tr-size { width: 90px; }


### PR DESCRIPTION
Before:
![pic](https://user-images.githubusercontent.com/11745692/28289453-f87efc0e-6b42-11e7-87dd-f2fd8087d851.png)

After:
![after](https://user-images.githubusercontent.com/11745692/28289465-fcd138c6-6b42-11e7-9313-e4d55b651972.png)

Also can't see it in this picture but the links are slightly less spaced together and slightly closer to the torrent stats