### PR TITLE
Better looking borders for user avatar & fix firefox bug

### DIFF
--- a/public/css/g.css
+++ b/public/css/g.css
@@ -20,7 +20,7 @@ a:hover { color:  #444; }
 
 .header .h-user .user-avatar {
 	background: #99BFD0;
-	border-color: #9ab8c2;
+	border-color: #a3c7d3;
 }
 .header .h-user .user-menu {
 	background: #BDE0EF;

--- a/public/css/g.css
+++ b/public/css/g.css
@@ -20,7 +20,7 @@ a:hover { color:  #444; }
 
 .header .h-user .user-avatar {
 	background: #99BFD0;
-	border-color: #adc1c8;
+	border-color: #9ab8c2;
 }
 .header .h-user .user-menu {
 	background: #BDE0EF;

--- a/public/css/g.css
+++ b/public/css/g.css
@@ -20,7 +20,7 @@ a:hover { color:  #444; }
 
 .header .h-user .user-avatar {
 	background: #99BFD0;
-	border-color: #1d6d90;
+	border-color: #b6c3c8;
 }
 .header .h-user .user-menu {
 	background: #BDE0EF;

--- a/public/css/g.css
+++ b/public/css/g.css
@@ -20,7 +20,7 @@ a:hover { color:  #444; }
 
 .header .h-user .user-avatar {
 	background: #99BFD0;
-	border-color: #b6c3c8;
+	border-color: #adc1c8;
 }
 .header .h-user .user-menu {
 	background: #BDE0EF;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -598,7 +598,6 @@ html, body {
 }
 .profile-main {
 	display: flex;
-	justify-content: space-between;
 }
 .profile-content {
 	width: 77%;


### PR DESCRIPTION
Granted, it specifically looked bad here because of the light background of my picture, but having really dark borders on such light colors (header background) really isn't aesthethical anyway. It makes sense for important stuff but the user avatar's borders need to be light / soft, it needs to blend with the background as to not draw eye attention, and this is what this change does

![before](https://user-images.githubusercontent.com/11745692/28397927-dc47ab8a-6d04-11e7-9b2d-388e0f7ca453.png)
After
![after](https://user-images.githubusercontent.com/11745692/28397928-de2807e2-6d04-11e7-94a6-170b046d4777.png)

Here is look with default avatar (after):
![pic](https://user-images.githubusercontent.com/11745692/28398077-c17ef780-6d05-11e7-8d00-4118eb4a739e.png)

Also, fix of this firefox bug display on small width:
![pic](https://user-images.githubusercontent.com/11745692/28398209-6a338d82-6d06-11e7-9b1e-5964f2e5ff12.png)

