### PR TITLE
Remove unused stuff

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -509,9 +509,6 @@ th {
     text-align: left;
     padding: 0 2px!important;
 }
-.tr-links.no-torrent {
-    width: 27px!important;
-}
 
 .tr-cs {
     width: 15px;

--- a/templates/layouts/partials/torrent_item.jet.html
+++ b/templates/layouts/partials/torrent_item.jet.html
@@ -52,7 +52,7 @@ Templates.Add("torrents.item", function(torrent) {
         </div></td>
         <td class="tr-name home-td"` +  colspan + `><a href="/view/` + torrent.id + `">` + Templates.EncodeEntities(torrent.name) + `</a></td>
         `+ commentTd +`
-        <td class="tr-links home-td` + (dlLink == "" ? " no-torrent" : "") + `">
+        <td class="tr-links home-td">
             <a href="` + torrent.magnet + `" title="{{ T("magnet_link") }}">
                 <div class="icon-magnet"></div>
             </a>`+ dlLink +`

--- a/templates/layouts/partials/torrent_item_upload.jet.html
+++ b/templates/layouts/partials/torrent_item_upload.jet.html
@@ -43,7 +43,7 @@ Templates.Add("torrents.item", function(torrent) {
         </div></td>
         <td class="tr-name home-td"` +  colspan + `><a>` + Templates.EncodeEntities(torrent.name) + `</a></td>
         `+ commentTd +`
-        <td class="tr-links home-td` + (dlLink == "" ? " no-torrent" : "")+ `">
+        <td class="tr-links home-td">
             <a  title="{{ T("magnet_link") }}">
                 <div class="icon-magnet"></div>
             </a>`+ dlLink +`

--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -84,7 +84,7 @@
           <span>{{len(.Comments)}}</span>
         </td>
         {{ end }}
-        <td class="tr-links home-td{{if .TorrentLink == ""}} no-torrent{{end}}">
+        <td class="tr-links home-td">
           <a href="{{.Magnet}}" title="{{  T("magnet_link") }}">
             <div class="icon-magnet"></div>
           </a>


### PR DESCRIPTION
Had planned to leave more room for torrent names if torrent link was missing but after some testing it turned out to be quite ugly, and moving the magnet link to the torrent link position when there is no torrent-link also is ugly so this stuff is useless