### PR TITLE
Fix "sign in" link being too long

### DIFF
--- a/templates/layouts/partials/helpers/badgemenu.jet.html
+++ b/templates/layouts/partials/helpers/badgemenu.jet.html
@@ -29,7 +29,7 @@
     </form>
   </div>
   {{ else }}
-  <a href="/login?redirectTo={{ URL.String() }}" class="nav-btn">
+  <a href="/login?redirectTo={{ URL.String() }}" class="nav-btn" style="width:auto;">
     {{  T("signin") }}<span class="caret"></span>
   </a> {{end}}
 </div>


### PR DESCRIPTION
It was constantly at a 150px width so clicking a bit further than refine (but on 100% empty space) would get you to log in page, now it depends on text length 