### PR TITLE
Lower title (h3) margins in refine & some small other stuff

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -386,13 +386,14 @@ select.form-input {
 .form-refine .refine-searchbox {
     border-radius: 3px 0 0 3px;
     width: 21%;
-    min-width: 170px;
+    min-width: 190px;
 }
 
 .form-refine .refine-category {
     border-left: none;
     border-radius: 0 3px 3px 0;
-    max-width: 42%;
+    max-width: 41%;
+    min-width: 162px;
 }
 
 .box.refine > form > div {
@@ -749,7 +750,7 @@ html, body {
 	margin-top: 5px;
     }
     .form-refine .refine-category {
-	max-width: 44%;
+	max-width: 30%;
     }
     .hide-xs {
 	display: none !important;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -127,6 +127,7 @@ body {
 .nav-btn.log-in div {
     display: none;
     font-size: 17px;
+    line-height: 65px;
 }
 .header .h-search {
     margin-right: 6px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -352,7 +352,7 @@ select.form-input {
 
 .box.refine h3 {
     margin-top: 1px;
-    margin-bottom: 10px;
+    margin-bottom: 11px;
 }
 
 .box.refine input[type="number"] {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -382,11 +382,13 @@ select.form-input {
     display: inline-block;
 }
 
-.form-refine .refine-searchbox::placeholder { opacity: 0; }
+.form-refine .refine-searchbox::placeholder {
+    opacity: 0;
+}
 .form-refine .refine-searchbox {
     border-radius: 3px 0 0 3px;
     width: 21%;
-    min-width: 190px;
+    min-width: 170px;
 }
 
 .form-refine .refine-category {
@@ -399,8 +401,13 @@ select.form-input {
 .box.refine > form > div {
 	display: flex;
 }
-.box.refine .refine-container-1 { width: 53%; }
-.box.refine .refine-container-2 { width: 47%; position: relative; }
+.box.refine .refine-container-1 {
+    width: 53%;
+}
+.box.refine .refine-container-2 {
+    width: 47%;
+    position: relative;
+}
 
 .categories a {
     display: inline-block;
@@ -409,16 +416,16 @@ select.form-input {
 }
 
 #announce { 
-	margin-bottom: 15px;
-	padding: 7px 10px;
-	background-color: #D9EDF7;
-	border: 1px solid #c4e1e8;
-	border-radius: 7px;
+    margin-bottom: 15px;
+    padding: 7px 10px;
+    background-color: #D9EDF7;
+    border: 1px solid #c4e1e8;
+    border-radius: 7px;
 }
 
 #announce:before { 
-	content: "!";
-	vertical-align: middle;
+    content: "!";
+    vertical-align: middle;
     float: left;
     margin: -2px 8px 0 0;
     font-size: 2.2em;
@@ -751,6 +758,9 @@ html, body {
     }
     .form-refine .refine-category {
 	max-width: 30%;
+    }
+    .form-refine .refine-searchbox {
+	min-width: 190px;
     }
     .hide-xs {
 	display: none !important;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -350,9 +350,9 @@ select.form-input {
     text-align: left;
 }
 
-.box.refine>h3 {
-    margin-top: 5px;
-    margin-bottom: 11px;
+.box.refine h3 {
+    margin-top: 1px;
+    margin-bottom: 10px;
 }
 
 .box.refine input[type="number"] {
@@ -363,8 +363,8 @@ select.form-input {
     width: 65px;
 }
 .box.refine .language {
-	position: absolute; 
-	right: 0;
+    position: absolute; 
+    right: 0;
 }
 
 .form-refine {

--- a/templates/layouts/partials/helpers/badgemenu.jet.html
+++ b/templates/layouts/partials/helpers/badgemenu.jet.html
@@ -29,8 +29,8 @@
     </form>
   </div>
   {{ else }}
-  <a href="/login?redirectTo={{ URL.String() }}" class="nav-btn log-in" style="width:auto;">
-	<div class="icon-user"></div>
+  <a href="/login?redirectTo={{ URL.String() }}" class="nav-btn log-in" style="width:auto;" title="{{  T("signin") }}">
+    <div class="icon-user"></div>
     <span>{{  T("signin") }}</span>
   </a> {{end}}
 </div>

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -16,7 +16,7 @@
 <div style="{{ if !Search.ShowRefine }}display:none;{{ end }}" class="box refine">
   </span>
   <form style="display: grid;" method="GET" action="{{ url }}">
-    <h3 style="margin-top: 2px;">{{ T("refine_search") }}</h3>
+    <h3>{{ T("refine_search") }}</h3>
 	<div>
 	  <div class="refine-container-1">
     <span class="form-refine">


### PR DESCRIPTION
Some changes happened to refine recently that made it more tight, so the margins for the h3 ended up not fitting the new size
Before:
![before](https://user-images.githubusercontent.com/11745692/29236312-4791bf50-7f09-11e7-8b5c-ed128cf75f5b.png)
After:
![after](https://user-images.githubusercontent.com/11745692/29236314-49af01d0-7f09-11e7-948d-1ac0bc35d4f4.png)

Some refine category & refine searchbox responsive size improvements to go along, as to avoid either of them looking either too big or too small at all resolutions aesthethical-wise
Put log-in icon at a lower height level and add a title to it with the text, useful in the case the log-in text is too big