### PR TITLE
Translation Overhaul

### DIFF
--- a/translations/es-es.all.json
+++ b/translations/es-es.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+    "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+    "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+    "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "Verifica tu correo electrónico para Nyaapantsu."
   },
@@ -100,6 +120,10 @@
     "translation": "Te has registrado exitosamente, ahora puedes usar tu cuenta."
   },
   {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "Ajustes de la Cuenta"
   },
@@ -132,6 +156,10 @@
     "translation": "Ver más torrents de %s "
   },
   {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
+  },
+  {
     "id": "category",
     "translation": "Categoría"
   },
@@ -160,6 +188,18 @@
     "translation": "Error 404"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "Subir"
   },
@@ -172,12 +212,24 @@
     "translation": "Fap"
   },
   {
+    "id": "fun",
+    "translation": "Fun"
+  },
+  {
     "id": "nothing_here",
     "translation": "No hay nada aquí."
   },
   {
     "id": "404_not_found",
     "translation": "404 No se encontró"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -258,6 +310,14 @@
   {
     "id": "answer_how_are_we_recovering",
     "translation": "Las bases de datos mencionadas están hospedadas en nyaa.pantsu.cat y sukebei.pantsu.cat. Hay una función de busqueda, y la (casi) total funcionalidad de nyaa deberia estar lista pronto. Las estadisticas de Seeder/leecher son posibles mediante 'scraping' y podrían ser restauradas en un futuro, debido a que otras funcionalidades son prioridad por el momento."
+  },
+  {
+    "id": "how_do_i_link_my_old_account",
+    "translation": "How do I link my old uploads back to my new account?"
+  },
+  {
+    "id": "answer_how_do_i_link_my_old_account",
+    "translation": "Join <a href=\"ircs://irc.rizon.net/nyaapantsu-help\">#nyaapantsu-help@Rizon</a> and ask a moderator to migrate your old torrents while mentioning your old and new usernames."
   },
   {
     "id": "are_the_trackers_working",
@@ -420,6 +480,42 @@
     "translation": "Software - Juegos"
   },
   {
+    "id": "art",
+    "translation": "Art"
+  },
+  {
+    "id": "art_anime",
+    "translation": "Art - Anime"
+  },
+  {
+    "id": "art_doujinshi",
+    "translation": "Art - Doujinshi"
+  },
+  {
+    "id": "art_games",
+    "translation": "Art - Games"
+  },
+  {
+    "id": "art_manga",
+    "translation": "Art - Manga"
+  },
+  {
+    "id": "art_pictures",
+    "translation": "Art - Pictures"
+  },
+  {
+    "id": "real_life",
+    "translation": "Real Life"
+  },
+  {
+    "id": "real_life_photobooks_and_pictures",
+    "translation": "Real Life - Photobooks and Pictures"
+  },
+  {
+    "id": "real_life_videos",
+    "translation": "Real Life - Videos"
+  },
+  {
     "id": "torrent_description",
     "translation": "Descripción del Torrent"
   },
@@ -430,6 +526,10 @@
   {
     "id": "show_all",
     "translation": "Mostrar todo"
+  },
+  {
+    "id": "delete_all",
+    "translation": "Delete all"
   },
   {
     "id": "filter_remakes",
@@ -450,6 +550,10 @@
   {
     "id": "description",
     "translation": "Descripción"
+  },
+  {
+    "id": "no_description",
+    "translation": "No description provided!"
   },
   {
     "id": "comments",
@@ -496,8 +600,16 @@
     "translation": "Miembro Confiable"
   },
   {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
     "id": "moderator",
     "translation": "Moderador"
+  },
+  {
+    "id": "api_token",
+    "translation": "API Token"
   },
   {
     "id": "save_changes",
@@ -522,6 +634,30 @@
   {
     "id": "moderation",
     "translation": "Moderación"
+  },
+  {
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
   },
   {
     "id": "who_is_renchon",
@@ -552,6 +688,10 @@
     "translation": "Remake"
   },
   {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
+  },
+  {
     "id": "profile_edit_page",
     "translation": "Editar perfil de %s"
   },
@@ -578,5 +718,1273 @@
   {
     "id": "language_code",
     "translation": "es-es"
+  },
+  {
+    "id": "delete",
+    "translation": "Delete"
+  },
+  {
+    "id": "website_link",
+    "translation": "Website Link"
+  },
+  {
+    "id": "files",
+    "translation": "Files"
+  },
+  {
+    "id": "no_files",
+    "translation": "No files found? That doesn't even make sense!"
+  },
+  {
+    "id": "uploaded_by",
+    "translation": "Uploaded by"
+  },
+  {
+    "id": "report_btn",
+    "translation": "Report"
+  },
+  {
+    "id": "are_you_sure",
+    "translation": "Are you sure?"
+  },
+  {
+    "id": "report_torrent_number",
+    "translation": "Report Torrent #%d"
+  },
+  {
+    "id": "report_type",
+    "translation": "Report type"
+  },
+  {
+    "id": "illegal_content",
+    "translation": "Illegal content"
+  },
+  {
+    "id": "spam_garbage",
+    "translation": "Spam / Garbage"
+  },
+  {
+    "id": "wrong_category",
+    "translation": "Wrong category"
+  },
+  {
+    "id": "duplicate_deprecated",
+    "translation": "Duplicate / Deprecated"
+  },
+  {
+    "id": "captcha",
+    "translation": "Captcha"
+  },
+  {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
+  },
+  {
+    "id": "file_name",
+    "translation": "File Name"
+  },
+  {
+    "id": "cancel",
+    "translation": "Cancel"
+  },
+  {
+    "id": "please_include_our_tracker",
+    "translation": "Please include udp://tracker.doko.moe:6969 in your trackers."
+  },
+  {
+    "id": "unknown",
+    "translation": "Unknown"
+  },
+  {
+    "id": "last_scraped",
+    "translation": "Last scraped: "
+  },
+  {
+    "id": "server_status_link",
+    "translation": "Server status can be found here"
+  },
+  {
+    "id": "no_database_dumps_available",
+    "translation": "No database dumps are available at this moment."
+  },
+  {
+    "id": "clear_notifications",
+    "translation": "Clear Notifications"
+  },
+  {
+    "id": "notifications_cleared",
+    "translation": "Notifications erased!"
+  },
+  {
+    "id": "my_notifications",
+    "translation": "My Notifications"
+  },
+  {
+    "id": "new_torrent_uploaded",
+    "translation": "New torrent: \"%s\" from %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
+  },
+  {
+    "id": "preferences",
+    "translation": "Preferences"
+  },
+  {
+    "id": "new_torrent_settings",
+    "translation": "Be notified when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_torrent_email_settings",
+    "translation": "Be notified by e-mail when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_comment_settings",
+    "translation": "Be notified when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_comment_email_settings",
+    "translation": "Be notified by e-mail when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_responses_settings",
+    "translation": "Be notified when there is a new response to your comment"
+  },
+  {
+    "id": "new_responses_email_settings",
+    "translation": "Be notified by e-mail when there is a new response to your comment"
+  },
+  {
+    "id": "new_follower_settings",
+    "translation": "Be notified when you have a new follower"
+  },
+  {
+    "id": "new_follower_email_settings",
+    "translation": "Be notified by e-mail when you have a new follower"
+  },
+  {
+    "id": "followed_settings",
+    "translation": "Be notified when you have followed someone"
+  },
+  {
+    "id": "followed_email_settings",
+    "translation": "Be notified by e-mail when you have followed someone"
+  },
+  {
+    "id": "yes",
+    "translation": "Yes"
+  },
+  {
+    "id": "no",
+    "translation": "No"
+  },
+  {
+    "id": "new_comment_on_torrent",
+    "translation": "New comment on torrent: \"%s\""
+  },
+  {
+    "id": "no_action_selected",
+    "translation": "You have to tell what you want to do with your selection!"
+  },
+  {
+    "id": "no_move_location_selected",
+    "translation": "Thou has't to telleth whither thee wanteth to moveth thy selection!"
+  },
+  {
+    "id": "select_one_element",
+    "translation": "You need to select at least 1 element!"
+  },
+  {
+    "id": "torrent_moved",
+    "translation": "Torrent %s moved!"
+  },
+  {
+    "id": "no_status_exist",
+    "translation": "No such status %d exist!"
+  },
+  {
+    "id": "torrent_deleted",
+    "translation": "Torrent %s deleted!"
+  },
+  {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "no_action_exist",
+    "translation": "No such action %s exist!"
+  },
+  {
+    "id": "torrent_not_exist",
+    "translation": "Torrent with ID %d doesn't exist!"
+  },
+  {
+    "id": "something_went_wrong",
+    "translation": "Something went wrong"
+  },
+  {
+    "id": "nb_torrents_updated",
+    "translation": "%d torrents updated."
+  },
+  {
+    "id": "torrent_updated",
+    "translation": "Torrent details updated."
+  },
+  {
+    "id": "fail_torrent_update",
+    "translation": "Failed to update torrent!"
+  },
+  {
+    "id": "bad_captcha",
+    "translation": "Bad captcha!"
+  },
+  {
+    "id": "comment_empty",
+    "translation": "Comment empty!"
+  },
+  {
+    "id": "no_owner_selected",
+    "translation": "New torrent owner is needed!"
+  },
+  {
+    "id": "no_category_selected",
+    "translation": "No category selected!"
+  },
+  {
+    "id": "no_user_found_id",
+    "translation": "User with id %d isn't in the database!"
+  },
+  {
+    "id": "invalid_torrent_category",
+    "translation": "Torrent category doesn't exist!"
+  },
+  {
+    "id": "torrent_owner_changed",
+    "translation": "Owner of torrent \"%s\" has been successfully changed!"
+  },
+  {
+    "id": "torrent_category_changed",
+    "translation": "Category of torrent \"%s\" has been changed!"
+  },
+  {
+    "id": "torrent_reports_deleted",
+    "translation": "Reports of torrent \"%s\" were deleted!"
+  },
+  {
+    "id": "edit",
+    "translation": "Edit"
+  },
+  {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
+    "id": "delete_definitely_torrent_warning",
+    "translation": "You will not be able to recover the file, neither stop someone to reupload it!"
+  },
+  {
+    "id": "delete_definitely",
+    "translation": "Delete definitely"
+  },
+  {
+    "id": "torrent_unblock",
+    "translation": "Unlock"
+  },
+  {
+    "id": "torrent_block",
+    "translation": "Lock"
+  },
+  {
+    "id": "torrent_deleted_definitely",
+    "translation": "Torrent has been erased from the database!"
+  },
+  {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
+    "id": "torrent_unblocked",
+    "translation": "Torrent has been unlocked!"
+  },
+  {
+    "id": "torrent_blocked",
+    "translation": "Torrent has been locked!"
+  },
+  {
+    "id": "torrent_nav_notdeleted",
+    "translation": "Torrents not deleted"
+  },
+  {
+    "id": "torrent_nav_deleted",
+    "translation": "Torrents deleted"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]

--- a/translations/hu-hu.all.json
+++ b/translations/hu-hu.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+    "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+    "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+    "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "Erősítsd meg az e-mail címedet a hozzáféréshez."
   },
@@ -100,6 +120,10 @@
     "translation": "Sikeres Regisztráció, mostmár használhatod a felhasználói fiókodat."
   },
   {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "Fiók Beállításai"
   },
@@ -112,12 +136,28 @@
     "translation": "Követés"
   },
   {
+    "id": "unfollow",
+    "translation": "Unfollow"
+  },
+  {
+    "id": "user_followed_msg",
+    "translation": "You have followed %s!"
+  },
+  {
+    "id": "user_unfollowed_msg",
+    "translation": "You have unfollowed %s!"
+  },
+  {
     "id": "profile_page",
     "translation": "%s Profilja"
   },
   {
     "id": "see_more_torrents_from",
     "translation": "További torrentek megtekintése %s-től "
+  },
+  {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
   },
   {
     "id": "category",
@@ -148,6 +188,18 @@
     "translation": "Hiba: 404"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "Feltöltés"
   },
@@ -160,12 +212,24 @@
     "translation": "Fap"
   },
   {
+    "id": "fun",
+    "translation": "Fun"
+  },
+  {
     "id": "nothing_here",
     "translation": "Itt nincs semmi."
   },
   {
     "id": "404_not_found",
     "translation": "404 Not Found"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -248,6 +312,14 @@
     "translation": "Az előbb említett adatbázisok a nyaa.pantsu.cat és sukebei.pantsu.cat domainen vannak hosztolva. Van kereső funkció, és (majdnem) teljes nyaa funkcionalitás is hamarosan érkezik. Seedelő/leech statisztikák lehetségesek scraping használatával, és lehet, hogy a közeljövőben elérhetőek lesznek, de más funkciók most a legfontosabbak."
   },
   {
+    "id": "how_do_i_link_my_old_account",
+    "translation": "How do I link my old uploads back to my new account?"
+  },
+  {
+    "id": "answer_how_do_i_link_my_old_account",
+    "translation": "Join <a href=\"ircs://irc.rizon.net/nyaapantsu-help\">#nyaapantsu-help@Rizon</a> and ask a moderator to migrate your old torrents while mentioning your old and new usernames."
+  },
+  {
     "id": "are_the_trackers_working",
     "translation": "A torrentek még mindig működnek?"
   },
@@ -310,6 +382,10 @@
   {
     "id": "all_categories",
     "translation": "Minden kategória"
+  },
+  {
+    "id": "select_a_torrent_category",
+    "translation": "Select a Torrent Category"
   },
   {
     "id": "anime",
@@ -404,6 +480,42 @@
     "translation": "Szoftver - Játékok"
   },
   {
+    "id": "art",
+    "translation": "Art"
+  },
+  {
+    "id": "art_anime",
+    "translation": "Art - Anime"
+  },
+  {
+    "id": "art_doujinshi",
+    "translation": "Art - Doujinshi"
+  },
+  {
+    "id": "art_games",
+    "translation": "Art - Games"
+  },
+  {
+    "id": "art_manga",
+    "translation": "Art - Manga"
+  },
+  {
+    "id": "art_pictures",
+    "translation": "Art - Pictures"
+  },
+  {
+    "id": "real_life",
+    "translation": "Real Life"
+  },
+  {
+    "id": "real_life_photobooks_and_pictures",
+    "translation": "Real Life - Photobooks and Pictures"
+  },
+  {
+    "id": "real_life_videos",
+    "translation": "Real Life - Videos"
+  },
+  {
     "id": "torrent_description",
     "translation": "Torrent Leírás"
   },
@@ -414,6 +526,10 @@
   {
     "id": "show_all",
     "translation": "Összes mutatása"
+  },
+  {
+    "id": "delete_all",
+    "translation": "Delete all"
   },
   {
     "id": "filter_remakes",
@@ -434,6 +550,10 @@
   {
     "id": "description",
     "translation": "Leírás"
+  },
+  {
+    "id": "no_description",
+    "translation": "No description provided!"
   },
   {
     "id": "comments",
@@ -480,8 +600,16 @@
     "translation": "Megbízható Tag"
   },
   {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
     "id": "moderator",
     "translation": "Moderátor"
+  },
+  {
+    "id": "api_token",
+    "translation": "API Token"
   },
   {
     "id": "save_changes",
@@ -506,6 +634,30 @@
   {
     "id": "moderation",
     "translation": "Moderáció"
+  },
+  {
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
   },
   {
     "id": "who_is_renchon",
@@ -534,6 +686,10 @@
   {
     "id": "torrent_status_remake",
     "translation": "Remake"
+  },
+  {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
   },
   {
     "id": "profile_edit_page",
@@ -620,6 +776,10 @@
     "translation": "Captcha"
   },
   {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
+  },
+  {
     "id": "file_name",
     "translation": "Fájlnév"
   },
@@ -662,6 +822,10 @@
   {
     "id": "new_torrent_uploaded",
     "translation": "Új torrent: \"%s\". Feltöltötte: %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
   },
   {
     "id": "preferences",
@@ -744,6 +908,54 @@
     "translation": "Torrent %s kitörölve!"
   },
   {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
     "id": "no_action_exist",
     "translation": "Nincs olyan művelet, hogy %s."
   },
@@ -808,6 +1020,10 @@
     "translation": "Szerkesztés"
   },
   {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
     "id": "delete_definitely_torrent_warning",
     "translation": "A fájlokat nem leszel képes visszaszerezni, viszont másokat sem tudsz megállítani attól, hogy újra feltöltsék."
   },
@@ -828,6 +1044,10 @@
     "translation": "A torrent ki lett törölve az adatbázisról."
   },
   {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
     "id": "torrent_unblocked",
     "translation": "A torrent fel van nyitva."
   },
@@ -842,5 +1062,929 @@
   {
     "id": "torrent_nav_deleted",
     "translation": "A Torrentek törölve lettek"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]

--- a/translations/is-is.all.json
+++ b/translations/is-is.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+    "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+    "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+    "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "Staðfestu tölvupóstfang þitt fyrir Nyaapantsu."
   },
@@ -100,6 +120,10 @@
     "translation": "Nýskráning tókst, þú getur núna notað aðganginn þinn."
   },
   {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "Aðgangsstillingar"
   },
@@ -132,6 +156,10 @@
     "translation": "Sjá fleiri torrent frá %s "
   },
   {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
+  },
+  {
     "id": "category",
     "translation": "Flokkur"
   },
@@ -160,6 +188,18 @@
     "translation": "Villa 404"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "Upphala"
   },
@@ -182,6 +222,14 @@
   {
     "id": "404_not_found",
     "translation": "404 Fannst ekki"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -452,6 +500,10 @@
     "translation": "List - Manga"
   },
   {
+    "id": "art_pictures",
+    "translation": "Art - Pictures"
+  },
+  {
     "id": "real_life",
     "translation": "Raunveruleiki"
   },
@@ -476,6 +528,10 @@
     "translation": "Sýna allt"
   },
   {
+    "id": "delete_all",
+    "translation": "Delete all"
+  },
+  {
     "id": "filter_remakes",
     "translation": "Sía út endurgerðir"
   },
@@ -494,6 +550,10 @@
   {
     "id": "description",
     "translation": "Lýsing"
+  },
+  {
+    "id": "no_description",
+    "translation": "No description provided!"
   },
   {
     "id": "comments",
@@ -540,6 +600,10 @@
     "translation": "Heiðursmeðlimur"
   },
   {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
     "id": "moderator",
     "translation": "Stjórnandi"
   },
@@ -572,6 +636,30 @@
     "translation": "Stjórnun"
   },
   {
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
+  },
+  {
     "id": "who_is_renchon",
     "translation": "Hver er <span lang=\"ja\">れんちょん</span>?"
   },
@@ -598,6 +686,10 @@
   {
     "id": "torrent_status_remake",
     "translation": "Endurgerð"
+  },
+  {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
   },
   {
     "id": "profile_edit_page",
@@ -632,8 +724,16 @@
     "translation": "Eyða"
   },
   {
+    "id": "website_link",
+    "translation": "Website Link"
+  },
+  {
     "id": "files",
     "translation": "Skrár"
+  },
+  {
+    "id": "no_files",
+    "translation": "No files found? That doesn't even make sense!"
   },
   {
     "id": "uploaded_by",
@@ -676,6 +776,10 @@
     "translation": "Captcha"
   },
   {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
+  },
+  {
     "id": "file_name",
     "translation": "Skráarnafn"
   },
@@ -702,5 +806,1185 @@
   {
     "id": "no_database_dumps_available",
     "translation": "Engin gagnagrunnsafrit standa til boða eins og er."
+  },
+  {
+    "id": "clear_notifications",
+    "translation": "Clear Notifications"
+  },
+  {
+    "id": "notifications_cleared",
+    "translation": "Notifications erased!"
+  },
+  {
+    "id": "my_notifications",
+    "translation": "My Notifications"
+  },
+  {
+    "id": "new_torrent_uploaded",
+    "translation": "New torrent: \"%s\" from %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
+  },
+  {
+    "id": "preferences",
+    "translation": "Preferences"
+  },
+  {
+    "id": "new_torrent_settings",
+    "translation": "Be notified when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_torrent_email_settings",
+    "translation": "Be notified by e-mail when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_comment_settings",
+    "translation": "Be notified when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_comment_email_settings",
+    "translation": "Be notified by e-mail when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_responses_settings",
+    "translation": "Be notified when there is a new response to your comment"
+  },
+  {
+    "id": "new_responses_email_settings",
+    "translation": "Be notified by e-mail when there is a new response to your comment"
+  },
+  {
+    "id": "new_follower_settings",
+    "translation": "Be notified when you have a new follower"
+  },
+  {
+    "id": "new_follower_email_settings",
+    "translation": "Be notified by e-mail when you have a new follower"
+  },
+  {
+    "id": "followed_settings",
+    "translation": "Be notified when you have followed someone"
+  },
+  {
+    "id": "followed_email_settings",
+    "translation": "Be notified by e-mail when you have followed someone"
+  },
+  {
+    "id": "yes",
+    "translation": "Yes"
+  },
+  {
+    "id": "no",
+    "translation": "No"
+  },
+  {
+    "id": "new_comment_on_torrent",
+    "translation": "New comment on torrent: \"%s\""
+  },
+  {
+    "id": "no_action_selected",
+    "translation": "You have to tell what you want to do with your selection!"
+  },
+  {
+    "id": "no_move_location_selected",
+    "translation": "Thou has't to telleth whither thee wanteth to moveth thy selection!"
+  },
+  {
+    "id": "select_one_element",
+    "translation": "You need to select at least 1 element!"
+  },
+  {
+    "id": "torrent_moved",
+    "translation": "Torrent %s moved!"
+  },
+  {
+    "id": "no_status_exist",
+    "translation": "No such status %d exist!"
+  },
+  {
+    "id": "torrent_deleted",
+    "translation": "Torrent %s deleted!"
+  },
+  {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "no_action_exist",
+    "translation": "No such action %s exist!"
+  },
+  {
+    "id": "torrent_not_exist",
+    "translation": "Torrent with ID %d doesn't exist!"
+  },
+  {
+    "id": "something_went_wrong",
+    "translation": "Something went wrong"
+  },
+  {
+    "id": "nb_torrents_updated",
+    "translation": "%d torrents updated."
+  },
+  {
+    "id": "torrent_updated",
+    "translation": "Torrent details updated."
+  },
+  {
+    "id": "fail_torrent_update",
+    "translation": "Failed to update torrent!"
+  },
+  {
+    "id": "bad_captcha",
+    "translation": "Bad captcha!"
+  },
+  {
+    "id": "comment_empty",
+    "translation": "Comment empty!"
+  },
+  {
+    "id": "no_owner_selected",
+    "translation": "New torrent owner is needed!"
+  },
+  {
+    "id": "no_category_selected",
+    "translation": "No category selected!"
+  },
+  {
+    "id": "no_user_found_id",
+    "translation": "User with id %d isn't in the database!"
+  },
+  {
+    "id": "invalid_torrent_category",
+    "translation": "Torrent category doesn't exist!"
+  },
+  {
+    "id": "torrent_owner_changed",
+    "translation": "Owner of torrent \"%s\" has been successfully changed!"
+  },
+  {
+    "id": "torrent_category_changed",
+    "translation": "Category of torrent \"%s\" has been changed!"
+  },
+  {
+    "id": "torrent_reports_deleted",
+    "translation": "Reports of torrent \"%s\" were deleted!"
+  },
+  {
+    "id": "edit",
+    "translation": "Edit"
+  },
+  {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
+    "id": "delete_definitely_torrent_warning",
+    "translation": "You will not be able to recover the file, neither stop someone to reupload it!"
+  },
+  {
+    "id": "delete_definitely",
+    "translation": "Delete definitely"
+  },
+  {
+    "id": "torrent_unblock",
+    "translation": "Unlock"
+  },
+  {
+    "id": "torrent_block",
+    "translation": "Lock"
+  },
+  {
+    "id": "torrent_deleted_definitely",
+    "translation": "Torrent has been erased from the database!"
+  },
+  {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
+    "id": "torrent_unblocked",
+    "translation": "Torrent has been unlocked!"
+  },
+  {
+    "id": "torrent_blocked",
+    "translation": "Torrent has been locked!"
+  },
+  {
+    "id": "torrent_nav_notdeleted",
+    "translation": "Torrents not deleted"
+  },
+  {
+    "id": "torrent_nav_deleted",
+    "translation": "Torrents deleted"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]

--- a/translations/ko-kr.all.json
+++ b/translations/ko-kr.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+    "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+    "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+    "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "고양이를 위해 이메일을 확인해주세요"
   },
@@ -96,6 +116,14 @@
     "translation": "마지막으로 이메일 인증을 완료해 주세요! 이메일이 도착하지 않았다면 스팸 메일함도 확인해 주세요."
   },
   {
+    "id": "signup_verification_noemail",
+    "translation": "Registration was successful, you may now use your account."
+  },
+  {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "계정 설정"
   },
@@ -112,12 +140,24 @@
     "translation": "언팔로우"
   },
   {
+    "id": "user_followed_msg",
+    "translation": "You have followed %s!"
+  },
+  {
+    "id": "user_unfollowed_msg",
+    "translation": "You have unfollowed %s!"
+  },
+  {
     "id": "profile_page",
     "translation": "%s 프로필 페이지"
   },
   {
     "id": "see_more_torrents_from",
     "translation": "%s 에서 더 많은 토렌트 보기"
+  },
+  {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
   },
   {
     "id": "category",
@@ -148,6 +188,18 @@
     "translation": "에러 404"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "업로드"
   },
@@ -160,12 +212,24 @@
     "translation": "자위"
   },
   {
+    "id": "fun",
+    "translation": "Fun"
+  },
+  {
     "id": "nothing_here",
     "translation": "아무것도 없음"
   },
   {
     "id": "404_not_found",
     "translation": "404 Not Found"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -248,6 +312,14 @@
     "translation": "nyaa.pantsu.cat 과 sukebei.pantsu.cat 에서 상기한 데이터베이스를 이용해 호스팅 중입니다. 현재는 검색기능 뿐이지만, 곧 완전한 기능이 완성 될겁니다. Seeder/leecher 통계는 scraping 을 통해 가능하며 가까운 시일내에 복구될 것이지만, 현재는 다른 기능을 중점적으로 작업중입니다."
   },
   {
+    "id": "how_do_i_link_my_old_account",
+    "translation": "How do I link my old uploads back to my new account?"
+  },
+  {
+    "id": "answer_how_do_i_link_my_old_account",
+    "translation": "Join <a href=\"ircs://irc.rizon.net/nyaapantsu-help\">#nyaapantsu-help@Rizon</a> and ask a moderator to migrate your old torrents while mentioning your old and new usernames."
+  },
+  {
     "id": "are_the_trackers_working",
     "translation": "토렌트들은 이용할 수 있다는거지?"
   },
@@ -310,6 +382,10 @@
   {
     "id": "all_categories",
     "translation": "모든 카테고리"
+  },
+  {
+    "id": "select_a_torrent_category",
+    "translation": "Select a Torrent Category"
   },
   {
     "id": "anime",
@@ -404,6 +480,42 @@
     "translation": "소프트웨어 - 게임"
   },
   {
+    "id": "art",
+    "translation": "Art"
+  },
+  {
+    "id": "art_anime",
+    "translation": "Art - Anime"
+  },
+  {
+    "id": "art_doujinshi",
+    "translation": "Art - Doujinshi"
+  },
+  {
+    "id": "art_games",
+    "translation": "Art - Games"
+  },
+  {
+    "id": "art_manga",
+    "translation": "Art - Manga"
+  },
+  {
+    "id": "art_pictures",
+    "translation": "Art - Pictures"
+  },
+  {
+    "id": "real_life",
+    "translation": "Real Life"
+  },
+  {
+    "id": "real_life_photobooks_and_pictures",
+    "translation": "Real Life - Photobooks and Pictures"
+  },
+  {
+    "id": "real_life_videos",
+    "translation": "Real Life - Videos"
+  },
+  {
     "id": "torrent_description",
     "translation": "토렌트 설명"
   },
@@ -414,6 +526,10 @@
   {
     "id": "show_all",
     "translation": "모두 보기"
+  },
+  {
+    "id": "delete_all",
+    "translation": "Delete all"
   },
   {
     "id": "filter_remakes",
@@ -436,6 +552,10 @@
     "translation": "설명"
   },
   {
+    "id": "no_description",
+    "translation": "No description provided!"
+  },
+  {
     "id": "comments",
     "translation": "댓글"
   },
@@ -452,11 +572,1419 @@
     "translation": "확인"
   },
   {
+    "id": "personal_info",
+    "translation": "Personal Info"
+  },
+  {
+    "id": "language",
+    "translation": "Language"
+  },
+  {
+    "id": "current_password",
+    "translation": "Current password"
+  },
+  {
+    "id": "role",
+    "translation": "Role"
+  },
+  {
+    "id": "banned",
+    "translation": "Banned"
+  },
+  {
+    "id": "default",
+    "translation": "Default"
+  },
+  {
+    "id": "trusted_member",
+    "translation": "Trusted member"
+  },
+  {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
+    "id": "moderator",
+    "translation": "Moderator"
+  },
+  {
+    "id": "api_token",
+    "translation": "API Token"
+  },
+  {
+    "id": "save_changes",
+    "translation": "Save Changes"
+  },
+  {
+    "id": "profile_updated",
+    "translation": "Your profile has been correctly updated!"
+  },
+  {
+    "id": "delete_account",
+    "translation": "Delete Account"
+  },
+  {
+    "id": "delete_account_confirm",
+    "translation": "Are you sure you want to delete this account?"
+  },
+  {
+    "id": "delete_success",
+    "translation": "The account has been successfully deleted!"
+  },
+  {
+    "id": "moderation",
+    "translation": "Moderation"
+  },
+  {
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
+  },
+  {
+    "id": "who_is_renchon",
+    "translation": "Who the fuck is <span lang=\"ja\">れんちょん</span>?"
+  },
+  {
+    "id": "renchon_anon_explanation",
+    "translation": "<span lang=\"ja\">れんちょん</span> (Ren-chon) is the username assigned to uploads and comments made anonymously. It is also used for torrents imported from the original nyaa, though sometimes the original uploader can be displayed alongside."
+  },
+  {
+    "id": "mark_as_remake",
+    "translation": "Mark as remake"
+  },
+  {
+    "id": "email_changed",
+    "translation": "Email changed successfully! You will have, however, to confirm it by clicking to the link sent to: %s"
+  },
+  {
+    "id": "torrent_status",
+    "translation": "Torrent status"
+  },
+  {
+    "id": "torrent_status_normal",
+    "translation": "Normal"
+  },
+  {
+    "id": "torrent_status_remake",
+    "translation": "Remake"
+  },
+  {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
+  },
+  {
+    "id": "profile_edit_page",
+    "translation": "Edit %s's profile"
+  },
+  {
+    "id": "seeders",
+    "translation": "Seeders"
+  },
+  {
+    "id": "leechers",
+    "translation": "Leechers"
+  },
+  {
+    "id": "completed",
+    "translation": "Completed"
+  },
+  {
+    "id": "change_language",
+    "translation": "Change Language"
+  },
+  {
     "id": "language_name",
     "translation": "한국어"
   },
   {
     "id": "language_code",
     "translation": "ko-kr"
+  },
+  {
+    "id": "delete",
+    "translation": "Delete"
+  },
+  {
+    "id": "website_link",
+    "translation": "Website Link"
+  },
+  {
+    "id": "files",
+    "translation": "Files"
+  },
+  {
+    "id": "no_files",
+    "translation": "No files found? That doesn't even make sense!"
+  },
+  {
+    "id": "uploaded_by",
+    "translation": "Uploaded by"
+  },
+  {
+    "id": "report_btn",
+    "translation": "Report"
+  },
+  {
+    "id": "are_you_sure",
+    "translation": "Are you sure?"
+  },
+  {
+    "id": "report_torrent_number",
+    "translation": "Report Torrent #%d"
+  },
+  {
+    "id": "report_type",
+    "translation": "Report type"
+  },
+  {
+    "id": "illegal_content",
+    "translation": "Illegal content"
+  },
+  {
+    "id": "spam_garbage",
+    "translation": "Spam / Garbage"
+  },
+  {
+    "id": "wrong_category",
+    "translation": "Wrong category"
+  },
+  {
+    "id": "duplicate_deprecated",
+    "translation": "Duplicate / Deprecated"
+  },
+  {
+    "id": "captcha",
+    "translation": "Captcha"
+  },
+  {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
+  },
+  {
+    "id": "file_name",
+    "translation": "File Name"
+  },
+  {
+    "id": "cancel",
+    "translation": "Cancel"
+  },
+  {
+    "id": "please_include_our_tracker",
+    "translation": "Please include udp://tracker.doko.moe:6969 in your trackers."
+  },
+  {
+    "id": "unknown",
+    "translation": "Unknown"
+  },
+  {
+    "id": "last_scraped",
+    "translation": "Last scraped: "
+  },
+  {
+    "id": "server_status_link",
+    "translation": "Server status can be found here"
+  },
+  {
+    "id": "no_database_dumps_available",
+    "translation": "No database dumps are available at this moment."
+  },
+  {
+    "id": "clear_notifications",
+    "translation": "Clear Notifications"
+  },
+  {
+    "id": "notifications_cleared",
+    "translation": "Notifications erased!"
+  },
+  {
+    "id": "my_notifications",
+    "translation": "My Notifications"
+  },
+  {
+    "id": "new_torrent_uploaded",
+    "translation": "New torrent: \"%s\" from %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
+  },
+  {
+    "id": "preferences",
+    "translation": "Preferences"
+  },
+  {
+    "id": "new_torrent_settings",
+    "translation": "Be notified when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_torrent_email_settings",
+    "translation": "Be notified by e-mail when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_comment_settings",
+    "translation": "Be notified when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_comment_email_settings",
+    "translation": "Be notified by e-mail when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_responses_settings",
+    "translation": "Be notified when there is a new response to your comment"
+  },
+  {
+    "id": "new_responses_email_settings",
+    "translation": "Be notified by e-mail when there is a new response to your comment"
+  },
+  {
+    "id": "new_follower_settings",
+    "translation": "Be notified when you have a new follower"
+  },
+  {
+    "id": "new_follower_email_settings",
+    "translation": "Be notified by e-mail when you have a new follower"
+  },
+  {
+    "id": "followed_settings",
+    "translation": "Be notified when you have followed someone"
+  },
+  {
+    "id": "followed_email_settings",
+    "translation": "Be notified by e-mail when you have followed someone"
+  },
+  {
+    "id": "yes",
+    "translation": "Yes"
+  },
+  {
+    "id": "no",
+    "translation": "No"
+  },
+  {
+    "id": "new_comment_on_torrent",
+    "translation": "New comment on torrent: \"%s\""
+  },
+  {
+    "id": "no_action_selected",
+    "translation": "You have to tell what you want to do with your selection!"
+  },
+  {
+    "id": "no_move_location_selected",
+    "translation": "Thou has't to telleth whither thee wanteth to moveth thy selection!"
+  },
+  {
+    "id": "select_one_element",
+    "translation": "You need to select at least 1 element!"
+  },
+  {
+    "id": "torrent_moved",
+    "translation": "Torrent %s moved!"
+  },
+  {
+    "id": "no_status_exist",
+    "translation": "No such status %d exist!"
+  },
+  {
+    "id": "torrent_deleted",
+    "translation": "Torrent %s deleted!"
+  },
+  {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "no_action_exist",
+    "translation": "No such action %s exist!"
+  },
+  {
+    "id": "torrent_not_exist",
+    "translation": "Torrent with ID %d doesn't exist!"
+  },
+  {
+    "id": "something_went_wrong",
+    "translation": "Something went wrong"
+  },
+  {
+    "id": "nb_torrents_updated",
+    "translation": "%d torrents updated."
+  },
+  {
+    "id": "torrent_updated",
+    "translation": "Torrent details updated."
+  },
+  {
+    "id": "fail_torrent_update",
+    "translation": "Failed to update torrent!"
+  },
+  {
+    "id": "bad_captcha",
+    "translation": "Bad captcha!"
+  },
+  {
+    "id": "comment_empty",
+    "translation": "Comment empty!"
+  },
+  {
+    "id": "no_owner_selected",
+    "translation": "New torrent owner is needed!"
+  },
+  {
+    "id": "no_category_selected",
+    "translation": "No category selected!"
+  },
+  {
+    "id": "no_user_found_id",
+    "translation": "User with id %d isn't in the database!"
+  },
+  {
+    "id": "invalid_torrent_category",
+    "translation": "Torrent category doesn't exist!"
+  },
+  {
+    "id": "torrent_owner_changed",
+    "translation": "Owner of torrent \"%s\" has been successfully changed!"
+  },
+  {
+    "id": "torrent_category_changed",
+    "translation": "Category of torrent \"%s\" has been changed!"
+  },
+  {
+    "id": "torrent_reports_deleted",
+    "translation": "Reports of torrent \"%s\" were deleted!"
+  },
+  {
+    "id": "edit",
+    "translation": "Edit"
+  },
+  {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
+    "id": "delete_definitely_torrent_warning",
+    "translation": "You will not be able to recover the file, neither stop someone to reupload it!"
+  },
+  {
+    "id": "delete_definitely",
+    "translation": "Delete definitely"
+  },
+  {
+    "id": "torrent_unblock",
+    "translation": "Unlock"
+  },
+  {
+    "id": "torrent_block",
+    "translation": "Lock"
+  },
+  {
+    "id": "torrent_deleted_definitely",
+    "translation": "Torrent has been erased from the database!"
+  },
+  {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
+    "id": "torrent_unblocked",
+    "translation": "Torrent has been unlocked!"
+  },
+  {
+    "id": "torrent_blocked",
+    "translation": "Torrent has been locked!"
+  },
+  {
+    "id": "torrent_nav_notdeleted",
+    "translation": "Torrents not deleted"
+  },
+  {
+    "id": "torrent_nav_deleted",
+    "translation": "Torrents deleted"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]

--- a/translations/nb-no.all.json
+++ b/translations/nb-no.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+    "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+    "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+    "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "Bekreft epost-addressen din."
   },
@@ -100,6 +120,10 @@
     "translation": "Ferdig! Ikkeno epost-piss her, bare kjør på."
   },
   {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "Innstillinger"
   },
@@ -132,6 +156,10 @@
     "translation": "Se flere torrenter fra %s "
   },
   {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
+  },
+  {
     "id": "category",
     "translation": "Kategori"
   },
@@ -160,6 +188,18 @@
     "translation": "Ikke funnet"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "Last opp"
   },
@@ -172,12 +212,24 @@
     "translation": "Snusk"
   },
   {
+    "id": "fun",
+    "translation": "Fun"
+  },
+  {
     "id": "nothing_here",
     "translation": "Niks, null, nada."
   },
   {
     "id": "404_not_found",
     "translation": "Ikke funnet"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -260,6 +312,14 @@
     "translation": "Det vi har ligger ute på nyaa.pantsu.cat og sukebei.pantsu.cat. Søk funker, og (nesten) all funksjonalitet fra nyaa vil dukke opp snarlig. Statistikk (seeders/leechers) kan vi muligens få til i fremtiden."
   },
   {
+    "id": "how_do_i_link_my_old_account",
+    "translation": "How do I link my old uploads back to my new account?"
+  },
+  {
+    "id": "answer_how_do_i_link_my_old_account",
+    "translation": "Join <a href=\"ircs://irc.rizon.net/nyaapantsu-help\">#nyaapantsu-help@Rizon</a> and ask a moderator to migrate your old torrents while mentioning your old and new usernames."
+  },
+  {
     "id": "are_the_trackers_working",
     "translation": "Funker torrentene enda?"
   },
@@ -322,6 +382,10 @@
   {
     "id": "all_categories",
     "translation": "Alle kategorier"
+  },
+  {
+    "id": "select_a_torrent_category",
+    "translation": "Select a Torrent Category"
   },
   {
     "id": "anime",
@@ -416,6 +480,42 @@
     "translation": "Mykvare - Spill"
   },
   {
+    "id": "art",
+    "translation": "Art"
+  },
+  {
+    "id": "art_anime",
+    "translation": "Art - Anime"
+  },
+  {
+    "id": "art_doujinshi",
+    "translation": "Art - Doujinshi"
+  },
+  {
+    "id": "art_games",
+    "translation": "Art - Games"
+  },
+  {
+    "id": "art_manga",
+    "translation": "Art - Manga"
+  },
+  {
+    "id": "art_pictures",
+    "translation": "Art - Pictures"
+  },
+  {
+    "id": "real_life",
+    "translation": "Real Life"
+  },
+  {
+    "id": "real_life_photobooks_and_pictures",
+    "translation": "Real Life - Photobooks and Pictures"
+  },
+  {
+    "id": "real_life_videos",
+    "translation": "Real Life - Videos"
+  },
+  {
     "id": "torrent_description",
     "translation": "Torrent-beskrivelse"
   },
@@ -426,6 +526,10 @@
   {
     "id": "show_all",
     "translation": "Vis alle"
+  },
+  {
+    "id": "delete_all",
+    "translation": "Delete all"
   },
   {
     "id": "filter_remakes",
@@ -446,6 +550,10 @@
   {
     "id": "description",
     "translation": "Beskrivelse"
+  },
+  {
+    "id": "no_description",
+    "translation": "No description provided!"
   },
   {
     "id": "comments",
@@ -492,8 +600,16 @@
     "translation": "Kjentkar"
   },
   {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
     "id": "moderator",
     "translation": "Moderator"
+  },
+  {
+    "id": "api_token",
+    "translation": "API Token"
   },
   {
     "id": "save_changes",
@@ -520,6 +636,30 @@
     "translation": "Moderering"
   },
   {
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
+  },
+  {
     "id": "who_is_renchon",
     "translation": "Hvem faen er <span lang=\"ja\">れんちょん</span>?"
   },
@@ -536,11 +676,1315 @@
     "translation": "Epost-addressen har blitt endret! Neste steg er å bekrefte den (sjekk innboksen)."
   },
   {
+    "id": "torrent_status",
+    "translation": "Torrent status"
+  },
+  {
+    "id": "torrent_status_normal",
+    "translation": "Normal"
+  },
+  {
+    "id": "torrent_status_remake",
+    "translation": "Remake"
+  },
+  {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
+  },
+  {
+    "id": "profile_edit_page",
+    "translation": "Edit %s's profile"
+  },
+  {
+    "id": "seeders",
+    "translation": "Seeders"
+  },
+  {
+    "id": "leechers",
+    "translation": "Leechers"
+  },
+  {
+    "id": "completed",
+    "translation": "Completed"
+  },
+  {
+    "id": "change_language",
+    "translation": "Change Language"
+  },
+  {
     "id": "language_name",
     "translation": "Norsk bokmål"
   },
   {
     "id": "language_code",
     "translation": "nb-no"
+  },
+  {
+    "id": "delete",
+    "translation": "Delete"
+  },
+  {
+    "id": "website_link",
+    "translation": "Website Link"
+  },
+  {
+    "id": "files",
+    "translation": "Files"
+  },
+  {
+    "id": "no_files",
+    "translation": "No files found? That doesn't even make sense!"
+  },
+  {
+    "id": "uploaded_by",
+    "translation": "Uploaded by"
+  },
+  {
+    "id": "report_btn",
+    "translation": "Report"
+  },
+  {
+    "id": "are_you_sure",
+    "translation": "Are you sure?"
+  },
+  {
+    "id": "report_torrent_number",
+    "translation": "Report Torrent #%d"
+  },
+  {
+    "id": "report_type",
+    "translation": "Report type"
+  },
+  {
+    "id": "illegal_content",
+    "translation": "Illegal content"
+  },
+  {
+    "id": "spam_garbage",
+    "translation": "Spam / Garbage"
+  },
+  {
+    "id": "wrong_category",
+    "translation": "Wrong category"
+  },
+  {
+    "id": "duplicate_deprecated",
+    "translation": "Duplicate / Deprecated"
+  },
+  {
+    "id": "captcha",
+    "translation": "Captcha"
+  },
+  {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
+  },
+  {
+    "id": "file_name",
+    "translation": "File Name"
+  },
+  {
+    "id": "cancel",
+    "translation": "Cancel"
+  },
+  {
+    "id": "please_include_our_tracker",
+    "translation": "Please include udp://tracker.doko.moe:6969 in your trackers."
+  },
+  {
+    "id": "unknown",
+    "translation": "Unknown"
+  },
+  {
+    "id": "last_scraped",
+    "translation": "Last scraped: "
+  },
+  {
+    "id": "server_status_link",
+    "translation": "Server status can be found here"
+  },
+  {
+    "id": "no_database_dumps_available",
+    "translation": "No database dumps are available at this moment."
+  },
+  {
+    "id": "clear_notifications",
+    "translation": "Clear Notifications"
+  },
+  {
+    "id": "notifications_cleared",
+    "translation": "Notifications erased!"
+  },
+  {
+    "id": "my_notifications",
+    "translation": "My Notifications"
+  },
+  {
+    "id": "new_torrent_uploaded",
+    "translation": "New torrent: \"%s\" from %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
+  },
+  {
+    "id": "preferences",
+    "translation": "Preferences"
+  },
+  {
+    "id": "new_torrent_settings",
+    "translation": "Be notified when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_torrent_email_settings",
+    "translation": "Be notified by e-mail when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_comment_settings",
+    "translation": "Be notified when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_comment_email_settings",
+    "translation": "Be notified by e-mail when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_responses_settings",
+    "translation": "Be notified when there is a new response to your comment"
+  },
+  {
+    "id": "new_responses_email_settings",
+    "translation": "Be notified by e-mail when there is a new response to your comment"
+  },
+  {
+    "id": "new_follower_settings",
+    "translation": "Be notified when you have a new follower"
+  },
+  {
+    "id": "new_follower_email_settings",
+    "translation": "Be notified by e-mail when you have a new follower"
+  },
+  {
+    "id": "followed_settings",
+    "translation": "Be notified when you have followed someone"
+  },
+  {
+    "id": "followed_email_settings",
+    "translation": "Be notified by e-mail when you have followed someone"
+  },
+  {
+    "id": "yes",
+    "translation": "Yes"
+  },
+  {
+    "id": "no",
+    "translation": "No"
+  },
+  {
+    "id": "new_comment_on_torrent",
+    "translation": "New comment on torrent: \"%s\""
+  },
+  {
+    "id": "no_action_selected",
+    "translation": "You have to tell what you want to do with your selection!"
+  },
+  {
+    "id": "no_move_location_selected",
+    "translation": "Thou has't to telleth whither thee wanteth to moveth thy selection!"
+  },
+  {
+    "id": "select_one_element",
+    "translation": "You need to select at least 1 element!"
+  },
+  {
+    "id": "torrent_moved",
+    "translation": "Torrent %s moved!"
+  },
+  {
+    "id": "no_status_exist",
+    "translation": "No such status %d exist!"
+  },
+  {
+    "id": "torrent_deleted",
+    "translation": "Torrent %s deleted!"
+  },
+  {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "no_action_exist",
+    "translation": "No such action %s exist!"
+  },
+  {
+    "id": "torrent_not_exist",
+    "translation": "Torrent with ID %d doesn't exist!"
+  },
+  {
+    "id": "something_went_wrong",
+    "translation": "Something went wrong"
+  },
+  {
+    "id": "nb_torrents_updated",
+    "translation": "%d torrents updated."
+  },
+  {
+    "id": "torrent_updated",
+    "translation": "Torrent details updated."
+  },
+  {
+    "id": "fail_torrent_update",
+    "translation": "Failed to update torrent!"
+  },
+  {
+    "id": "bad_captcha",
+    "translation": "Bad captcha!"
+  },
+  {
+    "id": "comment_empty",
+    "translation": "Comment empty!"
+  },
+  {
+    "id": "no_owner_selected",
+    "translation": "New torrent owner is needed!"
+  },
+  {
+    "id": "no_category_selected",
+    "translation": "No category selected!"
+  },
+  {
+    "id": "no_user_found_id",
+    "translation": "User with id %d isn't in the database!"
+  },
+  {
+    "id": "invalid_torrent_category",
+    "translation": "Torrent category doesn't exist!"
+  },
+  {
+    "id": "torrent_owner_changed",
+    "translation": "Owner of torrent \"%s\" has been successfully changed!"
+  },
+  {
+    "id": "torrent_category_changed",
+    "translation": "Category of torrent \"%s\" has been changed!"
+  },
+  {
+    "id": "torrent_reports_deleted",
+    "translation": "Reports of torrent \"%s\" were deleted!"
+  },
+  {
+    "id": "edit",
+    "translation": "Edit"
+  },
+  {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
+    "id": "delete_definitely_torrent_warning",
+    "translation": "You will not be able to recover the file, neither stop someone to reupload it!"
+  },
+  {
+    "id": "delete_definitely",
+    "translation": "Delete definitely"
+  },
+  {
+    "id": "torrent_unblock",
+    "translation": "Unlock"
+  },
+  {
+    "id": "torrent_block",
+    "translation": "Lock"
+  },
+  {
+    "id": "torrent_deleted_definitely",
+    "translation": "Torrent has been erased from the database!"
+  },
+  {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
+    "id": "torrent_unblocked",
+    "translation": "Torrent has been unlocked!"
+  },
+  {
+    "id": "torrent_blocked",
+    "translation": "Torrent has been locked!"
+  },
+  {
+    "id": "torrent_nav_notdeleted",
+    "translation": "Torrents not deleted"
+  },
+  {
+    "id": "torrent_nav_deleted",
+    "translation": "Torrents deleted"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]

--- a/translations/ru-ru.all.json
+++ b/translations/ru-ru.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+    "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+    "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+    "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "Подтвердите свой Email адрес для Nyaapantsu."
   },
@@ -100,6 +120,10 @@
     "translation": "Регистрация прошла успешно, теперь вы можете использовать свой аккаунт."
   },
   {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "Настройки аккаунта"
   },
@@ -132,6 +156,10 @@
     "translation": "Посмотреть другие торренты %s "
   },
   {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
+  },
+  {
     "id": "category",
     "translation": "Категория"
   },
@@ -160,6 +188,18 @@
     "translation": "Ошибка 404"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "Загрузить"
   },
@@ -168,12 +208,12 @@
     "translation": "FAQ"
   },
   {
-    "id": "fun",
-    "translation": "Fun"
-  },
-  {
     "id": "fap",
     "translation": "Fap"
+  },
+  {
+    "id": "fun",
+    "translation": "Fun"
   },
   {
     "id": "nothing_here",
@@ -182,6 +222,14 @@
   {
     "id": "404_not_found",
     "translation": "404 Не найдено"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -480,6 +528,10 @@
     "translation": "Показать все"
   },
   {
+    "id": "delete_all",
+    "translation": "Delete all"
+  },
+  {
     "id": "filter_remakes",
     "translation": "Ремейки"
   },
@@ -498,6 +550,10 @@
   {
     "id": "description",
     "translation": "Описание"
+  },
+  {
+    "id": "no_description",
+    "translation": "No description provided!"
   },
   {
     "id": "comments",
@@ -544,6 +600,10 @@
     "translation": "Надёжный пользователь"
   },
   {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
     "id": "moderator",
     "translation": "Модератор"
   },
@@ -576,6 +636,30 @@
     "translation": "На модерации"
   },
   {
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
+  },
+  {
     "id": "who_is_renchon",
     "translation": "Кто, черт побери, такой <span lang=\"ja\">れんちょん</span>?"
   },
@@ -602,6 +686,10 @@
   {
     "id": "torrent_status_remake",
     "translation": "Ремейк"
+  },
+  {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
   },
   {
     "id": "profile_edit_page",
@@ -636,8 +724,16 @@
     "translation": "Удалить"
   },
   {
+    "id": "website_link",
+    "translation": "Website Link"
+  },
+  {
     "id": "files",
     "translation": "Файлы"
+  },
+  {
+    "id": "no_files",
+    "translation": "No files found? That doesn't even make sense!"
   },
   {
     "id": "uploaded_by",
@@ -680,6 +776,10 @@
     "translation": "Капча"
   },
   {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
+  },
+  {
     "id": "file_name",
     "translation": "Имя файла"
   },
@@ -706,5 +806,1185 @@
   {
     "id": "no_database_dumps_available",
     "translation": "Сейчас нет доступных дампов базы"
+  },
+  {
+    "id": "clear_notifications",
+    "translation": "Clear Notifications"
+  },
+  {
+    "id": "notifications_cleared",
+    "translation": "Notifications erased!"
+  },
+  {
+    "id": "my_notifications",
+    "translation": "My Notifications"
+  },
+  {
+    "id": "new_torrent_uploaded",
+    "translation": "New torrent: \"%s\" from %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
+  },
+  {
+    "id": "preferences",
+    "translation": "Preferences"
+  },
+  {
+    "id": "new_torrent_settings",
+    "translation": "Be notified when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_torrent_email_settings",
+    "translation": "Be notified by e-mail when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_comment_settings",
+    "translation": "Be notified when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_comment_email_settings",
+    "translation": "Be notified by e-mail when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_responses_settings",
+    "translation": "Be notified when there is a new response to your comment"
+  },
+  {
+    "id": "new_responses_email_settings",
+    "translation": "Be notified by e-mail when there is a new response to your comment"
+  },
+  {
+    "id": "new_follower_settings",
+    "translation": "Be notified when you have a new follower"
+  },
+  {
+    "id": "new_follower_email_settings",
+    "translation": "Be notified by e-mail when you have a new follower"
+  },
+  {
+    "id": "followed_settings",
+    "translation": "Be notified when you have followed someone"
+  },
+  {
+    "id": "followed_email_settings",
+    "translation": "Be notified by e-mail when you have followed someone"
+  },
+  {
+    "id": "yes",
+    "translation": "Yes"
+  },
+  {
+    "id": "no",
+    "translation": "No"
+  },
+  {
+    "id": "new_comment_on_torrent",
+    "translation": "New comment on torrent: \"%s\""
+  },
+  {
+    "id": "no_action_selected",
+    "translation": "You have to tell what you want to do with your selection!"
+  },
+  {
+    "id": "no_move_location_selected",
+    "translation": "Thou has't to telleth whither thee wanteth to moveth thy selection!"
+  },
+  {
+    "id": "select_one_element",
+    "translation": "You need to select at least 1 element!"
+  },
+  {
+    "id": "torrent_moved",
+    "translation": "Torrent %s moved!"
+  },
+  {
+    "id": "no_status_exist",
+    "translation": "No such status %d exist!"
+  },
+  {
+    "id": "torrent_deleted",
+    "translation": "Torrent %s deleted!"
+  },
+  {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "no_action_exist",
+    "translation": "No such action %s exist!"
+  },
+  {
+    "id": "torrent_not_exist",
+    "translation": "Torrent with ID %d doesn't exist!"
+  },
+  {
+    "id": "something_went_wrong",
+    "translation": "Something went wrong"
+  },
+  {
+    "id": "nb_torrents_updated",
+    "translation": "%d torrents updated."
+  },
+  {
+    "id": "torrent_updated",
+    "translation": "Torrent details updated."
+  },
+  {
+    "id": "fail_torrent_update",
+    "translation": "Failed to update torrent!"
+  },
+  {
+    "id": "bad_captcha",
+    "translation": "Bad captcha!"
+  },
+  {
+    "id": "comment_empty",
+    "translation": "Comment empty!"
+  },
+  {
+    "id": "no_owner_selected",
+    "translation": "New torrent owner is needed!"
+  },
+  {
+    "id": "no_category_selected",
+    "translation": "No category selected!"
+  },
+  {
+    "id": "no_user_found_id",
+    "translation": "User with id %d isn't in the database!"
+  },
+  {
+    "id": "invalid_torrent_category",
+    "translation": "Torrent category doesn't exist!"
+  },
+  {
+    "id": "torrent_owner_changed",
+    "translation": "Owner of torrent \"%s\" has been successfully changed!"
+  },
+  {
+    "id": "torrent_category_changed",
+    "translation": "Category of torrent \"%s\" has been changed!"
+  },
+  {
+    "id": "torrent_reports_deleted",
+    "translation": "Reports of torrent \"%s\" were deleted!"
+  },
+  {
+    "id": "edit",
+    "translation": "Edit"
+  },
+  {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
+    "id": "delete_definitely_torrent_warning",
+    "translation": "You will not be able to recover the file, neither stop someone to reupload it!"
+  },
+  {
+    "id": "delete_definitely",
+    "translation": "Delete definitely"
+  },
+  {
+    "id": "torrent_unblock",
+    "translation": "Unlock"
+  },
+  {
+    "id": "torrent_block",
+    "translation": "Lock"
+  },
+  {
+    "id": "torrent_deleted_definitely",
+    "translation": "Torrent has been erased from the database!"
+  },
+  {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
+    "id": "torrent_unblocked",
+    "translation": "Torrent has been unlocked!"
+  },
+  {
+    "id": "torrent_blocked",
+    "translation": "Torrent has been locked!"
+  },
+  {
+    "id": "torrent_nav_notdeleted",
+    "translation": "Torrents not deleted"
+  },
+  {
+    "id": "torrent_nav_deleted",
+    "translation": "Torrents deleted"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]

--- a/translations/sv-se.all.json
+++ b/translations/sv-se.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+    "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+    "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+    "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "Bekräfta din mailadress för Nyaapantsu."
   },
@@ -100,6 +120,10 @@
     "translation": "Registreringen var lyckad. Du kan nu använda ditt konto."
   },
   {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "Kontoinställningar"
   },
@@ -132,6 +156,10 @@
     "translation": "Se flera torrents från %s "
   },
   {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
+  },
+  {
     "id": "category",
     "translation": "Kategori"
   },
@@ -160,6 +188,18 @@
     "translation": "Error 404"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "Ladda upp"
   },
@@ -172,12 +212,24 @@
     "translation": "Onanera"
   },
   {
+    "id": "fun",
+    "translation": "Fun"
+  },
+  {
     "id": "nothing_here",
     "translation": "Finns inget här."
   },
   {
     "id": "404_not_found",
     "translation": "404 Not Found"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -260,6 +312,14 @@
     "translation": "Databaserna hostas för tillfället på nyaa.pantsu.cat och sukebei.pantsu.cat. Det går att söka och (nästan) fullständig nyaa-funktionalitet är på gång. Seeder/leecher-statistik är möjlig via scraping och kan återställas i sinom tid; annan funktionalitet tar prioritet för tillfället."
   },
   {
+    "id": "how_do_i_link_my_old_account",
+    "translation": "How do I link my old uploads back to my new account?"
+  },
+  {
+    "id": "answer_how_do_i_link_my_old_account",
+    "translation": "Join <a href=\"ircs://irc.rizon.net/nyaapantsu-help\">#nyaapantsu-help@Rizon</a> and ask a moderator to migrate your old torrents while mentioning your old and new usernames."
+  },
+  {
     "id": "are_the_trackers_working",
     "translation": "Fungerar torrents fortfarande?"
   },
@@ -322,6 +382,10 @@
   {
     "id": "all_categories",
     "translation": "Alla kategorier"
+  },
+  {
+    "id": "select_a_torrent_category",
+    "translation": "Select a Torrent Category"
   },
   {
     "id": "anime",
@@ -416,6 +480,42 @@
     "translation": "Mjukvara - Spel"
   },
   {
+    "id": "art",
+    "translation": "Art"
+  },
+  {
+    "id": "art_anime",
+    "translation": "Art - Anime"
+  },
+  {
+    "id": "art_doujinshi",
+    "translation": "Art - Doujinshi"
+  },
+  {
+    "id": "art_games",
+    "translation": "Art - Games"
+  },
+  {
+    "id": "art_manga",
+    "translation": "Art - Manga"
+  },
+  {
+    "id": "art_pictures",
+    "translation": "Art - Pictures"
+  },
+  {
+    "id": "real_life",
+    "translation": "Real Life"
+  },
+  {
+    "id": "real_life_photobooks_and_pictures",
+    "translation": "Real Life - Photobooks and Pictures"
+  },
+  {
+    "id": "real_life_videos",
+    "translation": "Real Life - Videos"
+  },
+  {
     "id": "torrent_description",
     "translation": "Torrentbeskrivning"
   },
@@ -426,6 +526,10 @@
   {
     "id": "show_all",
     "translation": "Visa allt"
+  },
+  {
+    "id": "delete_all",
+    "translation": "Delete all"
   },
   {
     "id": "filter_remakes",
@@ -446,6 +550,10 @@
   {
     "id": "description",
     "translation": "Beskrivning"
+  },
+  {
+    "id": "no_description",
+    "translation": "No description provided!"
   },
   {
     "id": "comments",
@@ -492,8 +600,16 @@
     "translation": "Pålitlig medlem"
   },
   {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
     "id": "moderator",
     "translation": "Moderator"
+  },
+  {
+    "id": "api_token",
+    "translation": "API Token"
   },
   {
     "id": "save_changes",
@@ -520,6 +636,30 @@
     "translation": "Moderering"
   },
   {
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
+  },
+  {
     "id": "who_is_renchon",
     "translation": "Vem fan är <span lang=\"ja\">れんちょん</span>?"
   },
@@ -536,11 +676,1315 @@
     "translation": "Din mailadress har bytts! Du måste bekräfta adressen genom att klicka på länken som skickats till %s."
   },
   {
+    "id": "torrent_status",
+    "translation": "Torrent status"
+  },
+  {
+    "id": "torrent_status_normal",
+    "translation": "Normal"
+  },
+  {
+    "id": "torrent_status_remake",
+    "translation": "Remake"
+  },
+  {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
+  },
+  {
+    "id": "profile_edit_page",
+    "translation": "Edit %s's profile"
+  },
+  {
+    "id": "seeders",
+    "translation": "Seeders"
+  },
+  {
+    "id": "leechers",
+    "translation": "Leechers"
+  },
+  {
+    "id": "completed",
+    "translation": "Completed"
+  },
+  {
+    "id": "change_language",
+    "translation": "Change Language"
+  },
+  {
     "id": "language_name",
     "translation": "Svenska"
   },
   {
     "id": "language_code",
     "translation": "sv-sv"
+  },
+  {
+    "id": "delete",
+    "translation": "Delete"
+  },
+  {
+    "id": "website_link",
+    "translation": "Website Link"
+  },
+  {
+    "id": "files",
+    "translation": "Files"
+  },
+  {
+    "id": "no_files",
+    "translation": "No files found? That doesn't even make sense!"
+  },
+  {
+    "id": "uploaded_by",
+    "translation": "Uploaded by"
+  },
+  {
+    "id": "report_btn",
+    "translation": "Report"
+  },
+  {
+    "id": "are_you_sure",
+    "translation": "Are you sure?"
+  },
+  {
+    "id": "report_torrent_number",
+    "translation": "Report Torrent #%d"
+  },
+  {
+    "id": "report_type",
+    "translation": "Report type"
+  },
+  {
+    "id": "illegal_content",
+    "translation": "Illegal content"
+  },
+  {
+    "id": "spam_garbage",
+    "translation": "Spam / Garbage"
+  },
+  {
+    "id": "wrong_category",
+    "translation": "Wrong category"
+  },
+  {
+    "id": "duplicate_deprecated",
+    "translation": "Duplicate / Deprecated"
+  },
+  {
+    "id": "captcha",
+    "translation": "Captcha"
+  },
+  {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
+  },
+  {
+    "id": "file_name",
+    "translation": "File Name"
+  },
+  {
+    "id": "cancel",
+    "translation": "Cancel"
+  },
+  {
+    "id": "please_include_our_tracker",
+    "translation": "Please include udp://tracker.doko.moe:6969 in your trackers."
+  },
+  {
+    "id": "unknown",
+    "translation": "Unknown"
+  },
+  {
+    "id": "last_scraped",
+    "translation": "Last scraped: "
+  },
+  {
+    "id": "server_status_link",
+    "translation": "Server status can be found here"
+  },
+  {
+    "id": "no_database_dumps_available",
+    "translation": "No database dumps are available at this moment."
+  },
+  {
+    "id": "clear_notifications",
+    "translation": "Clear Notifications"
+  },
+  {
+    "id": "notifications_cleared",
+    "translation": "Notifications erased!"
+  },
+  {
+    "id": "my_notifications",
+    "translation": "My Notifications"
+  },
+  {
+    "id": "new_torrent_uploaded",
+    "translation": "New torrent: \"%s\" from %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
+  },
+  {
+    "id": "preferences",
+    "translation": "Preferences"
+  },
+  {
+    "id": "new_torrent_settings",
+    "translation": "Be notified when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_torrent_email_settings",
+    "translation": "Be notified by e-mail when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_comment_settings",
+    "translation": "Be notified when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_comment_email_settings",
+    "translation": "Be notified by e-mail when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_responses_settings",
+    "translation": "Be notified when there is a new response to your comment"
+  },
+  {
+    "id": "new_responses_email_settings",
+    "translation": "Be notified by e-mail when there is a new response to your comment"
+  },
+  {
+    "id": "new_follower_settings",
+    "translation": "Be notified when you have a new follower"
+  },
+  {
+    "id": "new_follower_email_settings",
+    "translation": "Be notified by e-mail when you have a new follower"
+  },
+  {
+    "id": "followed_settings",
+    "translation": "Be notified when you have followed someone"
+  },
+  {
+    "id": "followed_email_settings",
+    "translation": "Be notified by e-mail when you have followed someone"
+  },
+  {
+    "id": "yes",
+    "translation": "Yes"
+  },
+  {
+    "id": "no",
+    "translation": "No"
+  },
+  {
+    "id": "new_comment_on_torrent",
+    "translation": "New comment on torrent: \"%s\""
+  },
+  {
+    "id": "no_action_selected",
+    "translation": "You have to tell what you want to do with your selection!"
+  },
+  {
+    "id": "no_move_location_selected",
+    "translation": "Thou has't to telleth whither thee wanteth to moveth thy selection!"
+  },
+  {
+    "id": "select_one_element",
+    "translation": "You need to select at least 1 element!"
+  },
+  {
+    "id": "torrent_moved",
+    "translation": "Torrent %s moved!"
+  },
+  {
+    "id": "no_status_exist",
+    "translation": "No such status %d exist!"
+  },
+  {
+    "id": "torrent_deleted",
+    "translation": "Torrent %s deleted!"
+  },
+  {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "no_action_exist",
+    "translation": "No such action %s exist!"
+  },
+  {
+    "id": "torrent_not_exist",
+    "translation": "Torrent with ID %d doesn't exist!"
+  },
+  {
+    "id": "something_went_wrong",
+    "translation": "Something went wrong"
+  },
+  {
+    "id": "nb_torrents_updated",
+    "translation": "%d torrents updated."
+  },
+  {
+    "id": "torrent_updated",
+    "translation": "Torrent details updated."
+  },
+  {
+    "id": "fail_torrent_update",
+    "translation": "Failed to update torrent!"
+  },
+  {
+    "id": "bad_captcha",
+    "translation": "Bad captcha!"
+  },
+  {
+    "id": "comment_empty",
+    "translation": "Comment empty!"
+  },
+  {
+    "id": "no_owner_selected",
+    "translation": "New torrent owner is needed!"
+  },
+  {
+    "id": "no_category_selected",
+    "translation": "No category selected!"
+  },
+  {
+    "id": "no_user_found_id",
+    "translation": "User with id %d isn't in the database!"
+  },
+  {
+    "id": "invalid_torrent_category",
+    "translation": "Torrent category doesn't exist!"
+  },
+  {
+    "id": "torrent_owner_changed",
+    "translation": "Owner of torrent \"%s\" has been successfully changed!"
+  },
+  {
+    "id": "torrent_category_changed",
+    "translation": "Category of torrent \"%s\" has been changed!"
+  },
+  {
+    "id": "torrent_reports_deleted",
+    "translation": "Reports of torrent \"%s\" were deleted!"
+  },
+  {
+    "id": "edit",
+    "translation": "Edit"
+  },
+  {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
+    "id": "delete_definitely_torrent_warning",
+    "translation": "You will not be able to recover the file, neither stop someone to reupload it!"
+  },
+  {
+    "id": "delete_definitely",
+    "translation": "Delete definitely"
+  },
+  {
+    "id": "torrent_unblock",
+    "translation": "Unlock"
+  },
+  {
+    "id": "torrent_block",
+    "translation": "Lock"
+  },
+  {
+    "id": "torrent_deleted_definitely",
+    "translation": "Torrent has been erased from the database!"
+  },
+  {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
+    "id": "torrent_unblocked",
+    "translation": "Torrent has been unlocked!"
+  },
+  {
+    "id": "torrent_blocked",
+    "translation": "Torrent has been locked!"
+  },
+  {
+    "id": "torrent_nav_notdeleted",
+    "translation": "Torrents not deleted"
+  },
+  {
+    "id": "torrent_nav_deleted",
+    "translation": "Torrents deleted"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]

--- a/translations/zh-cn.all.json
+++ b/translations/zh-cn.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+    "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+    "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+    "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "请验证您的电子邮箱喵~"
   },
@@ -100,6 +120,10 @@
     "translation": "注册成功喵，账号已经可以使用了！"
   },
   {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "账号设置"
   },
@@ -132,6 +156,10 @@
     "translation": "更多种子来自 %s "
   },
   {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
+  },
+  {
     "id": "category",
     "translation": "分类"
   },
@@ -160,6 +188,18 @@
     "translation": "纳尼？ 是 404 喵！"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "上传"
   },
@@ -182,6 +222,14 @@
   {
     "id": "404_not_found",
     "translation": "404 不存在的喵~"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -452,6 +500,10 @@
     "translation": "二次元 - 漫画"
   },
   {
+    "id": "art_pictures",
+    "translation": "Art - Pictures"
+  },
+  {
     "id": "real_life",
     "translation": "三次元"
   },
@@ -476,6 +528,10 @@
     "translation": "显示所有"
   },
   {
+    "id": "delete_all",
+    "translation": "Delete all"
+  },
+  {
     "id": "filter_remakes",
     "translation": "过滤再发行版"
   },
@@ -494,6 +550,10 @@
   {
     "id": "description",
     "translation": "描述"
+  },
+  {
+    "id": "no_description",
+    "translation": "No description provided!"
   },
   {
     "id": "comments",
@@ -540,8 +600,16 @@
     "translation": "受信任会员"
   },
   {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
     "id": "moderator",
     "translation": "管理员"
+  },
+  {
+    "id": "api_token",
+    "translation": "API Token"
   },
   {
     "id": "save_changes",
@@ -568,8 +636,28 @@
     "translation": "节制"
   },
   {
-    "id": "api_token",
-    "translation": "API Token"
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
   },
   {
     "id": "who_is_renchon",
@@ -598,6 +686,10 @@
   {
     "id": "torrent_status_remake",
     "translation": "再发行"
+  },
+  {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
   },
   {
     "id": "profile_edit_page",
@@ -632,8 +724,16 @@
     "translation": "删除"
   },
   {
+    "id": "website_link",
+    "translation": "Website Link"
+  },
+  {
     "id": "files",
     "translation": "文件"
+  },
+  {
+    "id": "no_files",
+    "translation": "No files found? That doesn't even make sense!"
   },
   {
     "id": "uploaded_by",
@@ -674,6 +774,10 @@
   {
     "id": "captcha",
     "translation": "验证码"
+  },
+  {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
   },
   {
     "id": "file_name",
@@ -718,6 +822,10 @@
   {
     "id": "new_torrent_uploaded",
     "translation": "新的资源: \"%s\" 来自 %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
   },
   {
     "id": "preferences",
@@ -800,6 +908,54 @@
     "translation": "种子 %s 已被删除!"
   },
   {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
     "id": "no_action_exist",
     "translation": "操作 %s 不存在!"
   },
@@ -864,6 +1020,10 @@
     "translation": "编辑"
   },
   {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
     "id": "delete_definitely_torrent_warning",
     "translation": "除非你阻止另外一个正在上传这些文件的人，否则你无法恢复她们!"
   },
@@ -884,6 +1044,10 @@
     "translation": "该种子已从数据库中清除!"
   },
   {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
     "id": "torrent_unblocked",
     "translation": "种子已解锁!"
   },
@@ -898,5 +1062,929 @@
   {
     "id": "torrent_nav_deleted",
     "translation": "种子已被删除"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]

--- a/translations/zh-tw.all.json
+++ b/translations/zh-tw.all.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "rules",
+      "translation": "Rules"
+  },
+  {
+    "id": "no_cp",
+      "translation": "No child pornography (lolicon doesn't count)"
+  },
+  {
+    "id": "asia",
+      "translation": "Asian related content only (no Western Movies, no Cartoon)"
+  },
+  {
+    "id": "rules_spam",
+    "translation": "No spam"
+  },
+  {
+    "id": "rules_sukebei",
+    "translation": "NSFW content belongs in sukebei.pantsu.cat"
+  },
+  {
     "id": "verify_email_title",
     "translation": "喵 請驗證您的電子郵件"
   },
@@ -100,6 +120,10 @@
     "translation": "註冊成功，帳號已可供使用"
   },
   {
+    "id": "email_placeholder",
+    "translation": "Can be left blank."
+  },
+  {
     "id": "settings",
     "translation": "帳號設定"
   },
@@ -132,6 +156,10 @@
     "translation": "更多種子來自 %s "
   },
   {
+    "id": "torrents_uploaded",
+    "translation": "Torrents uploaded"
+  },
+  {
     "id": "category",
     "translation": "分類"
   },
@@ -160,6 +188,18 @@
     "translation": "糟糕！ 是 404"
   },
   {
+    "id": "error_400",
+    "translation": "Error 400"
+  },
+  {
+    "id": "error_500",
+    "translation": "Error 500"
+  },
+  {
+    "id": "err_no_results",
+    "translation": "No results found"
+  },
+  {
     "id": "upload",
     "translation": "上傳"
   },
@@ -172,12 +212,24 @@
     "translation": "尻尻"
   },
   {
+    "id": "fun",
+    "translation": "Fun"
+  },
+  {
     "id": "nothing_here",
     "translation": "什麼都沒有"
   },
   {
     "id": "404_not_found",
     "translation": "404 找不到啦"
+  },
+  {
+    "id": "500_internal_server_error",
+    "translation": "500 Internal Server Error"
+  },
+  {
+    "id": "400_bad_request",
+    "translation": "400 Bad Request"
   },
   {
     "id": "no_torrents_uploaded",
@@ -260,6 +312,14 @@
     "translation": "前述的資料庫目前放在 nyaa.pantsu.cat 和 sukebei.pantsu.cat 的伺服器。 我們有搜尋功能，而（幾乎）所有 nyaa 舊有功能將在未來不久後實現。 種子／連線數的統計資訊則可能透過抓取其他 tracker 來恢復，也許在未來某天吧！先做出其他較優先的功能再說。"
   },
   {
+    "id": "how_do_i_link_my_old_account",
+    "translation": "How do I link my old uploads back to my new account?"
+  },
+  {
+    "id": "answer_how_do_i_link_my_old_account",
+    "translation": "Join <a href=\"ircs://irc.rizon.net/nyaapantsu-help\">#nyaapantsu-help@Rizon</a> and ask a moderator to migrate your old torrents while mentioning your old and new usernames."
+  },
+  {
     "id": "are_the_trackers_working",
     "translation": "這些種子都還活著嗎？"
   },
@@ -286,10 +346,6 @@
   {
     "id": "answer_which_trackers_do_you_recommend",
     "translation": "我們現在有自己的 Tracker 啦！如果您上傳種子遭到拒絕，原因是 tracker 不符要求，那有可能需要加上這其中幾個 tracker："
-  },
-  {
-    "id": "other_trackers",
-    "translation": "不過你最好再加上這些，免得雷到。"
   },
   {
     "id": "how_can_i_help",
@@ -424,6 +480,42 @@
     "translation": "軟體 - 遊戲"
   },
   {
+    "id": "art",
+    "translation": "Art"
+  },
+  {
+    "id": "art_anime",
+    "translation": "Art - Anime"
+  },
+  {
+    "id": "art_doujinshi",
+    "translation": "Art - Doujinshi"
+  },
+  {
+    "id": "art_games",
+    "translation": "Art - Games"
+  },
+  {
+    "id": "art_manga",
+    "translation": "Art - Manga"
+  },
+  {
+    "id": "art_pictures",
+    "translation": "Art - Pictures"
+  },
+  {
+    "id": "real_life",
+    "translation": "Real Life"
+  },
+  {
+    "id": "real_life_photobooks_and_pictures",
+    "translation": "Real Life - Photobooks and Pictures"
+  },
+  {
+    "id": "real_life_videos",
+    "translation": "Real Life - Videos"
+  },
+  {
     "id": "torrent_description",
     "translation": "種子描述"
   },
@@ -434,6 +526,10 @@
   {
     "id": "show_all",
     "translation": "列出全部"
+  },
+  {
+    "id": "delete_all",
+    "translation": "Delete all"
   },
   {
     "id": "filter_remakes",
@@ -454,6 +550,10 @@
   {
     "id": "description",
     "translation": "描述"
+  },
+  {
+    "id": "no_description",
+    "translation": "No description provided!"
   },
   {
     "id": "comments",
@@ -500,11 +600,15 @@
     "translation": "受信任會員"
   },
   {
+    "id": "scraped_user",
+    "translation": "Scraped user"
+  },
+  {
     "id": "moderator",
     "translation": "管理員"
   },
   {
-    "id": " api_token",
+    "id": "api_token",
     "translation": "API Token"
   },
   {
@@ -530,6 +634,30 @@
   {
     "id": "moderation",
     "translation": "節制"
+  },
+  {
+    "id": "extensions_and_plugins",
+    "translation": "Extensions and Plugins (made by third-party developers)"
+  },
+  {
+    "id": "qbittorrent_plugin",
+    "translation": "qBittorrent Plugin"
+  },
+  {
+    "id": "local_client",
+    "translation": "Local Client"
+  },
+  {
+    "id": "chrome_extension",
+    "translation": "Chrome Extension"
+  },
+  {
+    "id": "firefox_extension",
+    "translation": "Firefox Extension"
+  },
+  {
+    "id": "android_app",
+    "translation": "Android App"
   },
   {
     "id": "who_is_renchon",
@@ -558,6 +686,10 @@
   {
     "id": "torrent_status_remake",
     "translation": "再發行"
+  },
+  {
+    "id": "torrent_status_blocked",
+    "translation": "Locked"
   },
   {
     "id": "profile_edit_page",
@@ -590,5 +722,1269 @@
   {
     "id": "delete",
     "translation": "刪除"
+  },
+  {
+    "id": "website_link",
+    "translation": "Website Link"
+  },
+  {
+    "id": "files",
+    "translation": "Files"
+  },
+  {
+    "id": "no_files",
+    "translation": "No files found? That doesn't even make sense!"
+  },
+  {
+    "id": "uploaded_by",
+    "translation": "Uploaded by"
+  },
+  {
+    "id": "report_btn",
+    "translation": "Report"
+  },
+  {
+    "id": "are_you_sure",
+    "translation": "Are you sure?"
+  },
+  {
+    "id": "report_torrent_number",
+    "translation": "Report Torrent #%d"
+  },
+  {
+    "id": "report_type",
+    "translation": "Report type"
+  },
+  {
+    "id": "illegal_content",
+    "translation": "Illegal content"
+  },
+  {
+    "id": "spam_garbage",
+    "translation": "Spam / Garbage"
+  },
+  {
+    "id": "wrong_category",
+    "translation": "Wrong category"
+  },
+  {
+    "id": "duplicate_deprecated",
+    "translation": "Duplicate / Deprecated"
+  },
+  {
+    "id": "captcha",
+    "translation": "Captcha"
+  },
+  {
+    "id": "captcha_audio",
+    "translation": "Captcha Audio"
+  },
+  {
+    "id": "file_name",
+    "translation": "File Name"
+  },
+  {
+    "id": "cancel",
+    "translation": "Cancel"
+  },
+  {
+    "id": "please_include_our_tracker",
+    "translation": "Please include udp://tracker.doko.moe:6969 in your trackers."
+  },
+  {
+    "id": "unknown",
+    "translation": "Unknown"
+  },
+  {
+    "id": "last_scraped",
+    "translation": "Last scraped: "
+  },
+  {
+    "id": "server_status_link",
+    "translation": "Server status can be found here"
+  },
+  {
+    "id": "no_database_dumps_available",
+    "translation": "No database dumps are available at this moment."
+  },
+  {
+    "id": "clear_notifications",
+    "translation": "Clear Notifications"
+  },
+  {
+    "id": "notifications_cleared",
+    "translation": "Notifications erased!"
+  },
+  {
+    "id": "my_notifications",
+    "translation": "My Notifications"
+  },
+  {
+    "id": "new_torrent_uploaded",
+    "translation": "New torrent: \"%s\" from %s"
+  },
+  {
+    "id": "torrent_uploaded",
+    "translation": "torrent uploaded successfully!"
+  },
+  {
+    "id": "preferences",
+    "translation": "Preferences"
+  },
+  {
+    "id": "new_torrent_settings",
+    "translation": "Be notified when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_torrent_email_settings",
+    "translation": "Be notified by e-mail when a new torrent is added from a user followed"
+  },
+  {
+    "id": "new_comment_settings",
+    "translation": "Be notified when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_comment_email_settings",
+    "translation": "Be notified by e-mail when there is a new comment on your torrents"
+  },
+  {
+    "id": "new_responses_settings",
+    "translation": "Be notified when there is a new response to your comment"
+  },
+  {
+    "id": "new_responses_email_settings",
+    "translation": "Be notified by e-mail when there is a new response to your comment"
+  },
+  {
+    "id": "new_follower_settings",
+    "translation": "Be notified when you have a new follower"
+  },
+  {
+    "id": "new_follower_email_settings",
+    "translation": "Be notified by e-mail when you have a new follower"
+  },
+  {
+    "id": "followed_settings",
+    "translation": "Be notified when you have followed someone"
+  },
+  {
+    "id": "followed_email_settings",
+    "translation": "Be notified by e-mail when you have followed someone"
+  },
+  {
+    "id": "yes",
+    "translation": "Yes"
+  },
+  {
+    "id": "no",
+    "translation": "No"
+  },
+  {
+    "id": "new_comment_on_torrent",
+    "translation": "New comment on torrent: \"%s\""
+  },
+  {
+    "id": "no_action_selected",
+    "translation": "You have to tell what you want to do with your selection!"
+  },
+  {
+    "id": "no_move_location_selected",
+    "translation": "Thou has't to telleth whither thee wanteth to moveth thy selection!"
+  },
+  {
+    "id": "select_one_element",
+    "translation": "You need to select at least 1 element!"
+  },
+  {
+    "id": "torrent_moved",
+    "translation": "Torrent %s moved!"
+  },
+  {
+    "id": "no_status_exist",
+    "translation": "No such status %d exist!"
+  },
+  {
+    "id": "torrent_deleted",
+    "translation": "Torrent %s deleted!"
+  },
+  {
+    "id": "torrent_deleted_by",
+    "translation": "Torrent #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "torrent_edited_by",
+    "translation": "Torrent #%d from %s has been edited by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been locked by %s."
+  },
+  {
+    "id": "torrent_blocked_by",
+    "translation": "Torrent #%d from %s has been unlocked by %s."
+  },
+  {
+    "id": "torrents_deleted",
+    "translation": "Torrents Deleted"
+  },
+  {
+    "id": "delete_torrent",
+    "translation": "Delete Torrent"
+  },
+  {
+    "id": "delete_report",
+    "translation": "Delete Report"
+  },
+  {
+    "id": "comment_deleted",
+    "translation": "Comment has been deleted!"
+  },
+  {
+    "id": "comment_deleted_by",
+    "translation": "Comment #%d from %s has been deleted by %s."
+  },
+  {
+    "id": "comment_edited_by",
+    "translation": "Comment #%d from %s has been edited by %s."
+  },
+  {
+    "id": "oauth_client_deleted",
+    "translation": "Oauth API Client has been deleted!"
+  },
+  {
+    "id": "oauth_client_deleted_by",
+    "translation": "Oauth API Client #%s from %s has been deleted by %s."
+  },
+  {
+    "id": "no_action_exist",
+    "translation": "No such action %s exist!"
+  },
+  {
+    "id": "torrent_not_exist",
+    "translation": "Torrent with ID %d doesn't exist!"
+  },
+  {
+    "id": "something_went_wrong",
+    "translation": "Something went wrong"
+  },
+  {
+    "id": "nb_torrents_updated",
+    "translation": "%d torrents updated."
+  },
+  {
+    "id": "torrent_updated",
+    "translation": "Torrent details updated."
+  },
+  {
+    "id": "fail_torrent_update",
+    "translation": "Failed to update torrent!"
+  },
+  {
+    "id": "bad_captcha",
+    "translation": "Bad captcha!"
+  },
+  {
+    "id": "comment_empty",
+    "translation": "Comment empty!"
+  },
+  {
+    "id": "no_owner_selected",
+    "translation": "New torrent owner is needed!"
+  },
+  {
+    "id": "no_category_selected",
+    "translation": "No category selected!"
+  },
+  {
+    "id": "no_user_found_id",
+    "translation": "User with id %d isn't in the database!"
+  },
+  {
+    "id": "invalid_torrent_category",
+    "translation": "Torrent category doesn't exist!"
+  },
+  {
+    "id": "torrent_owner_changed",
+    "translation": "Owner of torrent \"%s\" has been successfully changed!"
+  },
+  {
+    "id": "torrent_category_changed",
+    "translation": "Category of torrent \"%s\" has been changed!"
+  },
+  {
+    "id": "torrent_reports_deleted",
+    "translation": "Reports of torrent \"%s\" were deleted!"
+  },
+  {
+    "id": "edit",
+    "translation": "Edit"
+  },
+  {
+    "id": "lock_delete",
+    "translation": "Lock & Delete"
+  },
+  {
+    "id": "delete_definitely_torrent_warning",
+    "translation": "You will not be able to recover the file, neither stop someone to reupload it!"
+  },
+  {
+    "id": "delete_definitely",
+    "translation": "Delete definitely"
+  },
+  {
+    "id": "torrent_unblock",
+    "translation": "Unlock"
+  },
+  {
+    "id": "torrent_block",
+    "translation": "Lock"
+  },
+  {
+    "id": "torrent_deleted_definitely",
+    "translation": "Torrent has been erased from the database!"
+  },
+  {
+    "id": "torrent_not_deleted",
+    "translation": "Torrent was not deleted"
+  },
+  {
+    "id": "torrent_unblocked",
+    "translation": "Torrent has been unlocked!"
+  },
+  {
+    "id": "torrent_blocked",
+    "translation": "Torrent has been locked!"
+  },
+  {
+    "id": "torrent_nav_notdeleted",
+    "translation": "Torrents not deleted"
+  },
+  {
+    "id": "torrent_nav_deleted",
+    "translation": "Torrents deleted"
+  },
+  {
+    "id": "change_settings",
+    "translation": "Change Appearance/Language"
+  },
+  {
+    "id": "mascot",
+    "translation": "Mascot"
+  },
+  {
+    "id": "theme",
+    "translation": "Theme"
+  },
+  {
+    "id": "theme_select",
+    "translation": "Select a Theme"
+  },
+  {
+    "id": "theme_none",
+    "translation": "None"
+  },
+  {
+    "id": "upload_as_anon",
+    "translation": "Upload Anonymously"
+  },
+  {
+    "id": "cookies",
+    "translation": "By clicking save, you consent to our use of cookies"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "hide",
+    "translation": "Hide"
+  },
+  {
+    "id": "nyaa_pantsu",
+    "translation": "Nyaa Pantsu"
+  },
+  {
+    "id": "users",
+    "translation": "Users"
+  },
+  {
+    "id": "torrent_reports",
+    "translation": "Torrent Reports"
+  },
+  {
+    "id": "show_mod_tools",
+    "translation": "Show Mod Tools"
+  },
+  {
+    "id": "hide_mod_tools",
+    "translation": "Hide Mod Tools"
+  },
+  {
+    "id": "following_changes_applied",
+    "translation": "Following changes will be applied"
+  },
+  {
+    "id": "changes_in_following_order",
+    "translation": "Changes will be made in the following order:"
+  },
+  {
+    "id": "edit_changes",
+    "translation": "Edit Changes"
+  },
+  {
+    "id": "delete_changes",
+    "translation": "Delete Changes"
+  },
+  {
+    "id": "owner_id_placeholder",
+    "translation": "New Owner"
+  },
+  {
+    "id": "try_new_attempt",
+    "translation": "Trying a new attempt..."
+  },
+  {
+    "id": "query_is_broken",
+    "translation": "The query ({0}?{1}) seems broken!"
+  },
+  {
+    "id": "query_executed_success",
+    "translation": "Query executed with success!"
+  },
+  {
+    "id": "all_operations_done",
+    "translation": "All operations are done!"
+  },
+  {
+    "id": "refreshing_in",
+    "translation": "Refreshing the page in {0} seconds..."
+  },
+  {
+    "id": "delete_reports_with_torrents",
+    "translation": "Do you want to delete the reports along the selected torrents?"
+  },
+  {
+    "id": "with_st",
+    "translation": "with {0}"
+  },
+  {
+    "id": "and_reports",
+    "translation": " and reports"
+  },
+  {
+    "id": "reports",
+    "translation": "reports"
+  },
+  {
+    "id": "lock",
+    "translation": "lock"
+  },
+  {
+    "id": "status_js",
+    "translation": "status: {0}"
+  },
+  {
+    "id": "owner_id_js",
+    "translation": "owner_id: {0}"
+  },
+  {
+    "id": "category_js",
+    "translation": "category: {0}"
+  },
+  {
+    "id": "no_changes",
+    "translation": "No changes"
+  },
+  {
+    "id": "query_nb",
+    "translation": "Query #{0}"
+  },
+  {
+    "id": "reason",
+    "translation": "Reason"
+  },
+  {
+    "id": "actions",
+    "translation": "Actions"
+  },
+  {
+    "id": "action_select",
+    "translation": "Action..."
+  },
+  {
+    "id": "change_status",
+    "translation": "Change Status"
+  },
+  {
+    "id": "to_status",
+    "translation": "To..."
+  },
+  {
+    "id": "torrents_not_deleted",
+    "translation": "Torrents Not Deleted"
+  },
+  {
+    "id": "more",
+    "translation": "More"
+  },
+  {
+    "id": "last_comments",
+    "translation": "Last Comments"
+  },
+  {
+    "id": "last_reports",
+    "translation": "Last Reports"
+  },
+  {
+    "id": "last_torrents",
+    "translation": "Last Torrents"
+  },
+  {
+    "id": "last_users",
+    "translation": "Last Users"
+  },
+  {
+    "id": "moderation_overview",
+    "translation": "Moderation Overview"
+  },
+  {
+    "id": "users_list",
+    "translation": "Users List"
+  },
+  {
+    "id": "comments_list",
+    "translation": "Comments List"
+  },
+  {
+    "id": "reports_list",
+    "translation": "Reports List"
+  },
+  {
+    "id": "torrents_list",
+    "translation": "Torrents List"
+  },
+  {
+    "id": "torrent_edit_panel",
+    "translation": "Torrent Edit Panel"
+  },
+  {
+    "id": "torrent_reassign",
+    "translation": "Torrent Reassign"
+  },
+  {
+    "id": "reassign_warning",
+    "translation": "Reassigning torrents to a new user is not easily reverted and should be done with care."
+  },
+  {
+    "id": "previous_username",
+    "translation": "Previous Username"
+  },
+  {
+    "id": "torrent_id",
+    "translation": "Torrent ID"
+  },
+  {
+    "id": "reassign_indication",
+    "translation": "One ID per line <b>or</b> a single username"
+  },
+  {
+    "id": "reassign_warning_2",
+    "translation": "Might take a long time, do <b>NOT</b> abort the request."
+  },
+  {
+    "id": "reassign_to",
+    "translation": "Reassign to:"
+  },
+  {
+    "id": "reassign_based_on",
+    "translation": "Reassign based on:"
+  },
+  {
+    "id": "user_id",
+    "translation": "User ID"
+  },
+  {
+    "id": "mascot_url",
+    "translation": "Mascot URL"
+  },
+  {
+    "id": "no_notifications",
+    "translation": "No Notifications"
+  },
+  {
+    "id": "report_msg",
+    "translation": "The torrent #%d has been reported!"
+  },
+  {
+    "id": "email_not_valid",
+    "translation": "Email Address is not valid!"
+  },
+  {
+    "id": "username_illegal",
+    "translation": "Username contains illegal characters!"
+  },
+  {
+    "id": "torrent_language",
+    "translation": "Torrent language"
+  },
+  {
+    "id": "language_not_mandatory",
+    "translation": "Language is not mandatory anymore"
+  },
+  {
+    "id": "language_en-us_name",
+    "translation": "English"
+  },
+  {
+    "id": "language_ca-es_name",
+    "translation": "Catalan"
+  },
+  {
+    "id": "language_de-de_name",
+    "translation": "German"
+  },
+  {
+    "id": "language_es-es_name",
+    "translation": "Spanish"
+  },
+  {
+    "id": "language_es-mx_name",
+    "translation": "Spanish (LATAM)"
+  },
+  {
+    "id": "language_fr-fr_name",
+    "translation": "French"
+  },
+  {
+    "id": "language_hu-hu_name",
+    "translation": "Hungarian"
+  },
+  {
+    "id": "language_is-is_name",
+    "translation": "Icelandic"
+  },
+  {
+    "id": "language_it-it_name",
+    "translation": "Italian"
+  },
+  {
+    "id": "language_ja-jp_name",
+    "translation": "Japanese"
+  },
+  {
+    "id": "language_ko-kr_name",
+    "translation": "Korean"
+  },
+  {
+    "id": "language_nb-no_name",
+    "translation": "Norwegian"
+  },
+  {
+    "id": "language_nl-nl_name",
+    "translation": "Dutch"
+  },
+  {
+    "id": "language_pt-br_name",
+    "translation": "Portuguese (Brazil)"
+  },
+  {
+    "id": "language_pt-pt_name",
+    "translation": "Portuguese (Portugal)"
+  },
+  {
+    "id": "language_ro-ro_name",
+    "translation": "Romanian"
+  },
+  {
+    "id": "language_ru-ru_name",
+    "translation": "Russian"
+  },
+  {
+    "id": "language_sv-se_name",
+    "translation": "Swedish"
+  },
+  {
+    "id": "language_th-th_name",
+    "translation": "Thai"
+  },
+  {
+    "id": "language_zh-cn_name",
+    "translation": "Simplified Chinese"
+  },
+  {
+    "id": "language_zh-tw_name",
+    "translation": "Traditional Chinese"
+  },
+  {
+    "id": "language_other_name",
+    "translation": "Other"
+  },
+  {
+    "id": "language_multiple_name",
+    "translation": "Multiple Languages"
+  },
+  {
+    "id": "activity_list",
+    "translation": "Activity List"
+  },
+  {
+    "id": "activities",
+    "translation": "Activities"
+  },
+  {
+    "id": "filter",
+    "translation": "Filter"
+  },
+  {
+    "id": "error_min_length",
+    "translation": "Minimal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_min_number",
+    "translation": "%s must be %s or greater"
+  },
+  {
+    "id": "error_min_field",
+    "translation": "%s must be equal or greater to %s"
+  },
+  {
+    "id": "error_min_array",
+    "translation": "%s must contain at least %s items"
+  },
+  {
+    "id": "error_less_date",
+    "translation": "%s must be less than the current Date & Time"
+  },
+  {
+    "id": "error_less_array",
+    "translation": "%s must contain less than %s items"
+  },
+  {
+    "id": "error_less_length",
+    "translation": "%s must be less than %s in length"
+  },
+  {
+    "id": "error_less_number",
+    "translation": "%s must be less than %s"
+  },
+  {
+    "id": "error_less_equal_date",
+    "translation": "%s must be less than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_greater_date",
+    "translation": "%s must be greater than the current Date & Time"
+  },
+  {
+    "id": "error_greater_length",
+    "translation": "%s must be greater than %s in length"
+  },
+  {
+    "id": "error_greater_number",
+    "translation": "%s must be greater than %s"
+  },
+  {
+    "id": "error_greater_equal_date",
+    "translation": "%s must be greater than or equal to the current Date & Time"
+  },
+  {
+    "id": "error_max_field",
+    "translation": "%s must be equal or less to %s"
+  },
+  {
+    "id": "error_max_length",
+    "translation": "Maximal length of %s required for the input: %s"
+  },
+  {
+    "id": "error_max_number",
+    "translation": "%s must be %s or less"
+  },
+  {
+    "id": "error_max_array",
+    "translation": "%s must contain at maximum %s items"
+  },
+  {
+    "id": "error_length",
+    "translation": "Length of %s required for the input: %s"
+  },
+  {
+    "id": "error_equal",
+    "translation": "%s is not equal to %s"
+  },
+  {
+    "id": "error_same_value",
+    "translation": "Field '%s' must have the same value as the field '%s'"
+  },
+  {
+    "id": "error_field",
+    "translation": "Unexpected error on field: %s"
+  },
+  {
+    "id": "error_not_equal",
+    "translation": "%s should not be equal to %s"
+  },
+  {
+    "id": "error_wrong_value",
+    "translation": "Wrong value for the input: %s"
+  },
+  {
+    "id": "error_field_needed",
+    "translation": "Field needed: %s"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_alpha",
+    "translation": "%s can only contain alphabetic characters"
+  },
+  {
+    "id": "error_alphanum",
+    "translation": "%s can only contain alphanumeric characters"
+  },
+  {
+    "id": "error_numeric_valid",
+    "translation": "%s must be a valid numeric value"
+  },
+  {
+    "id": "error_number_valid",
+    "translation": "%s must be a valid number"
+  },
+  {
+    "id": "error_hexadecimal_valid",
+    "translation": "%s must be a valid hexadecimal"
+  },
+  {
+    "id": "error_hex_valid",
+    "translation": "%s must be a valid HEX color"
+  },
+  {
+    "id": "error_rgb_valid",
+    "translation": "%s must be a valid RGB color"
+  },
+  {
+    "id": "error_rgba_valid",
+    "translation": "%s must be a valid RGBA color"
+  },
+  {
+    "id": "error_hsl_valid",
+    "translation": "%s must be a valid HSL color"
+  },
+  {
+    "id": "error_hsla_valid",
+    "translation": "%s must be a valid HSLA color"
+  },
+  {
+    "id": "error_url_valid",
+    "translation": "%s must be a valid URL"
+  },
+  {
+    "id": "error_uri_valid",
+    "translation": "%s must be a valid URI"
+  },
+  {
+    "id": "error_base64_valid",
+    "translation": "%s must be a valid Base64 string"
+  },
+  {
+    "id": "error_contains",
+    "translation": "%s must contain the text '%s'"
+  },
+  {
+    "id": "error_contains_any",
+    "translation": "%s must contain at least one of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes",
+    "translation": "%s cannot contain the text '%s'"
+  },
+  {
+    "id": "error_excludes_all",
+    "translation": "%s cannot contain any of the following characters '%s'"
+  },
+  {
+    "id": "error_excludes_rune",
+    "translation": "%s cannot contain the following '%s'"
+  },
+  {
+    "id": "error_color_valid",
+    "translation": "%s must be a valid color"
+  },
+  {
+    "id": "error_",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "error_len_array",
+    "translation": "%s must contain %s items"
+  },
+  {
+    "id": "refine_search",
+    "translation": "Refine your search"
+  },
+  {
+    "id": "between",
+    "translation": "Between"
+  },
+  {
+    "id": "and",
+    "translation": "and"
+  },
+  {
+    "id": "days",
+    "translation": "Days"
+  },
+  {
+    "id": "months",
+    "translation": "Months"
+  },
+  {
+    "id": "years",
+    "translation": "Years"
+  },
+  {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
+    "id": "large",
+    "translation": "large."
+  },
+  {
+    "id": "old",
+    "translation": "old"
+  },
+  {
+    "id": "optional",
+    "translation": "Optional"
+  },
+  {
+    "id": "search_for",
+    "translation": "Search for"
+  },
+  {
+    "id": "show",
+    "translation": "Show"
+  },
+  {
+    "id": "username_taken",
+    "translation": "Username already taken, you can choose: %s"
+  },
+  {
+    "id": "email_in_db",
+    "translation": "Email address already in database"
+  },
+  {
+    "id": "user_not_found",
+    "translation": "User not found"
+  },
+  {
+    "id": "incorrect_password",
+    "translation": "Password Incorrect"
+  },
+  {
+    "id": "password_error_generating",
+    "translation": "Error when generating your password hash"
+  },
+  {
+    "id": "permission_delete_error",
+    "translation": "You don't have the right to delete this"
+  },
+  {
+    "id": "no_username_password",
+    "translation": "No username/password entered"
+  },
+  {
+    "id": "account_banned",
+    "translation": "Account banned"
+  },
+  {
+    "id": "account_need_activation",
+    "translation": "This account needs activation from Moderators, please contact us"
+  },
+  {
+    "id": "retrieve_torrent_error",
+    "translation": "Couldn't retrieve torrents"
+  },
+  {
+    "id": "multiple_username_error",
+    "translation": "More than one username given"
+  },
+  {
+    "id": "elevating_user_error",
+    "translation": "Elevating status to moderator is prohibited"
+  },
+  {
+    "id": "parse_error_line",
+    "translation": "Couldn't parse on line %d"
+  },
+  {
+    "id": "language_not_available",
+    "translation": "Language not available"
+  },
+  {
+    "id": "mascot_url_too_long",
+    "translation": "Mascot URL is too long (max is 255 chars)"
+  },
+  {
+    "id": "mascor_url_parse_error",
+    "translation": "Error occurred when parsing mascot URL: %s"
+  },
+  {
+    "id": "no_id_given",
+    "translation": "No torrent ID given"
+  },
+  {
+    "id": "error_api_token",
+    "translation": "Error API token doesn't exist"
+  },
+  {
+    "id": "uploads_disabled",
+    "translation": "Uploads are disabled"
+  },
+  {
+    "id": "try_to_delete_report_inexistant",
+    "translation": "Trying to delete a torrent report that does not exists"
+  },
+  {
+    "id": "torrent_report_not_created",
+    "translation": "TorrentReport was not created"
+  },
+  {
+    "id": "user_not_deleted",
+    "translation": "User wasn't deleted"
+  },
+  {
+    "id": "error_content_type_post",
+    "translation": "Please provide either of Content-Type: application/json header or multipart/form-data"
+  },
+  {
+    "id": "torrent_name_invalid",
+    "translation": "Torrent name is invalid"
+  },
+  {
+    "id": "torrent_private",
+    "translation": "Torrent is private"
+  },
+  {
+    "id": "torrent_no_working_trackers",
+    "translation": "Torrent does not have any (working) trackers: <a href=\"/faq#trackers\">Trackers List</a>"
+  },
+  {
+    "id": "torrent_desc_invalid",
+    "translation": "Torrent description is invalid"
+  },
+  {
+    "id": "torrent_cat_invalid",
+    "translation": "Torrent category is invalid"
+  },
+  {
+    "id": "torrent_lang_invalid",
+    "translation": "Language sent is not yet supported! You can help supporting it by contributing in our github page"
+  },
+  {
+    "id": "torrent_cat_is_english",
+    "translation": "Torrent's category is for English translations, but language wasn't English. We changed it to english"
+  },
+  {
+    "id": "torrent_cat_not_english",
+    "translation": "Torrent's category is for non-English translations, but language selected is only English"
+  },
+  {
+    "id": "torrent_magnet_invalid",
+    "translation": "Magnet couldn't be parsed, please check it"
+  },
+  {
+    "id": "torrent_hash_invalid",
+    "translation": "Torrent hash is incorrect"
+  },
+  {
+    "id": "torrent_plus_magnet",
+    "translation": "Upload either a torrent file or magnet link, not both"
+  },
+  {
+    "id": "torrent_file_invalid",
+    "translation": "Torrent File is invalid"
+  },
+  {
+    "id": "torrent_uri_invalid",
+    "translation": "Website url or IRC link is invalid"
+  },
+  {
+    "id": "api_documentation",
+    "translation": "API documentation"
+  },
+  {
+    "id": "api_help",
+    "translation": "Do you have an api?"
+  },
+  {
+    "id": "trusted",
+    "translation": "Torrents uploaded by trusted users."
+  },
+  {
+    "id": "reencodes",
+    "translation": "Re-encodes"
+  },
+  {
+    "id": "remux",
+    "translation": "Remux of another uploader's original release"
+  },
+  {
+    "id": "reupload",
+    "translation": "Reupload of another users torrent with missing and/or unrelated additional files."
+  },
+  {
+    "id": "red",
+    "translation": "Red entries are: "
+  },
+  {
+    "id": "green",
+    "translation": "Green entries are:"
+  },
+  {
+    "id": "torrent_colors",
+    "translation": "Torrent colors"
+  },
+  {
+    "id": "torrent_preview",
+    "translation": "Preview your torrent"
+  },
+  {
+    "id": "announcement",
+    "translation": "Announcement"
+  },
+  {
+    "id": "update_client_failed",
+    "translation": "Update of the client has failed!"
+  },
+  {
+    "id": "update_client_success",
+    "translation": "You have successfully updated the client!"
+  },
+  {
+    "id": "update_client_panel",
+    "translation": "Update a Client"
+  },
+  {
+    "id": "create_client_success",
+    "translation": "You have successfully created the client!"
+  },
+  {
+    "id": "create_client_failed",
+    "translation": "Client creation has failed!"
+  },
+  {
+    "id": "create_client_panel",
+    "translation": "Create a new Client"
+  },
+  {
+    "id": "redirect_uri",
+    "translation": "Redirect URI"
+  },
+  {
+    "id": "grant_types",
+    "translation": "Grant Types"
+  },
+  {
+    "id": "response_types",
+    "translation": "Response Types"
+  },
+  {
+    "id": "scope",
+    "translation": "Scopes"
+  },
+  {
+    "id": "owner",
+    "translation": "Owner"
+  },
+  {
+    "id": "policy_uri",
+    "translation": "Policy URI"
+  },
+  {
+    "id": "tos_uri",
+    "translation": "Terms Of Service URI"
+  },
+  {
+    "id": "logo_uri",
+    "translation": "Logo URI"
+  },
+  {
+    "id": "contacts",
+    "translation": "Owner Emails"
+  },
+  {
+    "id": "oauth_clients_list",
+    "translation": "OAuth API Clients"
+  },
+  {
+    "id": "add",
+    "translation": "Add"
+  },
+  {
+    "id": "remove",
+    "translation": "Remove"
+  },
+  {
+    "id": "secret",
+    "translation": "Client Secret"
+  },
+  {
+    "id": "torrent_age",
+    "translation": "{1} days {2} hours ago"
+  },
+  {
+    "id": "wrong_tag_type",
+    "translation": "The tag type selected doesn't exist"
+  },
+  {
+    "id": "add_tag",
+    "translation": "Add a Tag"
+  },
+  {
+    "id": "tagtype",
+    "translation": "Tag Type"
+  },
+  {
+    "id": "tagtype_anidbid",
+    "translation": "Anidb ID"
+  },
+  {
+    "id": "tagtype_vndbid",
+    "translation": "VNdb ID"
+  },
+  {
+    "id": "tagtype_quality",
+    "translation": "Video Quality"
+  },
+  {
+    "id": "torrent_tags",
+    "translation": "Torrent tags"
+  },
+  {
+    "id": "announcements",
+    "translation": "Announcements"
+  },
+  {
+    "id": "message",
+    "translation": "Message"
+  },
+  {
+    "id": "delay",
+    "translation": "Delay"
+  },
+  {
+    "id": "update_annoucement_panel",
+    "translation": "Update Announcement"
+  },
+  {
+    "id": "create_annoucement_panel",
+    "translation": "Create Announcement"
+  },
+  {
+    "id": "expire",
+    "translation": "Expire"
   }
 ]


### PR DESCRIPTION
This concerns the currently 2+ months old translations: es-es, hu-hu, is-is, ko-kr, nb-no, ru-ru, sv-se, zh-cn, zh-tw

Note: No actual Translations were made.

These translations are now on par with the en-us one.  Old strings weren't overwritten. 
Its now a shitton easier for the translators of their respective country to translate the strings now since all the mess of old unorganized strings is properly aligned to the english translation for better future translations.



