### PR TITLE
Fix flag label not working in edit.html & admin edit.html

### DIFF
--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -59,7 +59,7 @@
             {{ T("old")}}.
         </span>
         <div name="language" class="form-refine form-input language">
-            {{ yield flagList(languages=GetTorrentLanguages(), selected=Search.Languages, inputname="lang")}}
+            {{ yield flagList(languages=GetTorrentLanguages(), selected=Search.Languages, inputname="lang", id="refine-search")}}
         </div>
         <button type="submit" class="form-input refine-btn" name="refine" value="1">{{  T("refine")}}</button>
     </form>


### PR DESCRIPTION
The labels had the same ID as the flags in the refine search form (that is included in every single page), as such they would not work and would instead check the refine flags
Refine flags & labels have their own ID now so everything is good