### PR TITLE
Fix padding of torrent list on mobile & torrent preview stuff

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -998,16 +998,16 @@ input.nav-btn {
 .rules-drop {
 	display: flex;
 	user-select: none;
-	cursor: pointer;
 	vertical-align: bottom;
-	width: 432px;
-	max-width:100%;
+	width: 429px
+	max-width: 100%;
+}
+.rules-drop > summary {
+	cursor: pointer;
 }
 .rules-drop > div {
 	display: inline-block;
 	height: auto;
-	width: 429px;
-	max-width: 100%;
 	border: 1px solid black;
 	padding: 0;
 	border-top: none;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -459,7 +459,7 @@ html, body {
 	.tr-links { width: 48px; }
 	.header .h-search input { width: 90px !important; }
 	.header .h-search input:focus { width: 150px !important; }
-	.box { padding: 9px; }
+	.box { padding: 8px; }
 	th, .home-td, .user-td { padding: 2px 2px; }
 }
 
@@ -1030,7 +1030,7 @@ summary:after {
 }
 details[open] summary:after {
 	content: "-";
-	margin: -4px 5px 0 0;
+	margin: -5px 5px 0 0;
 }
 .torrent-preview-table > table { border: 3px solid #dfdeeb; }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -278,7 +278,7 @@ select.form-input {
 	padding: 10px 5px;
 }
 
-.results { padding: 0 }
+.results { padding: 0!important; }
 
 table {
 	border-collapse:collapse;
@@ -453,6 +453,7 @@ html, body {
 		width: 100%;
 		height: auto;
 	}
+	.box { padding: 7px; }
 	.tr-cat { width: 71px; }
 	.torrent-preview-table .tr-cat { width: 74px; }
 	.tr-links { width: 48px; }
@@ -465,6 +466,7 @@ html, body {
 @media (max-width: 520px) {
 	.form-input.language { width: 281px; }	
 	.form-input.refine { display: none; }
+	.tr-links { width: 44px; }
 }
 
 .up-input {
@@ -1000,11 +1002,13 @@ input.nav-btn {
 	cursor: pointer;
 	vertical-align: bottom;
 	width: 432px;
+	max-width:100%;
 }
 .rules-drop > div {
 	display: inline-block;
 	height: auto;
 	width: 429px;
+	max-width: 100%;
 	border: 1px solid black;
 	padding: 0;
 	border-top: none;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -410,18 +410,16 @@ html, body {
 
 /* hide the username */
 @media (max-width: 1100px)  {
-	.header .h-user { width: 58px; padding-left: 0px; }
+	.header .h-user { width: 58px; }
 	.header .h-user .user-menu { right: 100px; }
 	.header .h-user .user-info { display: none; }
-	.header .h-user .nav-btn { padding: 0px; }
+	.header .h-user .nav-btn { padding: 0px; width: 46px; }
 }
 
 @media (min-width: 960px)  { .visible-md { display: none } }
 
 @media (max-width: 960px)  {
-	.hide-md {
-		display: none;
-	}
+	.hide-md { display: none; }
 	.visible-md { display: block }
 }
 
@@ -453,6 +451,7 @@ html, body {
 		width: 100%;
 		height: auto;
 	}
+	.header .h-user { width: 46px; }
 	.box { padding: 7px; }
 	.tr-cat { width: 71px; }
 	.torrent-preview-table .tr-cat { width: 74px; }

--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -89,7 +89,7 @@ var Kilo = function (params) {
         for (var i = 0; i < l; i++) {
           torrentHTML.push(Templates.Render('torrents.item', torrents[i]))
         }
-        document.getElementById("torrentListResults").innerHTML = torrentHTML[0] + document.getElementById("torrentListResults").innerHTML + torrentHTML[1]
+        document.getElementById("torrentListResults").innerHTML = torrentHTML[0] + document.getElementsByName("torrent-info tr")[0].outerHTML + torrentHTML[1]
       })
     }
   }

--- a/public/js/kilo.js
+++ b/public/js/kilo.js
@@ -89,7 +89,7 @@ var Kilo = function (params) {
         for (var i = 0; i < l; i++) {
           torrentHTML.push(Templates.Render('torrents.item', torrents[i]))
         }
-        document.getElementById("torrentListResults").innerHTML = torrentHTML[0] + document.getElementsByName("torrent-info tr")[0].outerHTML + torrentHTML[1]
+        document.getElementById("torrentListResults").innerHTML = torrentHTML[0] + document.getElementById("torrentListResults").innerHTML + torrentHTML[1]
       })
     }
   }

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -5,8 +5,8 @@
 {{block title()}}{{ T("upload")}}{{end}}
 {{block content_body()}}
 <div style="text-align: left;" class="box">
-	<details class="rules-drop">
-		<summary class="form-input">{{ T("rules")}}</summary>
+	<details>
+		<summary class="form-input rules-drop">{{ T("rules")}}</summary>
 	    	<div class="form-input">
 		    <ul>
 		    	<li>{{ T("no_cp")}}</li>
@@ -38,6 +38,16 @@
           </tr>
           </thead>
           <tbody id="torrentListResults">
+			<tr class="torrent-info hidden">
+				<td class="tr-cat home-td"></td>
+				<td class="tr-name home-td" colspan="2"><a></a></td>
+				<td class="tr-links home-td"></td>
+						  <td class="tr-size home-td hide-xs"></td>
+						  <td class="tr-se home-td hide-xs"></td>
+						  <td class="tr-le home-td hide-xs"></td>
+						  <td class="tr-dl home-td hide-xs"></td>
+						  <td></td>
+			</tr>
         	<tr name="torrent-info tr" class="torrent-info{{ if User.IsTrusted() }} trusted{{end}}">
               		<td class="tr-cat home-td">
 				<div class="nyaa-cat table-torrent-category">
@@ -57,6 +67,16 @@
 		      <td class="tr-dl home-td hide-xs">0</td>
 		      <td class="tr-date home-td date-short hide-xs table-torrent-date" title="2017-07-12T16:58:29Z">Jul 12, 2017</td>
 		  </tr>
+			<tr class="torrent-info hidden">
+				<td class="tr-cat home-td"></td>
+				<td class="tr-name home-td" colspan="2"><a></a></td>
+				<td class="tr-links home-td"></td>
+						  <td class="tr-size home-td hide-xs"></td>
+						  <td class="tr-se home-td hide-xs"></td>
+						  <td class="tr-le home-td hide-xs"></td>
+						  <td class="tr-dl home-td hide-xs"></td>
+						  <td></td>
+			</tr>
           </tbody>
 		</table></div>
 

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -38,7 +38,7 @@
           </tr>
           </thead>
           <tbody id="torrentListResults">
-			<tr class="torrent-info">
+			<tr class="torrent-info hidden">
 								<td class="tr-cat home-td">
 							<div class="nyaa-cat nyaa-cat-2" title="Software - Games">
 							<a class="category"></a>
@@ -76,7 +76,7 @@
 		      <td class="tr-dl home-td hide-xs">0</td>
 		      <td class="tr-date home-td date-short hide-xs table-torrent-date" title="2017-07-12T16:58:29Z">Jul 12, 2017</td>
 		  </tr>
-		<tr class="torrent-info">
+		<tr class="torrent-info hidden">
 							<td class="tr-cat home-td">
 						<div class="nyaa-cat nyaa-cat-3" title="Audio - Lossless">
 						<a class="category"></a>

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -5,8 +5,8 @@
 {{block title()}}{{ T("upload")}}{{end}}
 {{block content_body()}}
 <div style="text-align: left;" class="box">
-	<details>
-		<summary class="form-input rules-drop">{{ T("rules")}}</summary>
+	<details class="rules-drop">
+		<summary class="form-input">{{ T("rules")}}</summary>
 	    	<div class="form-input">
 		    <ul>
 		    	<li>{{ T("no_cp")}}</li>

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -38,25 +38,6 @@
           </tr>
           </thead>
           <tbody id="torrentListResults">
-			<tr class="torrent-info hidden">
-								<td class="tr-cat home-td">
-							<div class="nyaa-cat nyaa-cat-2" title="Software - Games">
-							<a class="category"></a>
-							<a><img src="/img/blank.gif" class="flag flag-en" title="English"></a>
-									 </div>
-								 </td>
-								<td class="tr-name home-td" colspan="2"><a>Example torrent #1</a></td>
-					  
-						  <td class="tr-links home-td">
-						  <a title="Magnet Link"><div class="icon-magnet"></div></a>
-						  <a title="Torrent file"><div class="icon-floppy"></div></a>
-						  </td>
-						  <td class="tr-size home-td hide-xs">324.8 MiB</td>
-						  <td class="tr-se home-td hide-xs">0</td>
-						  <td class="tr-le home-td hide-xs">0</td>
-						  <td class="tr-dl home-td hide-xs">0</td>
-						  <td class="tr-date home-td date-short hide-xs table-torrent-date" title="2017-07-19T11:54:42.189Z">Jul 19, 2017</td>
-		  </tr>
         	<tr name="torrent-info tr" class="torrent-info{{ if User.IsTrusted() }} trusted{{end}}">
               		<td class="tr-cat home-td">
 				<div class="nyaa-cat table-torrent-category">
@@ -75,24 +56,6 @@
 		      <td class="tr-le home-td hide-xs">0</td>
 		      <td class="tr-dl home-td hide-xs">0</td>
 		      <td class="tr-date home-td date-short hide-xs table-torrent-date" title="2017-07-12T16:58:29Z">Jul 12, 2017</td>
-		  </tr>
-		<tr class="torrent-info hidden">
-							<td class="tr-cat home-td">
-						<div class="nyaa-cat nyaa-cat-3" title="Audio - Lossless">
-						<a class="category"></a>
-								 </div>
-							 </td>
-							<td class="tr-name home-td" colspan="2"><a>Example torrent #2</a></td>
-				  
-					  <td class="tr-links home-td">
-					  <a title="Magnet Link"><div class="icon-magnet"></div></a>
-					  <a title="Torrent file"><div class="icon-floppy"></div></a>
-					  </td>
-					  <td class="tr-size home-td hide-xs">570.4 MiB</td>
-					  <td class="tr-se home-td hide-xs">0</td>
-					  <td class="tr-le home-td hide-xs">0</td>
-					  <td class="tr-dl home-td hide-xs">0</td>
-					  <td class="tr-date home-td date-short hide-xs table-torrent-date" title="Jul 12, 2017">Jul 12, 2017</td>
 		  </tr>
           </tbody>
 		</table></div>

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -38,6 +38,25 @@
           </tr>
           </thead>
           <tbody id="torrentListResults">
+			<tr class="torrent-info">
+								<td class="tr-cat home-td">
+							<div class="nyaa-cat nyaa-cat-2" title="Software - Games">
+							<a class="category"></a>
+							<a><img src="/img/blank.gif" class="flag flag-en" title="English"></a>
+									 </div>
+								 </td>
+								<td class="tr-name home-td" colspan="2"><a>Example torrent #1</a></td>
+					  
+						  <td class="tr-links home-td">
+						  <a title="Magnet Link"><div class="icon-magnet"></div></a>
+						  <a title="Torrent file"><div class="icon-floppy"></div></a>
+						  </td>
+						  <td class="tr-size home-td hide-xs">324.8 MiB</td>
+						  <td class="tr-se home-td hide-xs">0</td>
+						  <td class="tr-le home-td hide-xs">0</td>
+						  <td class="tr-dl home-td hide-xs">0</td>
+						  <td class="tr-date home-td date-short hide-xs table-torrent-date" title="2017-07-19T11:54:42.189Z">Jul 19, 2017</td>
+		  </tr>
         	<tr name="torrent-info tr" class="torrent-info{{ if User.IsTrusted() }} trusted{{end}}">
               		<td class="tr-cat home-td">
 				<div class="nyaa-cat table-torrent-category">
@@ -56,6 +75,24 @@
 		      <td class="tr-le home-td hide-xs">0</td>
 		      <td class="tr-dl home-td hide-xs">0</td>
 		      <td class="tr-date home-td date-short hide-xs table-torrent-date" title="2017-07-12T16:58:29Z">Jul 12, 2017</td>
+		  </tr>
+		<tr class="torrent-info">
+							<td class="tr-cat home-td">
+						<div class="nyaa-cat nyaa-cat-3" title="Audio - Lossless">
+						<a class="category"></a>
+								 </div>
+							 </td>
+							<td class="tr-name home-td" colspan="2"><a>Example torrent #2</a></td>
+				  
+					  <td class="tr-links home-td">
+					  <a title="Magnet Link"><div class="icon-magnet"></div></a>
+					  <a title="Torrent file"><div class="icon-floppy"></div></a>
+					  </td>
+					  <td class="tr-size home-td hide-xs">570.4 MiB</td>
+					  <td class="tr-se home-td hide-xs">0</td>
+					  <td class="tr-le home-td hide-xs">0</td>
+					  <td class="tr-dl home-td hide-xs">0</td>
+					  <td class="tr-date home-td date-short hide-xs table-torrent-date" title="Jul 12, 2017">Jul 12, 2017</td>
 		  </tr>
           </tbody>
 		</table></div>


### PR DESCRIPTION
padding: 0 was getting overwritten by the @media .box rule so i made it into !important
Also lowered the @media 810px box rule by one pixels so that it looks slightly better on upload and other pages
Some fixes related to the rules width on upload so that it doesn't break on tiny screens too
And some space saving for mobile on link column
Also the details minus sign is more aligned with the text in front of it
Additionally in torrent preview, two examples torrents are already there when the page is loaded and they get replaced with real ones afterward

![before](https://user-images.githubusercontent.com/11745692/28364210-c2ad8e0a-6c83-11e7-837f-e34f3f1566ab.png)
After
![after](https://user-images.githubusercontent.com/11745692/28364263-fcde0622-6c83-11e7-9922-cbbd24d9b20b.png)


![before](https://user-images.githubusercontent.com/11745692/28364380-880fb470-6c84-11e7-9777-25b3fb3c8b22.png)
After
![after](https://user-images.githubusercontent.com/11745692/28364383-8ade0a8a-6c84-11e7-8329-7d9120f39761.png)
