### PR TITLE
Fix "sign in" nav btn that would take more space than what it contained

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -121,6 +121,7 @@ body {
     text-decoration: none;
     background: none;
     border: none;
+    max-width: 100%;
 }
 
 .header .h-search {


### PR DESCRIPTION
Would be at 100+px constantly, even if the h-user that contained it was half of that.