### PR TITLE
Background-color for refine button, better category borders for tomorrow, some other css stuff

### DIFF
--- a/public/css/classic.css
+++ b/public/css/classic.css
@@ -48,6 +48,12 @@ a:hover {
     background: #fafafa;
     color: #666;
 }
+.form-input.refine {
+    border-color: rgb(74, 92, 193)!important;
+    background: rgb(74, 92, 193);
+    color: white;
+}
+
 
 .btn:hover, .up-btn:hover {
     background: rgba(192, 192, 192, 0.2);

--- a/public/css/classic.css
+++ b/public/css/classic.css
@@ -166,3 +166,4 @@ td.tr-le, .error-text {
 .form-input.language {
     background-color: #f5f5f5;
 }
+.torrent-preview-table>table { border: 3px solid #ededed; }

--- a/public/css/g.css
+++ b/public/css/g.css
@@ -46,6 +46,9 @@ a:hover {
     background: #fff;
     color: #676767;
 }
+.form-input.refine {
+    background: #ffdaa3;
+}
 
 .header .h-user .user-avatar {
     background: #99BFD0;

--- a/public/css/g.css
+++ b/public/css/g.css
@@ -47,7 +47,7 @@ a:hover {
     color: #676767;
 }
 .form-input.refine {
-    background: #ffdfb0;
+    background: #FFE2B8;
 }
 
 .header .h-user .user-avatar {

--- a/public/css/g.css
+++ b/public/css/g.css
@@ -47,7 +47,7 @@ a:hover {
     color: #676767;
 }
 .form-input.refine {
-    background: #ffdaa3;
+    background: #ffdfb0;
 }
 
 .header .h-user .user-avatar {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -163,17 +163,17 @@ select.form-input {
 }
 
 .form-input.search-box {
-    margin-right: -20px;
+    margin-right: -26px;
     padding-right: 20px;
 }
 
 .form-input.search-box+.icon-search {
-    left: -5px;
+    left: -1px;
     top: -1px;
     position: relative;
     padding: 0;
-    width: 16px;
-    height: 24px;
+    width: 22px;
+    height: 25px;
     box-shadow: none;
     border: none;
     vertical-align: middle;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1435,22 +1435,21 @@ summary {
     display: block;
 }
 
-summary::-webkit-details-marker {
-    display: none
-}
+summary::-webkit-details-marker { display: none }
 
 summary:after {
     vertical-align: middle;
     float: left;
-    margin: -3px 5px 0 0;
+    margin: -1px 5px 0 0;
     content: "+";
+    width: 12px;
     font-size: 1.5em;
     font-weight: bold;
 }
 
 details[open] summary:after {
     content: "-";
-    margin: -1% 5px 0 0;
+    margin: -1% 3px 0px 2px;
 }
 
 .refine-btn {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -612,8 +612,11 @@ html, body {
 /* holy fucking shit fuck responsive design */
 
 
-/* hide the username */
+@media (min-width: 2560px) { 
+    .container { max-width: 60%!important; }
+}
 
+/* hide the username */
 @media (max-width: 1100px) {
     .header .h-user {
         width: 58px;

--- a/public/css/tomorrow.css
+++ b/public/css/tomorrow.css
@@ -42,7 +42,11 @@ a:hover {
     background: #141517;
     color: #c5c8c6;
 }
-
+.form-input.refine {
+    border-color: #151514!important;
+    background: #2d2f34;
+    color: #bbbbbb;
+}
 .header .h-user .user-avatar {
     background: #99BFD0;
     border-color: #282A2E;

--- a/public/css/tomorrow.css
+++ b/public/css/tomorrow.css
@@ -43,8 +43,8 @@ a:hover {
     color: #c5c8c6;
 }
 .form-input.refine {
-    border-color: #151514!important;
-    background: #2d2f34;
+    border-color: #1c1c1c!important
+    background: #343434;
     color: #bbbbbb;
 }
 .header .h-user .user-avatar {

--- a/public/css/tomorrow.css
+++ b/public/css/tomorrow.css
@@ -190,3 +190,4 @@ td.tr-le, .error-text {
     border-color: #53565e;
 }
 .tr-cat div.nyaa-cat { border-color: #232324!important; }
+.torrent-preview-table > table { border: 2px solid #1a1a1d; }

--- a/public/css/tomorrow.css
+++ b/public/css/tomorrow.css
@@ -189,3 +189,4 @@ td.tr-le, .error-text {
 .torrent-info-box {
     border-color: #53565e;
 }
+.tr-cat div.nyaa-cat { border-color: #232324!important; }

--- a/templates/layouts/partials/helpers/flags.jet.html
+++ b/templates/layouts/partials/helpers/flags.jet.html
@@ -1,7 +1,8 @@
 {{ block flagList(languages=nil, selected="", inputname="languages", id="lang")}}
 {{ if isset(languages) }}
-{{ range _, language := languages }}
-<span class="input-group"><span name="{{id}}-languagename">{{LanguageName(language, T)}}</span><input type="checkbox" name="{{inputname}}" class="form-language-checkbox" id="{{id}}-{{ language.Code }}" value="{{language.Code}}"{{ range _, v := selected}}{{ if contains(v, language.Code) }} checked{{end}}{{end}}><label for="{{id}}-{{ language.Code }}" class="flag flag-{{ language.Flag(false) }}" title="{{LanguageName(language, T)}}"></label></span>
-{{ end }}
+{{ range _, language := languages }}<span class="input-group">
+<span name="{{id}}-languagename">{{LanguageName(language, T)}}</span>
+<input type="checkbox" name="{{inputname}}" class="form-language-checkbox" id="{{id}}-{{ language.Code }}" value="{{language.Code}}"{{ range _, v := selected}}{{ if contains(v, language.Code) }} checked{{end}}{{end}}><label for="{{id}}-{{ language.Code }}" class="flag flag-{{ language.Flag(false) }}" title="{{LanguageName(language, T)}}"></label>
+</span>{{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
A problem with the refine button was that it didn't stand out enough, it's position made it look like a search button and even i once made the mistake of thinking it was one and using it to trigger the search. These changes aim to bring visual cues showing that the refine button is a **seperate** element from the regular search as to avoid these kinds of user-mistakes.

![g](https://user-images.githubusercontent.com/11745692/28650127-d74272d0-7279-11e7-8592-88ac3b3ab672.png)
![classic](https://user-images.githubusercontent.com/11745692/28650129-d90444ae-7279-11e7-9368-4478675fe777.png)
![tomorrow](https://user-images.githubusercontent.com/11745692/28650131-db2a1f42-7279-11e7-9343-7a93fa79b5f6.png)

The colors could be improved for tomorrow but i'm lacking imagination on that one. It's still better than the plain black background there currently is though.

Also, better category borders for tomorrow:
Before:
![category before](https://user-images.githubusercontent.com/11745692/28650363-bc5a085a-727b-11e7-9fb7-184f499a64e3.png)
After
![categoryafter](https://user-images.githubusercontent.com/11745692/28650364-bf5da746-727b-11e7-9f97-58d392fb6d03.png)

Also make it wider, some summary improvements, and better torrent preview borders on tomorrow & classic