### PR TITLE
Not showing torrents with invalid categories in listing

### DIFF
--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -52,6 +52,7 @@
   </thead>
   <tbody id="torrentListResults">
     {{ range Models}}
+	{{ if CategoryName(.Category, .SubCategory) != ""}}
     <tr id="torrent_{{ .ID }}" class="torrent-info {{if .Status == 2}}remake{{else if .Status == 3}}trusted{{else if .Status == 4}}aplus{{end}}" >
       {{ if User.HasAdmin() }}
       <td class="tr-cb hide">
@@ -105,6 +106,7 @@
         {{end}}
         <td class="tr-date home-td date-short hide-xs">{{.Date}}</td>
       </tr>
+	  {{end}}
       {{end}}
     </tbody>
   </table>

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -13,7 +13,7 @@
     <tr class="torrent-info-row">
       <td class="torrent-info-td torrent-info-label">{{  T("category") }}:</td>
       <td class="torrent-info-td torrent-info-data" style="padding:0">
-        <a href="{{URL.Parse("/search?c="+Torrent.Category+"_"+Torrent.SubCategory) }}">{{ T(CategoryName(Torrent.Category, Torrent.SubCategory)) }}</a>
+        <a href="{{URL.Parse("/search?c="+Torrent.Category+"_"+Torrent.SubCategory) }}">{{ CategoryName(Torrent.Category, Torrent.SubCategory) == "" ? T("unknown") : T(CategoryName(Torrent.Category, Torrent.SubCategory)) }}</a>
         <br/>
       </td>
       <td class="torrent-info-td torrent-info-label">{{  T("date") }}:</td>


### PR DESCRIPTION
Anidex scrapper has tendency of bringing garbage torrents with wrong categories in place they shouldn't, aka hentai on nyaa, non-hentai on sukebei, and most importantly no category with it
First of in torrent view, instead of an empty category the torrent will show "Unknown"
Secondly in listing, if the torrent category name is empty (aka if the category & sub category do not fit together, aka invalid category), the torrent is simply not listed.
This will prevent hentai torrents with invalid categories such as these https://nyaa.pantsu.cat/search?c=1_&userID=0&q= (Anime Sub in Software search)
From popping up not only in homepage, but also in category search.

