### PR TITLE
Show hours & minutes (instead of days & hours) when hovering last scraped date

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -57,8 +57,8 @@ function parseAllDates() {
     var dateDifference = dateDiff(new Date(e.innerText), new Date())
     
     if(e.className.includes("scrape-date"))
-      e.title = dateDifference.d + " days " + dateDifference.h + " hours " + dateDifference.m + " minutes ago" + 
-    //e.title = T.r("torrent_age", dateDifference.d, dateDifference.h, dateDifference.m)
+      e.title = ((dateDifference.d * 24) + dateDifference.h) + " hours " + dateDifference.m + " minutes ago" + 
+    //e.title = T.r("torrent_age2", dateDifference.h, dateDifference.m)
     else
       e.title = dateDifference.d + " days " + dateDifference.h + " hours ago"
 	  

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -55,7 +55,13 @@ function parseAllDates() {
   for (var i in list) {
     var e = list[i]
     var dateDifference = dateDiff(new Date(e.innerText), new Date())
-	  e.title = dateDifference.d + " days " + dateDifference.h + " hours ago"
+    
+    if(e.className.includes("scrape-date"))
+      e.title = dateDifference.d + " days " + dateDifference.h + " hours " + dateDifference.m + " minutes ago" + 
+    //e.title = T.r("torrent_age", dateDifference.d, dateDifference.h, dateDifference.m)
+    else
+      e.title = dateDifference.d + " days " + dateDifference.h + " hours ago"
+	  
     //e.title = T.r("torrent_age", dateDifference.d, dateDifference.h)
     e.innerText = new Date(e.innerText).toLocaleString(lang)
   }
@@ -64,6 +70,7 @@ function dateDiff( str1, str2 ) {
     var diff = Date.parse( str2 ) - Date.parse( str1 ); 
     return isNaN( diff ) ? NaN : {
         diff : diff,
+	m  : Math.floor( diff /     60000 %   60 ),
         h  : -Math.floor( diff /  3600000 %   24 ),
         d  : -Math.floor( diff / 86400000        )
     };

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -48,7 +48,7 @@
       <td class="torrent-info-td torrent-info-label">{{ T("size")}}:</td>
       <td class="torrent-view-td torrent-info-data">{{ fileSize(Torrent.Filesize, T) }}</td>
       <td class="torrent-info-td torrent-info-label">{{ T("last_scraped")}}</td>
-      <td class="torrent-info-td{{if !Torrent.LastScrape.IsZero && formatDateRFC(Torrent.LastScrape) != "0001-01-01T00:00:00Z"}} date-full">{{formatDateRFC(Torrent.LastScrape)}}{{else}}">{{ T("unknown")}}{{end}}</td>
+      <td class="torrent-info-td scrape-date{{if !Torrent.LastScrape.IsZero && formatDateRFC(Torrent.LastScrape) != "0001-01-01T00:00:00Z"}} date-full">{{formatDateRFC(Torrent.LastScrape)}}{{else}}">{{ T("unknown")}}{{end}}</td>
     </tr>
     {{ if len(Torrent.Languages) > 0 && Torrent.Languages[0] != "" }}
     <tr class="torrent-info-row">


### PR DESCRIPTION
Hovering it show the difference between the date and current date (2 days 5 hours ago), since stat scraping tends to happen frequently we'll show hours & minutes instead