### PR TITLE
Fix display of invalid scraping date

### DIFF
--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -47,7 +47,7 @@
       <td class="torrent-info-td torrent-info-label">{{ T("size")}}:</td>
       <td class="torrent-view-td torrent-info-data">{{ fileSize(Torrent.Filesize, T) }}</td>
       <td class="torrent-info-td torrent-info-label">{{ T("last_scraped")}}</td>
-      <td class="torrent-info-td{{if !Torrent.LastScrape.IsZero}} date-full">{{formatDateRFC(Torrent.LastScrape)}}{{else}}">{{ T("unknown")}}{{end}}</td>
+      <td class="torrent-info-td{{if !Torrent.LastScrape.IsZero && formatDateRFC(Torrent.LastScrape) != "0001-01-01T00:00:00Z"}} date-full">{{formatDateRFC(Torrent.LastScrape)}}{{else}}">{{ T("unknown")}}{{end}}</td>
     </tr>
     {{ if len(Torrent.Languages) > 0 && Torrent.Languages[0] != "" }}
     <tr class="torrent-info-row">


### PR DESCRIPTION
Every single torrent show 0001-01-01T00:00:00Z as the scraping date which is obviously wrong. This change will now show "uknown" when the date is invalid, aka when the stat scraper is dead, aka all the time
Could be done in a better way, like actually doing that check in the IsZero function.