### PR TITLE
Fixed width for text in refine, make smaller header apply at 500px wide devices & under

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -379,8 +379,10 @@ select.form-input {
 }
 
 .form-refine span.spacing {
-    min-width: 100px;
     display: inline-block;
+    width: 100px;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .form-refine .refine-searchbox::placeholder {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -792,9 +792,16 @@ html, body {
     .header .h-user {
         width: 46px;
     }
-    .header .h-user .user-avatar { margin: 0;} 
-    .header .h-user { max-width: 46px; width: auto; }
-    .header .h-user .user-menu { right: 104px;}
+    .header .h-user .user-avatar {
+	margin: 0;
+    } 
+    .header .h-user {
+	max-width: 46px;
+	width: auto;
+    }
+    .header .h-user .user-menu {
+        right: 104px;
+    }
     .box {
         padding: 7px;
     }
@@ -804,26 +811,47 @@ html, body {
     .tr-se, .tr-le {
         width: 36px;
     }
-    .header .h-search input { width: 84px !important; }
+    .header .h-search input {
+	width: 84px !important;
+    }
     .tr-links {
         width: 48px;
     }
     .box {
         padding: 8px;
     }
-    .torrent-hr { margin-bottom: 0; }
+    .torrent-hr {
+	margin-bottom: 0;
+    }
 }
 
-@media (max-height: 750px) {
-	.header { height: 56px; }
-	.header .container>div { line-height: 58px; padding: 0 0.6rem; }
-	.header .h-logo img { height: 57px; padding: 5px 8px 5px 2px; }
-	.header .h-user .nav-btn { height: 57px; }
-	#content { top: 58px; }
-	#content.content-admin { top: 108px; }
+@media (max-height: 750px),(max-width: 500px) {
+    .header {
+	height: 56px;
+    }
+    .header .container > div {
+	line-height: 58px; padding: 0 0.6rem;
+    }
+    .header .h-logo img {
+	height: 57px; padding: 5px 8px 5px 2px;
+    }
+    .header .h-user .nav-btn {
+	height: 57px;
+    }
 	
-	h3 { margin-bottom: 5px; }
-	.form-refine { margin-bottom: 8px; }
+    #content {
+	top: 58px;
+    }
+    #content.content-admin {
+	top: 108px;
+    }
+	
+    h3 {
+	margin-bottom: 5px;
+    }
+    .form-refine {
+	margin-bottom: 8px;
+    }
 }
 
 @media (max-width: 565px) {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -814,9 +814,6 @@ html, body {
     .header .h-search input {
 	width: 84px !important;
     }
-    .tr-links {
-        width: 48px;
-    }
     .box {
         padding: 8px;
     }

--- a/templates/layouts/partials/helpers/badgemenu.jet.html
+++ b/templates/layouts/partials/helpers/badgemenu.jet.html
@@ -12,9 +12,9 @@
   </button>
   <div class="user-menu">
     <a class="nav-btn" href="/user/{{ User.ID }}/{{ User.Username }}">{{ T("profile")}}</a>
-    <a class="nav-btn{{ User.GetUnreadNotifications() > 0 ? " notif " : " " }}" href="/notifications">
+    <a class="nav-btn notif" href="/notifications">
       {{  T("my_notifications")}}
-      <span class="badge">({{ User.GetUnreadNotifications() }})</span>
+      {{if User.GetUnreadNotifications() > 0}}<span class="badge">({{ User.GetUnreadNotifications() }})</span>{{end}}
     </a>
     <a class="nav-btn" href="/user/{{ User.ID }}/{{ User.Username }}/edit">
       {{ T("settings")}}


### PR DESCRIPTION
I allowed various width when i made it at first because it was an improvement over the previous design anyway, but now that i've done a lot of work on making it look properly on all resolutions i chose to prevent such things  from happening:
![pic](https://user-images.githubusercontent.com/11745692/29253434-1e803374-807d-11e7-8b38-47d048510b46.png)
I haven't noticed any language where it happened but there could be one or it could happen with future translation.
There's still enough room for a decent amount of characters (longer than that and the text is hidden):
![pic](https://user-images.githubusercontent.com/11745692/29253440-4c3c13e6-807d-11e7-8afc-c549de44f3f1.png)

Smaller header applies at 500px wide & under instead of just being based on height. It will apply if the device is under 501px wide or under 751px tall
Hide notification count if it's at 0 because no need to show it and the count is more eyecatching if you're used to not see any count at all