### PR TITLE
Fix horrible subs description / <code>'s width in description

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1118,6 +1118,7 @@ input.filelist-checkbox:checked+table.table-filelist {
     max-width: 100%;
     max-height: 100%;
 }
+#description-box code { white-space: normal; }
 
 
 /* Markdown editor fixes */

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1118,8 +1118,10 @@ input.filelist-checkbox:checked+table.table-filelist {
     max-width: 100%;
     max-height: 100%;
 }
-#description-box code { white-space: normal; }
 
+#description-box code { 
+	white-space: normal; 
+}
 
 /* Markdown editor fixes */
 


### PR DESCRIPTION
Before
![before](https://user-images.githubusercontent.com/11745692/28991272-27c4707e-7986-11e7-8a11-b6e6e0622e0d.png)
After
![after](https://user-images.githubusercontent.com/11745692/28991275-2980cc14-7986-11e7-8945-bc6e033fd3ab.png)
