### PR TITLE
More responsive category icon & <th> padding

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -627,7 +627,7 @@ html, body {
     height: 40px;
 }
 
-/* holy fucking shit fuck responsive design */
+/* responsive design */
 
 
 @media (min-width: 2560px) { 
@@ -652,6 +652,18 @@ html, body {
     }
 	.header .h-user>a.nav-btn { padding: 0!important; }
 }
+
+/* Image category shrinking & padding lowering between 1050 & 860px, do not modify any of these values */
+@media (max-width: 1050px) { 
+	.tr-cat { width: 8.7%; }
+	th, .home-td, .user-td { padding: 2px 0.25%; }
+}
+
+@media (max-width: 860px) { 
+	.tr-cat { width: 71px; }
+	th, .home-td, .user-td { padding: 2px 2px; }
+}
+/* end of category shrinking */
 
 @media (min-width: 960px) {
     .visible-md {
@@ -708,9 +720,6 @@ html, body {
     .box {
         padding: 7px;
     }
-    .tr-cat {
-        width: 71px;
-    }
     .torrent-preview-table .tr-cat {
         width: 74px;
     }
@@ -723,9 +732,6 @@ html, body {
     .header .h-search input { width: 84px !important; }
     .box {
         padding: 8px;
-    }
-    th, .home-td, .user-td {
-        padding: 2px 2px;
     }
     .torrent-hr { margin-bottom: 0; }
 }


### PR DESCRIPTION
Previously it was fixed at 90px (padding 2px 5px) and at 810px wide it would change to 77px (2px 2px) which does not make much sense.
Now between 1050 and 860px the width & padding progressively get lowered to go from 90 -> 77 and 2px 5px -> 2px 2px
http://i.4cdn.org/g/1501755564295.webm
It uses percentage fuckery because you cannot set a max or min-width for this shit
Oh also yes, at 865px the padding is 1px lower than at 860px wide (& smaller), it's not intentional but it doesn't really matter because it's not like people have screen that can dynamically change their width and all