### PR TITLE
Megumeme less visible, better torrent-info-box borders

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1016,12 +1016,8 @@ input.nav-btn {
 	border-top: none;
 }
 .rules-drop > div > ul { margin: 0; margin-right: 15px; }
-.refine-btn {
-	width: 30%;
-}
-summary::-webkit-details-marker {
-	display: none
-}
+summary { display: block; }
+summary::-webkit-details-marker { display: none }
 summary:after {
 	vertical-align: middle;
 	float: left;
@@ -1034,6 +1030,7 @@ details[open] summary:after {
 	content: "-";
 	margin: -5px 5px 0 0;
 }
+.refine-btn { width: 30%; }
 .torrent-preview-table > table { border: 3px solid #dfdeeb; }
 
 .nyaa-cat { background: url('/img/categories.png') no-repeat; background-position-x: right!important; max-width: 80px; min-width: 67px; height: 28px; display: block; }

--- a/public/css/tomorrow.css
+++ b/public/css/tomorrow.css
@@ -14,7 +14,7 @@ a:hover { color:  #5F89AC; }
 .header .nav-btn { color: #c5c8c6; }
 .header .nav-btn:hover { color: #eee; }
 
-.box, .pagination li { background: hsla(222, 8%, 20%, 0.8); border-color: #141517 !important; }
+.box, .pagination li { background: hsla(222, 8%, 20%, 0.85); border-color: #141517 !important; }
 
 .form-input { border-color: #0C0D0E !important; background: #141517; color: #c5c8c6; }
 
@@ -100,3 +100,4 @@ td.tr-le, .error-text { color: #cc6666; }
 .form-input.language { background-color: #35363c; }
 
 .torrent-info-box > p > a, .torrent-info-box > div > a, #description-box a { text-decoration: none; }
+.torrent-info-box { border-color: #53565e; }


### PR DESCRIPTION
![before](https://user-images.githubusercontent.com/11745692/28416861-00ec58c2-6d56-11e7-9a88-ec9b3bf9367c.png)
After
![after](https://user-images.githubusercontent.com/11745692/28416863-046220d6-6d56-11e7-9f9c-da41da6525b4.png)

Removal of firefox's default marker for \<summary\>
![marker](https://user-images.githubusercontent.com/11745692/28417217-836996d8-6d57-11e7-9e48-aae4821ecd7c.png)
