### PR TITLE
Japanese-specific css for header, fix of wrong class

### DIFF
--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -7,7 +7,7 @@
   <tr class="torrent-info">
     <th class="tr-cat user-td">{{ T("category")}}</th>
     <th class="tr-name user-td">{{ T("name")}}</th>
-    <th class="tr-dl user-td">{{ T("links")}}</th>
+    <th class="tr-links user-td">{{ T("links")}}</th>
     <th class="tr-size user-td hide-xs">{{ T("size")}}</th>
     <th class="tr-date user-td hide-xs">{{ T("date")}}</th>
   </tr>


### PR DESCRIPTION
Before
![before](https://user-images.githubusercontent.com/11745692/28546664-d6cebf0c-70cb-11e7-9dee-d1afb170893d.png)
After
![after](https://user-images.githubusercontent.com/11745692/28546668-d9d50a1c-70cb-11e7-9e05-9bde1fa62e38.png)
