### PR TITLE
AAAAAA

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -132,7 +132,7 @@ select.form-input {
 	position: relative;
  	padding: 0;
  	width: 16px;
-    	height: 26px;
+    	height: 24px;
 	box-shadow: none;
 	border: none;
 	vertical-align: middle;

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -66,7 +66,7 @@
   {{else}}
   <p>{{  T("no_description") }}</p>
   {{end}}
-  <input type="checkbox" id="show-filelist" {{if len(Torrent.FileList) < 4 && len(Torrent.FileList) != 0}}checked{{end}}>
+  <input type="checkbox" id="show-filelist" {{if len(Torrent.FileList) < 4 && len(Torrent.FileList) > 1}}checked{{end}}>
   <label class="torrent-hr filelist-control{{if len(Torrent.FileList) == 0}} hidden{{end}}" for="show-filelist">{{ T("files")}}</label>
   <div class="torrent-info-box{{if len(Torrent.FileList) == 0}} hidden{{end}}" id="filelist">
     {{ if len(Torrent.FileList) > 0 }}


### PR DESCRIPTION
No point in showing the filelist by default if there's only 1 file (so it only does it at 2 & 3 files now)
Fix height of "loop icon" (lmao akuma) to not overlap the borders (happened in some rare cases)