### PR TITLE
fix spacing of footer on firefox & some other browsers

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -753,7 +753,7 @@ html, body {
     .form-refine .refine-searchbox { width: 55%; }
     .form-refine .refine-searchbox::placeholder { opacity: 1; }
     .language { width: 350px; }
-    #footer { margin-bottom: 25px; }
+    #footer { padding-bottom: 25px; }
 }
 
 @media (max-width: 440px) {


### PR DESCRIPTION
the page needed more room for refine button at the bottom on mobile, and the margin simply did not work on firefox