### PR TITLE
Minimum width for the whole website, much better look for header under tight screens

### DIFF
--- a/public/css/g.css
+++ b/public/css/g.css
@@ -48,7 +48,7 @@ a:hover {
 }
 .form-input.refine {
     background: #dff6ff;
-    border-color: #b9cdd5!important
+    border-color: #b9cdd5!important;
 }
 
 .header .h-user .user-avatar {

--- a/public/css/g.css
+++ b/public/css/g.css
@@ -48,7 +48,7 @@ a:hover {
 }
 .form-input.refine {
     background: #dff6ff;
-    border-color: #c4d9e1!important;
+    border-color: #b9cdd5!important
 }
 
 .header .h-user .user-avatar {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -656,7 +656,7 @@ html, body {
 }
 
 @media (max-width: 810px) {
-    body { margin: 2px; }
+    body { margin: 8px 0; }
     .header .h-user .user-avatar { margin: 0;} 
     .torrent-info-row>td {
         display: block;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -12,6 +12,8 @@ a {
     text-decoration: none;
 }
 
+body, .container { min-width: 400px;}
+
 .header, .pagination {
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -711,7 +713,7 @@ html, body {
     }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 565px) {
     .form-input.language {
         width: 281px;
     }
@@ -724,6 +726,11 @@ html, body {
     .hide-smol {
         display: none!important;
     }
+	.header .nav-btn { padding: 0px 6px!important;}
+	.form-input.form-category { width: 50px; margin-right: -5px;}
+}
+@media (max-width: 440px) {
+	.header .nav-btn { padding: 0px 3px!important;}
 }
 
 .up-input {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -631,7 +631,7 @@ html, body {
         display: none;
     }
     .header .h-user>.nav-btn {
-        padding: 0px;
+        padding: 0 5px!important;
         width: 50px;
     }
 }
@@ -656,6 +656,7 @@ html, body {
 }
 
 @media (max-width: 810px) {
+	.header .h-user .user-avatar { margin: 0;} 
     .torrent-info-row>td {
         display: block;
     }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -625,7 +625,7 @@ html, body {
         width: 58px;
     }
     .header .h-user .user-menu {
-        right: 101px;
+        right: 92px;
     }
     .header .h-user .user-info {
         display: none;
@@ -684,7 +684,7 @@ html, body {
     .header .h-user {
         width: 46px;
     }
-    .header .h-user .user-menu { right: 113px;}
+    .header .h-user .user-menu { right: 104px;}
     .box {
         padding: 7px;
     }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -632,8 +632,9 @@ html, body {
     }
     .header .h-user>.nav-btn {
         padding: 0 5px!important;
+		font-size: 85%;
         width: 50px;
-    }
+    }.header .h-user>a.nav-btn { padding: 0!important; }
 }
 
 @media (min-width: 960px) {
@@ -1577,7 +1578,6 @@ details[open] summary:after {
     background-position: 0 -624px;
 }
 
-html[lang="ja-jp"] .header .nav-btn { padding: 0 8px;}
 
 .input-ui-list > .element {
     display: flex;
@@ -1585,4 +1585,13 @@ html[lang="ja-jp"] .header .nav-btn { padding: 0 8px;}
 
 .input-ui-list + .add-input {
     margin-bottom:1rem;
+}
+
+/* Language specific CSS */
+
+html[lang="ja-jp"] .header .nav-btn { padding: 0 8px;}
+@media (max-width: 1100px) {
+    html[lang="ja-jp"] .header .h-user>.nav-btn {
+		font-size: 75%;
+    }
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -631,10 +631,11 @@ html, body {
         display: none;
     }
     .header .h-user>.nav-btn {
-        padding: 0 5px!important;
+        padding: 0 3px!important;
 		font-size: 85%;
-        width: 50px;
-    }.header .h-user>a.nav-btn { padding: 0!important; }
+		width: 100%;
+    }
+	.header .h-user>a.nav-btn { padding: 0!important; }
 }
 
 @media (min-width: 960px) {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -63,7 +63,7 @@ body {
 }
 
 .container {
-    max-width: 1080px;
+    max-width: 1100px;
     margin: 0 auto;
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -656,7 +656,8 @@ html, body {
 }
 
 @media (max-width: 810px) {
-	.header .h-user .user-avatar { margin: 0;} 
+    body { margin: 2px; }
+    .header .h-user .user-avatar { margin: 0;} 
     .torrent-info-row>td {
         display: block;
     }
@@ -701,12 +702,7 @@ html, body {
     .tr-links {
         width: 48px;
     }
-    .header .h-search input {
-        width: 90px !important;
-    }
-    .header .h-search input:focus {
-        width: 150px !important;
-    }
+    .header .h-search input { width: 153px !important; }
     .box {
         padding: 8px;
     }
@@ -716,6 +712,7 @@ html, body {
 }
 
 @media (max-width: 565px) {
+    .header .h-search input { width: 90px !important; }
     .form-input.language {
         width: 281px;
     }
@@ -728,11 +725,11 @@ html, body {
     .hide-smol {
         display: none!important;
     }
-	.header .nav-btn { padding: 0px 6px!important;}
-	.form-input.form-category { width: 50px; margin-right: -5px;}
+    .header .nav-btn { padding: 0px 6px!important;}
+    .form-input.form-category { width: 50px; margin-right: -5px;}
 }
 @media (max-width: 440px) {
-	.header .nav-btn { padding: 0px 3px!important;}
+    .header .nav-btn { padding: 0px 3px!important;}
 }
 
 .up-input {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -625,7 +625,7 @@ html, body {
         width: 58px;
     }
     .header .h-user .user-menu {
-        right: 100px;
+        right: 101px;
     }
     .header .h-user .user-info {
         display: none;
@@ -684,6 +684,7 @@ html, body {
     .header .h-user {
         width: 46px;
     }
+    .header .h-user .user-menu { right: 113px;}
     .box {
         padding: 7px;
     }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -702,7 +702,7 @@ html, body {
     .tr-links {
         width: 48px;
     }
-    .header .h-search input { width: 153px !important; }
+    .header .h-search input { width: 84px !important; }
     .box {
         padding: 8px;
     }

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -1,6 +1,6 @@
 {{ import "flags" }}
 {{block search_common()}}
-<select name="c" class="form-input hide-xs form-category">
+<select name="c" class="form-input form-category">
   <option value="_">{{ T("all_categories")}}</option>
   {{ range _, cat := GetCategories(true, true) }}
   <option value="{{ cat.ID }}" {{if Search.Category == cat.ID }}selected{{end}}>{{ T(cat.Name) }}</option>


### PR DESCRIPTION
The category select is now constantly shown, the header has room to fit logo + 4 links regardless of width (as it cannot go under 400px wide anymore). This also means that it does not fit the fifth link (Boards link), but that is pretty irrelevant.
This is the smallest it will ever look, anything under 400px wide will have this even if the device is not big enough to fit it. As such, they might have to scroll to get to the download links:
![03](https://user-images.githubusercontent.com/11745692/28753598-113f0d58-7537-11e7-9390-7a2cb3dbbc1e.png)
And here are screenshots at higher width
![02](https://user-images.githubusercontent.com/11745692/28753607-352661da-7537-11e7-8845-268637c99815.png)
![01](https://user-images.githubusercontent.com/11745692/28753609-36d4ba0e-7537-11e7-9ca7-4c227314bd0e.png)

Additionally, the user menu is now properly aligned throughout all resolutions.
Before:
![before1](https://user-images.githubusercontent.com/11745692/28753846-7019acb8-753a-11e7-8ce9-b6eed24b3489.png)
![before2](https://user-images.githubusercontent.com/11745692/28753847-701a3160-753a-11e7-9ac6-a34aae358512.png)
After:
![after](https://user-images.githubusercontent.com/11745692/28753867-bc604dde-753a-11e7-8744-bb70daae8a42.png)
![after1](https://user-images.githubusercontent.com/11745692/28753848-7495b8ea-753a-11e7-9ccc-94f5e0aa7216.png)

And some other stuff. Removal of :focus rule for the searchbox, .container 20px wider, searchbox bigger at lower res when it has the space, better outline for refine button under g.css, body has lower padding at lower resolution to give more space to torrent table. Some padding and font-size enhancements for "Sign in" text in the header, to make it fit fully under japanese translation and give it more space to work with overall