### PR TITLE
Removal of JS for searchbox & refine

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -123,16 +123,6 @@ function startupCode() {
 
   if (document.cookie.includes("newVersion"))
     document.getElementById("commit").className = "new";
-
-  document.getElementsByClassName("search-box")[0].addEventListener("focus", function (e) {
-    var w = document.getElementsByClassName("h-user")[0].offsetWidth
-    document.getElementsByClassName("h-user")[0].style.display = "none"
-    document.getElementsByClassName("search-box")[0].style.width = document.getElementsByClassName("search-box")[0].offsetWidth + w + "px"
-  })
-  document.getElementsByClassName("search-box")[0].addEventListener("blur", function (e) {
-    document.getElementsByClassName("search-box")[0].style.width = ""
-    document.getElementsByClassName("h-user")[0].style.display = "inline-block"
-  })
 }
 
 function playVoice() {
@@ -144,17 +134,6 @@ function playVoice() {
     console.log("Your mascot doesn't support yet audio files!")
   }
 }
-
-document.getElementsByClassName("form-input refine")[0].addEventListener("click", function (e) {
-  document.getElementsByClassName("box refine")[0].style.display = document.getElementsByClassName("box refine")[0].style.display == "none" ? "block" : "none"
-  if (document.getElementsByClassName("form-input refine-searchbox")[0].value != document.getElementsByClassName("form-input search-box")[0].value)
-    document.getElementsByClassName("form-input refine-searchbox")[0].value = document.getElementsByClassName("form-input search-box")[0].value
-  if (document.getElementsByClassName("form-input refine-category")[0].selectedIndex != document.getElementsByClassName("form-input form-category")[0].selectedIndex)
-    document.getElementsByClassName("form-input refine-category")[0].selectedIndex = document.getElementsByClassName("form-input form-category")[0].selectedIndex
-  e.preventDefault()
-  if (document.getElementsByClassName("box refine")[0].style.display == "block")
-    scrollTo(0, 0)
-})
 
 function humanFileSize(bytes, si) {
   var k = si ? 1000 : 1024

--- a/templates/layouts/index_site.jet.html
+++ b/templates/layouts/index_site.jet.html
@@ -10,6 +10,5 @@
 {{block titleBase()}} - {{block title()}}{{end}}{{end}}
 
 {{ block content_body_base()}}
-{{ yield search_refine(url=URL.Parse("/search")) }}
 {{ block content_body()}}{{end}}
 {{end}}

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -14,7 +14,7 @@
 <button type="submit" class="form-input refine" name="refine" value="1">{{  T("refine")}}</button>
 {{end}}
 {{block search_refine(url="") }}
-<div style="text-align:left;{{ if !Search.ShowRefine }}display:none;{{ end }}" class="box refine">
+<div style="text-align:left;" class="box refine">
   <h3>{{ T("refine_search") }}</h3>
   <form style="display: grid;" method="GET" action="{{ url }}">
     <span class="form-refine">

--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -3,6 +3,9 @@
 {{block title()}}{{ T("home")}}{{end}}
 {{block contclass()}}{{if User.HasAdmin() }}content-admin{{end}}{{end}}
 {{block content_body()}}
+{{if Search.ShowRefine}}
+	{{ yield search_refine(url=URL.Parse("/search")) }}
+{{end}}
 <!-- Contain the table within a grid, as for better sizing -->
 <div class="results box">
   <table>


### PR DESCRIPTION
I've found myself spending a lot of my time browsing the website with JS disabled recently, and here's why:

The searchbox JS, although designed to be pratical, ended up being more annoying than anything. Proceeding to write your text then clicking the search icon only to see the search box suddenly shrink and the form not submitting is a very annoying thing, and i can't really think of any viable workaround. Is the searchbox expanding really needed or even wanted? I can't think of any time it's been useful to me, and just like for other users it's been annoying a few times for me too.

As for the refine, i just don't really think the JS is needed nor useful. There's nothing inherently wrong with one page load to get to the refine stuff, and the fact that you can in the header select the category, write in the searchbox and then click refine to start the search while now showing the refine options (if JS disabled) makes much more sense to me: you get to see relevant results immediately and can look at them to start thinking about how precisely you are gonna refine it (which flags? trusted/not?), as it all depends on what content there already is without refining the search. I personally like the behavior of the refine stuff without JS disabled much more, and as stated in the first line it's pretty much why i disable the JS 100% of the time while browsing the website.