### PR TITLE
Make file list indent work across all browsers & some other css stuff

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -590,6 +590,7 @@ textarea {
     line-height: 5px;
     margin-left: 1px;
 }
+#commit.invalid:after { content: "wew"; }
 
 html, body {
     height: 100%;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -407,6 +407,7 @@ th, .home-td, .user-td {
     text-overflow: ellipsis;
 }
 
+.user-td { padding: 2px 0; }
 .user-td.tr-cat {
     padding: 4px 5px 4px 1px;
     min-width: 74px!important;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -582,7 +582,7 @@ textarea {
     margin-bottom: 1.2rem;
 }
 
-#commit.new:after {
+#commit.new:after,#commit.invalid:after {
     content: "new";
     color: red;
     font-size: 10pt;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -737,6 +737,7 @@ html, body {
     .form-refine .refine-searchbox { width: 48%; }
     .form-refine .refine-searchbox::placeholder { opacity: 1; }
     .language { width: 350px; }
+    #footer { margin-bottom: 25px; }
 }
 
 @media (max-width: 440px) {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -719,7 +719,11 @@ html, body {
     .header .h-search { margin-right: 0; }
     .header .h-search input { width: 90px !important; }
     .form-input.refine {
-        display: none;
+	position: fixed;
+	border: 1px solid black;
+	bottom: 0;
+	width: 50%;
+	left: 25%;
     }
     .tr-links {
         width: 44px;
@@ -731,10 +735,10 @@ html, body {
     .form-input.form-category { width: 50px; margin-right: -5px;}
     span.spacing { display: none!important; }
     .form-refine .refine-category { width: 50%; }
-	.form-refine .refine-searchbox { width: 48%; }
+    .form-refine .refine-searchbox { width: 48%; }
     .form-refine .refine-category::placeholder { opacity: 1; }
-	.form-refine .refine-searchbox::placeholder { opacity: 1; }
-	.language { width: 350px; }
+    .form-refine .refine-searchbox::placeholder { opacity: 1; }
+    .language { width: 350px; }
 }
 
 @media (max-width: 440px) {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -582,7 +582,7 @@ textarea {
     margin-bottom: 1.2rem;
 }
 
-#commit.new:after,#commit.invalid:after {
+#commit.new:after,#commit.wew:after {
     content: "new";
     color: red;
     font-size: 10pt;
@@ -590,7 +590,7 @@ textarea {
     line-height: 5px;
     margin-left: 1px;
 }
-#commit.invalid:after { content: "wew"; }
+#commit.wew:after { content: "wew"; }
 
 html, body {
     height: 100%;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -979,8 +979,7 @@ thead.torrentinfo tr {
 /* The margin that gives the tree-like effect, based on the nest-level */
 
 .tr-filelist td:first-child::before {
-    margin-left: calc(var(--nest-level) * 2rem);
-    margin-right: 0.5rem;
+    margin-right: 0.4rem;
 }
 
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -714,9 +714,6 @@ html, body {
 @media (max-width: 565px) {
     .header .h-search { margin-right: 0; }
     .header .h-search input { width: 90px !important; }
-    .form-input.language {
-        width: 281px;
-    }
     .form-input.refine {
         display: none;
     }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -725,7 +725,11 @@ html, body {
     }
     .header .nav-btn { padding: 0px 6px!important;}
     .form-input.form-category { width: 50px; margin-right: -5px;}
+    .spacing { display: none; }
+    .form-refine .refine-category { width: 50%; }
+	.form-refine .refine-searchbox { width: 48%; }
 }
+
 @media (max-width: 440px) {
     .header .nav-btn { padding: 0px 3px!important;}
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -683,10 +683,6 @@ html, body {
     .hide-xs {
         display: none !important;
     }
-    #description-box img {
-        width: 100%;
-        height: auto;
-    }
     .header .h-user {
         width: 46px;
     }
@@ -842,11 +838,6 @@ html, body {
 .torrent-info-box {
     border: 1px solid #ccc;
     border-radius: 4px;
-}
-
-.torrent-info-box img {
-    max-width: 100%;
-    max-height: 100%;
 }
 
 .torrent-info-box>p>a, .torrent-info-box>div>a, #description-box a {
@@ -1058,9 +1049,14 @@ input.filelist-checkbox:checked+table.table-filelist {
     margin-bottom: 10px;
 }
 
-#description-box div {
+#description-box div, #description-box p {
     margin-top: 14px;
     margin-bottom: 14px;
+}
+
+#description-box img {
+    max-width: 100%;
+    max-height: 100%;
 }
 
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -124,11 +124,7 @@ body {
 }
 
 .header .h-search {
-    margin-right: 8px;
-}
-
-.header .h-search {
-    margin-right: 2px;
+    margin-right: 6px;
 }
 
 .header .h-search .form-input {
@@ -714,6 +710,7 @@ html, body {
 }
 
 @media (max-width: 565px) {
+    .header .h-search { margin-right: 0; }
     .header .h-search input { width: 90px !important; }
     .form-input.language {
         width: 281px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -383,6 +383,8 @@ select.form-input {
     border-radius: 0 3px 3px 0;
 	max-width: 50%;
 }
+.form-refine .refine-category::placeholder { opacity: 0; }
+.form-refine .refine-searchbox::placeholder { opacity: 0; }
 
 .categories a {
     display: inline-block;
@@ -712,8 +714,6 @@ html, body {
         padding: 2px 2px;
     }
 }
-    .form-refine .refine-category::placeholder { opacity: 0; }
-	.form-refine .refine-searchbox::placeholder { opacity: 0; }
 
 @media (max-width: 565px) {
     .header .h-search { margin-right: 0; }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -608,6 +608,9 @@ html, body {
     pointer-events: auto;
 }
 
+.results.box>table>thead.torrent-info>tr {
+    height: 40px;
+}
 
 /* holy fucking shit fuck responsive design */
 
@@ -648,10 +651,8 @@ html, body {
     .visible-md {
         display: block
     }
-}
-
-.results.box>table>thead.torrent-info>tr {
-    height: 40px;
+	.user-td.tr-date { width: 100px; }
+	.user-td.tr-size { width: 77px; }
 }
 
 @media (max-width: 810px) {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -372,7 +372,7 @@ select.form-input {
     display: inline-block;
 }
 
-.form-refine .refine-searchbox::placeholder { opacity: 0; }*
+.form-refine .refine-searchbox::placeholder { opacity: 0; }
 .form-refine .refine-searchbox {
     border-radius: 3px 0 0 3px;
     width: 21%;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -275,7 +275,7 @@ select.form-input {
 .header .h-user .user-menu .nav-btn {
     float: none;
     display: block;
-    padding: 0px 10px;
+    padding: 0px 10px!important;
     height: 43px;
     line-height: 40px;
     text-align: left;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -372,6 +372,7 @@ select.form-input {
     display: inline-block;
 }
 
+.form-refine .refine-searchbox::placeholder { opacity: 0; }*
 .form-refine .refine-searchbox {
     border-radius: 3px 0 0 3px;
     width: 21%;
@@ -383,8 +384,6 @@ select.form-input {
     border-radius: 0 3px 3px 0;
 	max-width: 50%;
 }
-.form-refine .refine-category::placeholder { opacity: 0; }
-.form-refine .refine-searchbox::placeholder { opacity: 0; }
 
 .categories a {
     display: inline-block;
@@ -736,7 +735,6 @@ html, body {
     span.spacing { display: none!important; }
     .form-refine .refine-category { width: 50%; }
     .form-refine .refine-searchbox { width: 48%; }
-    .form-refine .refine-category::placeholder { opacity: 1; }
     .form-refine .refine-searchbox::placeholder { opacity: 1; }
     .language { width: 350px; }
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -375,11 +375,13 @@ select.form-input {
 .form-refine .refine-searchbox {
     border-radius: 3px 0 0 3px;
     width: 21%;
+    min-width: 170px;
 }
 
 .form-refine .refine-category {
     border-left: none;
     border-radius: 0 3px 3px 0;
+	max-width: 50%;
 }
 
 .categories a {
@@ -710,6 +712,8 @@ html, body {
         padding: 2px 2px;
     }
 }
+    .form-refine .refine-category::placeholder { opacity: 0; }
+	.form-refine .refine-searchbox::placeholder { opacity: 0; }
 
 @media (max-width: 565px) {
     .header .h-search { margin-right: 0; }
@@ -725,9 +729,12 @@ html, body {
     }
     .header .nav-btn { padding: 0px 6px!important;}
     .form-input.form-category { width: 50px; margin-right: -5px;}
-    .spacing { display: none; }
+    span.spacing { display: none!important; }
     .form-refine .refine-category { width: 50%; }
 	.form-refine .refine-searchbox { width: 48%; }
+    .form-refine .refine-category::placeholder { opacity: 1; }
+	.form-refine .refine-searchbox::placeholder { opacity: 1; }
+	.language { width: 350px; }
 }
 
 @media (max-width: 440px) {

--- a/public/css/tomorrow.css
+++ b/public/css/tomorrow.css
@@ -187,7 +187,7 @@ td.tr-le, .error-text {
 }
 
 .torrent-info-box {
-    border-color: #53565e;
+    border-color: #515456;
 }
 .tr-cat div.nyaa-cat { border-color: #232324!important; }
 .torrent-preview-table > table { border: 2px solid #1a1a1d; }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -124,7 +124,7 @@ function startupCode() {
   }
 
   if (document.cookie.includes("newVersion"))
-    document.getElementById("commit").className = "new";
+    document.getElementById("commit").className = document.getElementById("commit") != "unknown" ? "new" : "wew";
 }
 
 function playVoice() {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -132,20 +132,21 @@ function startupCode() {
 	
 	
   var CurrentTheme = document.getElementById("theme").href;
-  UserTheme = [CurrentTheme.substring(CurrentTheme.indexOf("/css/") + 5, CurrentTheme.indexOf("?v")), "tomorrow.css"]
+  UserTheme = [CurrentTheme.substring(CurrentTheme.indexOf("/css/") + 5, CurrentTheme.indexOf(".css")), "tomorrow"]
   if(UserTheme[0] == UserTheme[1])
-	UserTheme[1] = "g.css"
+	UserTheme[1] = "g"
 }
 
 function toggleTheme() {
-  var CurrentTheme = document.getElementById("theme").href, versionIndex = CurrentTheme.indexOf("?v")
-  
-  if(versionIndex == -1)
-	CurrentTheme = CurrentTheme.substring(CurrentTheme.indexOf("/css/") + 5)
-  else 
-	CurrentTheme = CurrentTheme.substring(CurrentTheme.indexOf("/css/") + 5, versionIndex)
+  var CurrentTheme = document.getElementById("theme").href
+  CurrentTheme = CurrentTheme.substring(CurrentTheme.indexOf("/css/") + 5, CurrentTheme.indexOf(".css"))
+  CurrentTheme = (CurrentTheme == UserTheme[0] ? UserTheme[1] : UserTheme[0])
 
-  document.getElementById("theme").href = "/css/" + (CurrentTheme == UserTheme[0] ? UserTheme[1] : UserTheme[0]);
+  document.getElementById("theme").href = "/css/" + CurrentTheme + ".css";
+  
+  var farFuture = new Date()
+  farFuture.setTime(farFuture.getTime() + 50 * 36000 * 15000)
+  document.cookie = "theme=" + CurrentTheme + ";path=/;expires=" + farFuture.toUTCString()
 }
 
 function playVoice() {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -124,7 +124,7 @@ function startupCode() {
   }
 
   if (document.cookie.includes("newVersion"))
-    document.getElementById("commit").className = document.getElementById("commit").innerHTML != "unknown" ? "new" : "invalid";
+    document.getElementById("commit").className = document.getElementById("commit").innerHTML != "unknown" ? "new" : "wew";
 }
 
 function playVoice() {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -102,6 +102,7 @@ else
     startupCode()
   })
 
+ var UserTheme
 
 function startupCode() {
   var shiftWindow = function () {
@@ -125,6 +126,26 @@ function startupCode() {
 
   if (document.cookie.includes("newVersion"))
     document.getElementById("commit").className = document.getElementById("commit").innerHTML != "unknown" ? "new" : "wew";
+
+  document.getElementById("dark-toggle").style.display = "inline-block";
+  document.getElementById("dark-toggle").addEventListener("click", toggleTheme);
+	
+	
+  var CurrentTheme = document.getElementById("theme").href;
+  UserTheme = [CurrentTheme.substring(CurrentTheme.indexOf("/css/") + 5, CurrentTheme.indexOf("?v")), "tomorrow.css"]
+  if(UserTheme[0] == UserTheme[1])
+	UserTheme[1] = "g.css"
+}
+
+function toggleTheme() {
+  var CurrentTheme = document.getElementById("theme").href, versionIndex = CurrentTheme.indexOf("?v")
+  
+  if(versionIndex == -1)
+	CurrentTheme = CurrentTheme.substring(CurrentTheme.indexOf("/css/") + 5)
+  else 
+	CurrentTheme = CurrentTheme.substring(CurrentTheme.indexOf("/css/") + 5, versionIndex)
+
+  document.getElementById("theme").href = "/css/" + (CurrentTheme == UserTheme[0] ? UserTheme[1] : UserTheme[0]);
 }
 
 function playVoice() {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -124,7 +124,7 @@ function startupCode() {
   }
 
   if (document.cookie.includes("newVersion"))
-    document.getElementById("commit").className = document.getElementById("commit") != "unknown" ? "new" : "wew";
+    document.getElementById("commit").className = document.getElementById("commit").innerHTML != "unknown" ? "new" : "invalid";
 }
 
 function playVoice() {

--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -84,7 +84,7 @@
     <footer id="footer">
       <div class="container footer center">
         <div class="footer-opt">
-          <p><a href="/settings">{{ T("change_settings") }}</a></p>
+          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" style="display: none" href="#"> - Toggle Dark Mode</a></p>
         </div>
         <span><i>Powered by <a href="#">Nyaa Pantsu</a> v{{ Config.Version }} - commit <a id="commit" href="https://github.com/NyaaPantsu/nyaa/commit/{{ Config.Build }}">{{ Config.Build }}</a></i></span>
       </div>

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -19,7 +19,7 @@
   <form style="display: grid;" method="GET" action="{{ url }}">
     <span class="form-refine">
       <span class="spacing">{{ T("search_for") }}:</span>
-      <input type="text" class="form-input refine-searchbox" size="30" name="q" value="{{Search.NameLike}}"/><select name="c" class="form-input refine-category"/>
+      <input type="text" class="form-input refine-searchbox" size="30" name="q" value="{{Search.NameLike}}" placeholder="{{ T("search_for") }}"/><select name="c" class="form-input refine-category"/>
       <option value="_">{{ T("all_categories")}}</option>
       {{ range _, cat := GetCategories(true, true) }}
       <option value="{{ cat.ID }}" {{if Search.Category == cat.ID }}selected{{end}}>{{ T(cat.Name) }}</option>

--- a/templates/layouts/partials/helpers/treeview.jet.html
+++ b/templates/layouts/partials/helpers/treeview.jet.html
@@ -17,8 +17,8 @@
 {{ end }}
 
 {{ range _, file := treeviewData.Folder.Files }}
-<tr class="tr-filelist tr-file" style="--nest-level: {{ treeviewData.NestLevel }}">
-  <td>{{file.Filename()}}</td>
+<tr class="tr-filelist tr-file">
+  <td style="padding-left: {{ treeviewData.NestLevel * 8 }}%;">{{file.Filename()}}</td>
   <td>{{fileSize(file.Filesize, T)}}</td>
 </tr>
 {{ end }}

--- a/templates/layouts/partials/helpers/treeview.jet.html
+++ b/templates/layouts/partials/helpers/treeview.jet.html
@@ -18,7 +18,7 @@
 
 {{ range _, file := treeviewData.Folder.Files }}
 <tr class="tr-filelist tr-file">
-  <td style="padding-left: {{ treeviewData.NestLevel * 8 }}%;">{{file.Filename()}}</td>
+  <td style="margin-left: {{ treeviewData.NestLevel * 8 }}%;">{{file.Filename()}}</td>
   <td>{{fileSize(file.Filesize, T)}}</td>
 </tr>
 {{ end }}

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -9,7 +9,7 @@
     <th class="tr-name user-td">{{ T("name")}}</th>
     <th class="tr-links user-td">{{ T("links")}}</th>
     <th class="tr-size user-td hide-xs">{{ T("size")}}</th>
-    <th class="tr-date user-td hide-xs">{{ T("date")}}</th>
+    <th class="tr-date user-td hide-smol">{{ T("date")}}</th>
   </tr>
   {{ range i, t := UserProfile.Torrents }}
   {{ torrent := t.ToJSON() }}
@@ -49,7 +49,7 @@
     <td class="tr-size user-td hide-xs">
       {{ fileSize(torrent.Filesize, T) }}
     </td>
-    <td class="tr-date user-td date-short hide-xs">{{torrent.Date}}</td>
+    <td class="tr-date user-td date-short hide-smol">{{torrent.Date}}</td>
   </tr>
   {{end}}
 </table>


### PR DESCRIPTION
I know the nest level fuckery was appreciated and all (i mean, **margin-left: calc(var(--nest-level) * 2rem);** !!!) but i've seen a handful of users reporting it did not work, so i opted for a simple margin instead
I have NO idea if the **treeviewData.NestLevel * 8** will work though

Refine button now look good on mobile instead of being broken, it's button is now visible at a fixed position at the bottom of the screen instead of being invisible
Bigger margin for h-search as the whole page being 20px bigger now allows it
Fix padding of user-menu that was being overwritten by @media rules
Better padding for torrent list in user profile
Date and size are smaller at lower res in user profile
Date now shown longer the lower res you go, in user profile
Some other random css stuff
![refine](https://user-images.githubusercontent.com/11745692/28791546-1c98ab90-762d-11e7-8afe-6886fc259448.png)

Also toggle dark mode for javascript users