### PR TITLE
different behavior for refine JS

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -138,14 +138,17 @@ function playVoice() {
 }
 
 document.getElementsByClassName("form-input refine")[0].addEventListener("click", function (e) {
-  document.getElementsByClassName("box refine")[0].style.display = document.getElementsByClassName("box refine")[0].style.display == "none" ? "block" : "none"
-  if (document.getElementsByClassName("form-input refine-searchbox")[0].value != document.getElementsByClassName("form-input search-box")[0].value)
-    document.getElementsByClassName("form-input refine-searchbox")[0].value = document.getElementsByClassName("form-input search-box")[0].value
-  if (document.getElementsByClassName("form-input refine-category")[0].selectedIndex != document.getElementsByClassName("form-input form-category")[0].selectedIndex)
-    document.getElementsByClassName("form-input refine-category")[0].selectedIndex = document.getElementsByClassName("form-input form-category")[0].selectedIndex
-  e.preventDefault()
-  if (document.getElementsByClassName("box refine")[0].style.display == "block")
-    scrollTo(0, 0)
+  if(document.getElementsByClassName("form-input search-box")[0].value == "" || location.pathname != "/")
+  {
+    document.getElementsByClassName("box refine")[0].style.display = document.getElementsByClassName("box refine")[0].style.display == "none" ? "block" : "none"
+    if (document.getElementsByClassName("form-input refine-searchbox")[0].value != document.getElementsByClassName("form-input search-box")[0].value)
+      document.getElementsByClassName("form-input refine-searchbox")[0].value = document.getElementsByClassName("form-input search-box")[0].value
+    if (document.getElementsByClassName("form-input refine-category")[0].selectedIndex != document.getElementsByClassName("form-input form-category")[0].selectedIndex)
+      document.getElementsByClassName("form-input refine-category")[0].selectedIndex = document.getElementsByClassName("form-input form-category")[0].selectedIndex
+    if (document.getElementsByClassName("box refine")[0].style.display == "block")
+      scrollTo(0, 0)
+    e.preventDefault()
+  }
 })
 
 function humanFileSize(bytes, si) {


### PR DESCRIPTION
If search field is empty (header), refine button will open the refine div as to allow you to select the refine options before starting the search
If search field is not empty (header), we assume that the user want to do the search and then refine his stuff, so it submits the form and the next page will show the refine div automatically
If the user is already doing a search, the refine button will go back to showing / hiding the refine div, even if header the field is not empty

Aka it only changes one thing: If you were to go on the homepage, write some stuff in the header and hit refine, it used to show the div. Now it will submit the form because we assume the user WANTS to start the search before he wants to refine it (because he needs it). You can still show and hide refine div like normal if the field is empty, you may still put the text you want to search for in the search-box field that is located inside the refine div, and you may still suddenly show the refine div if it's currently hidden should you already be doing a search.