### PR TITLE
tr-links of lower size if no torrent link & some other stuff

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -392,7 +392,7 @@ select.form-input {
 .form-refine .refine-category {
     border-left: none;
     border-radius: 0 3px 3px 0;
-    max-width: 43%;
+    max-width: 42%;
 }
 
 .box.refine > form > div {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -669,24 +669,34 @@ html, body {
     }
     .header .h-user>.nav-btn {
         padding: 0 3px!important;
-		font-size: 85%;
-		width: 100%;
+	font-size: 85%;
+	width: 100%;
     }
-	.header .h-user>a.nav-btn { padding: 0!important; }
-	.nav-btn.log-in span { display: none; }
-	.nav-btn.log-in div { display: block; }
+    .header .h-user>a.nav-btn { padding: 0!important; }
+    .nav-btn.log-in span { display: none; }
+    .nav-btn.log-in div { display: block; }
 }
 
 /* Image category shrinking & padding lowering between 1050 & 860px, do not modify any of these values */
 @media (max-width: 1050px) { 
-	.tr-cat { width: 8.7%; }
-	.torrent-preview-table .tr-cat { width: 9.1%; }
-	th, .home-td, .user-td { padding: 2px 0.25%; }
+    .tr-cat {
+	width: 8.7%;
+    }
+    .torrent-preview-table .tr-cat {
+	width: 9.1%;
+     }
+     th, .home-td, .user-td {
+	 padding: 2px 0.25%!important;
+    }
 }
 
 @media (max-width: 860px) { 
-	.tr-cat { width: 71px; }
-	th, .home-td, .user-td { padding: 2px 2px; }
+    .tr-cat {
+	width: 71px;
+    }
+    th, .home-td, .user-td {
+	padding: 2px 2px!important;
+    }
 }
 /* end of category shrinking */
 
@@ -703,22 +713,24 @@ html, body {
     .visible-md {
         display: block
     }
-	.user-td.tr-date { width: 100px; }
-	.user-td.tr-size { width: 77px; }
-	.box.refine > form > div { display: inline-grid !important; }
-	.box.refine > form > div > div { width: 100%!important; }
-	.refine-btn,.language { 
-		position: initial!important;
-		bottom: initial!important; 
-		width: 100%!important;
-	}
-	.language { width: initial!important; }
-	.refine-container-2 { margin-top: 5px; }
-	.hide-xs { display: none !important; }
+    .user-td.tr-date { width: 100px; }
+    .user-td.tr-size { width: 77px; }
+    .box.refine > form > div { display: inline-grid !important; }
+    .box.refine > form > div > div { width: 100%!important; }
+    .refine-btn,.language { 
+	position: initial!important;
+	bottom: initial!important; 
+	width: 100%!important;
+    }
+     .language { width: initial!important; }
+    .refine-container-2 { margin-top: 5px; }
+    .hide-xs { display: none !important; }
 }
 
 @media (max-width: 810px) {
-    body { margin: 8px 0; }
+    body {
+	margin: 8px 0;
+    }
     .torrent-info-row>td {
         display: block;
     }
@@ -782,7 +794,7 @@ html, body {
 	left: 25%;
     }
     .tr-links {
-        width: 44px!important;
+        width: 44px;
     }
     .hide-smol {
         display: none!important;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -392,7 +392,7 @@ select.form-input {
 .form-refine .refine-category {
     border-left: none;
     border-radius: 0 3px 3px 0;
-    max-width: 50%;
+    max-width: 43%;
 }
 
 .box.refine > form > div {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -813,8 +813,12 @@ html, body {
 }
 
 @media (max-width: 565px) {
-    .header .h-search { margin-right: 0; }
-    .header .h-search input { width: 90px !important; }
+    .header .h-search {
+	margin-right: 0;
+    }
+    .header .h-search input {
+	width: 90px !important;
+   }
     .form-input.refine {
 	position: fixed;
 	border: 1px solid black;
@@ -828,14 +832,35 @@ html, body {
     .hide-smol {
         display: none!important;
     }
-    .header .nav-btn { padding: 0px 6px!important;}
-    .form-input.form-category { width: 72px; margin-right: -5px; border-right: none; }
-    span.spacing { display: none!important; }
-    .form-refine .refine-category { width: 45%; }
-    .form-refine .refine-searchbox { width: 55%; }
-    .form-refine .refine-searchbox::placeholder { opacity: 1; }
-    .language { width: 350px; }
-    #footer { padding-bottom: 25px; }
+    .header .nav-btn {
+	padding: 0px 6px!important;
+    }
+    .form-input.form-category {
+	width: 72px;
+	margin-right: -5px;
+	border-right: none;
+    }
+    span.spacing {
+	display: none!important;
+    }
+    .form-refine input.form-input {
+	width: 80px;
+    }
+    .form-refine .refine-category {
+	width: 45%;
+    }
+    .form-refine .refine-searchbox {
+	width: 55%!important;
+    }
+    .form-refine .refine-searchbox::placeholder {
+	opacity: 1;
+    }
+    .language {
+	width: 350px;
+    }
+    #footer {
+	padding-bottom: 25px;
+    }
 }
 
 @media (max-width: 440px) {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -839,6 +839,7 @@ html, body {
 	width: 72px;
 	margin-right: -5px;
 	border-right: none;
+	border-radius: 3px 0 0 3px;
     }
     span.spacing {
 	display: none!important;
@@ -865,6 +866,7 @@ html, body {
 
 @media (max-width: 440px) {
     .header .nav-btn { padding: 0px 3px!important;}
+    .form-input.form-category { width: 55px; }
 }
 
 .up-input {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -770,7 +770,7 @@ html, body {
         padding-left: 5px;
     }
     .profile-main {
-        display: inline-grid !important;
+        display: block!important;
     }
     .profile-panel, .profile-content {
         border-radius: 4px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -732,7 +732,7 @@ html, body {
 	width: 77px;
     }
     .box.refine > form > div {
-	display: inline-grid !important;
+	display: block;
     }
     .box.refine > form > div > div {
 	width: 100%!important;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -672,9 +672,18 @@ html, body {
 	font-size: 85%;
 	width: 100%;
     }
-    .header .h-user>a.nav-btn { padding: 0!important; }
-    .nav-btn.log-in span { display: none; }
-    .nav-btn.log-in div { display: block; }
+    .header .h-user>a.nav-btn {
+	padding: 0!important;
+    }
+    .nav-btn.log-in span {
+	display: none;
+    }
+    .nav-btn.log-in div {
+	display: block;
+    }
+    .tr-se, .tr-le, .tr-dl {
+	width: 46px;
+    }
 }
 
 /* Image category shrinking & padding lowering between 1050 & 860px, do not modify any of these values */
@@ -686,7 +695,7 @@ html, body {
 	width: 9.1%;
      }
      th, .home-td, .user-td {
-	 padding: 2px 0.25%!important;
+	 padding: 2px 0.4%!important;
     }
 }
 
@@ -713,18 +722,32 @@ html, body {
     .visible-md {
         display: block
     }
-    .user-td.tr-date { width: 100px; }
-    .user-td.tr-size { width: 77px; }
-    .box.refine > form > div { display: inline-grid !important; }
-    .box.refine > form > div > div { width: 100%!important; }
+    .user-td.tr-date {
+	width: 100px;
+    }
+    .user-td.tr-size {
+	width: 77px;
+    }
+    .box.refine > form > div {
+	display: inline-grid !important;
+    }
+    .box.refine > form > div > div {
+	width: 100%!important;
+    }
     .refine-btn,.language { 
 	position: initial!important;
 	bottom: initial!important; 
 	width: 100%!important;
     }
-     .language { width: initial!important; }
-    .refine-container-2 { margin-top: 5px; }
-    .hide-xs { display: none !important; }
+    .language {
+	width: initial!important;
+    }
+    .refine-container-2 {
+	margin-top: 5px;
+    }
+    .hide-xs {
+	display: none !important;
+    }
 }
 
 @media (max-width: 810px) {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -506,6 +506,9 @@ th {
     text-align: left;
     padding: 0 2px!important;
 }
+.tr-links.no-torrent {
+    width: 27px!important;
+}
 
 .tr-cs {
     width: 15px;
@@ -749,9 +752,6 @@ html, body {
     .tr-se, .tr-le {
         width: 36px;
     }
-    .tr-links {
-        width: 48px;
-    }
     .header .h-search input { width: 84px !important; }
     .box {
         padding: 8px;
@@ -782,7 +782,7 @@ html, body {
 	left: 25%;
     }
     .tr-links {
-        width: 44px;
+        width: 44px!important;
     }
     .hide-smol {
         display: none!important;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -124,7 +124,10 @@ body {
     border: none;
     max-width: 100%;
 }
-.nav-btn.log-in div { display: none; font-size: 16px; }
+.nav-btn.log-in div {
+    display: none;
+    font-size: 17px;
+}
 .header .h-search {
     margin-right: 6px;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -698,7 +698,7 @@ html, body {
 	width: 9.1%;
      }
      th, .home-td, .user-td {
-	 padding: 2px 0.4%!important;
+	 padding: 2px 0.3%!important;
     }
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -748,6 +748,9 @@ html, body {
     .refine-container-2 {
 	margin-top: 5px;
     }
+    .form-refine .refine-category {
+	max-width: 44%;
+    }
     .hide-xs {
 	display: none !important;
     }

--- a/templates/layouts/partials/torrent_item.jet.html
+++ b/templates/layouts/partials/torrent_item.jet.html
@@ -52,7 +52,7 @@ Templates.Add("torrents.item", function(torrent) {
         </div></td>
         <td class="tr-name home-td"` +  colspan + `><a href="/view/` + torrent.id + `">` + Templates.EncodeEntities(torrent.name) + `</a></td>
         `+ commentTd +`
-        <td class="tr-links home-td` + dlLink == `` ? ` no-torrent` : `` + `">
+        <td class="tr-links home-td` + (dlLink == "" ? " no-torrent" : "") + `">
             <a href="` + torrent.magnet + `" title="{{ T("magnet_link") }}">
                 <div class="icon-magnet"></div>
             </a>`+ dlLink +`

--- a/templates/layouts/partials/torrent_item.jet.html
+++ b/templates/layouts/partials/torrent_item.jet.html
@@ -52,7 +52,7 @@ Templates.Add("torrents.item", function(torrent) {
         </div></td>
         <td class="tr-name home-td"` +  colspan + `><a href="/view/` + torrent.id + `">` + Templates.EncodeEntities(torrent.name) + `</a></td>
         `+ commentTd +`
-        <td class="tr-links home-td">
+        <td class="tr-links home-td` + dlLink == `` ? ` no-torrent` : `` + `">
             <a href="` + torrent.magnet + `" title="{{ T("magnet_link") }}">
                 <div class="icon-magnet"></div>
             </a>`+ dlLink +`

--- a/templates/layouts/partials/torrent_item_upload.jet.html
+++ b/templates/layouts/partials/torrent_item_upload.jet.html
@@ -43,7 +43,7 @@ Templates.Add("torrents.item", function(torrent) {
         </div></td>
         <td class="tr-name home-td"` +  colspan + `><a>` + Templates.EncodeEntities(torrent.name) + `</a></td>
         `+ commentTd +`
-        <td class="tr-links home-td` + dlLink == `` ? ` no-torrent` : `` + `">
+        <td class="tr-links home-td` + (dlLink == "" ? " no-torrent" : "")+ `">
             <a  title="{{ T("magnet_link") }}">
                 <div class="icon-magnet"></div>
             </a>`+ dlLink +`

--- a/templates/layouts/partials/torrent_item_upload.jet.html
+++ b/templates/layouts/partials/torrent_item_upload.jet.html
@@ -43,7 +43,7 @@ Templates.Add("torrents.item", function(torrent) {
         </div></td>
         <td class="tr-name home-td"` +  colspan + `><a>` + Templates.EncodeEntities(torrent.name) + `</a></td>
         `+ commentTd +`
-        <td class="tr-links home-td">
+        <td class="tr-links home-td` + dlLink == `` ? ` no-torrent` : `` + `">
             <a  title="{{ T("magnet_link") }}">
                 <div class="icon-magnet"></div>
             </a>`+ dlLink +`

--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -84,7 +84,7 @@
           <span>{{len(.Comments)}}</span>
         </td>
         {{ end }}
-        <td class="tr-links home-td">
+        <td class="tr-links home-td{{if .TorrentLink == ""}} no-torrent{{end}}">
           <a href="{{.Magnet}}" title="{{  T("magnet_link") }}">
             <div class="icon-magnet"></div>
           </a>


### PR DESCRIPTION
tr-links: Reduced size if no torrent link, but should be aligned with all the others
Also fix padding that didn't apply because of missing !important
last fixes for refine that visually somewhat broke at some very specific resolution
On IE & low res, refine & profile user to be quite broken because of display: inline-grid not being supported, it now works