### PR TITLE
Add "sort by" inputs in refine on low res

### DIFF
--- a/controllers/search/search.go
+++ b/controllers/search/search.go
@@ -61,6 +61,10 @@ func SearchHandler(c *gin.Context) {
 		searchForm.ShowRefine = true
 	}
 
+	if c.Query("order") == "true" {
+		searchForm.SortOrder = true
+	}
+	
 	maxPages := math.Ceil(float64(nbTorrents) / float64(searchParam.Max))
 	if pagenum > int(maxPages) {
 		variables := templates.Commonvariables(c)

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -763,6 +763,9 @@ html, body {
     .hide-xs {
 	display: none !important;
     }
+    .show-xs {
+	display: inline-block!important;
+    }
 }
 
 @media (max-width: 810px) {
@@ -1781,10 +1784,16 @@ span.tag {
     border-bottom-right-radius: 1rem;
     padding: 2px 0.5rem 2px 0.4rem;
     display: inline-block;
-	color: black;
-	background: #e8f3f7;
+    color: black;
+    background: #e8f3f7;
 }
-.tag.pending a.tag-form { border-left: 1px solid #d8d8d8; }
+.tag.pending a.tag-form {
+    border-left: 1px solid #d8d8d8;
+}
+
+.show-xs {
+    display: none;
+}
 
 /* Language specific CSS */
 

--- a/templates/helpers.go
+++ b/templates/helpers.go
@@ -32,6 +32,8 @@ type SearchForm struct {
 	MaxSize          string
 	FromDate         string
 	ToDate           string
+	SortOrder        bool
+	SortType         string
 }
 
 // NewNavigation return a navigation struct with
@@ -56,5 +58,7 @@ func NewSearchForm(c *gin.Context) SearchForm {
 		MaxSize:          c.Query("maxSize"),  // We need to overwrite the value here, since size are formatted
 		FromDate:         c.Query("fromDate"), // We need to overwrite the value here, since we can have toDate instead and date are formatted
 		ToDate:           c.Query("toDate"),   // We need to overwrite the value here, since date are formatted
+		SortOrder:        false,
+		SortType:         c.Query("sort"), 
 	}
 }

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -52,7 +52,7 @@
     </select>
     {{  T("large")}}
   </span>
-  <span class="form-refine" style="margin-bottom: 2px;">
+  <span class="form-refine">
     <span class="spacing">{{ T("between")}}</span>
     <input class="form-input" size="7" name="fromDate" type="text" value="{{Search.FromDate}}"/>
     {{ T("and")}}
@@ -63,7 +63,24 @@
       <option value="y"{{if Search.DateType == "y"}} selected{{end}}>{{  T("years")}}</option>
     </select>
     {{ T("old")}}.
-	  </div>
+    </span>
+	<span class="form-refine show-xs" style="margin-bottom: 2px;">
+		<span class="spacing">Sort by</span>
+		<select name="sort" class="form-input">
+			<option value="0">None</option>
+			<option value="1"{{if Search.SortType == "1"}}selected{{end}}>{{T("name")}}</option>
+			<option value="4"{{if Search.SortType == "4"}}selected{{end}}>{{T("size")}}</option>
+			<option value="5"{{if Search.SortType == "5"}}selected{{end}}>{{T("seeders")}}</option>
+			<option value="6"{{if Search.SortType == "6"}}selected{{end}}>{{T("leechers")}}</option>
+			<option value="7"{{if Search.SortType == "7"}}selected{{end}}>{{T("downloads")}}</option>
+			<option value="2"{{if Search.SortType == "2"}}selected{{end}}>{{T("date")}}</option>
+		</select>
+		<select name="order" class="form-input">
+			<option value="false">{{T("ascending")}}</option>
+			<option value="true"{{if Search.SortOrder}}selected{{end}}>{{T("descending")}}</option>
+		</select>
+	</span>
+    </div>
 	  <div class="refine-container-2">
 		  <div name="language" class="form-refine form-input language">
 			{{ yield flagList(languages=GetTorrentLanguages(), selected=Search.Languages, inputname="lang", id="refine-search")}}

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -65,14 +65,14 @@
     {{ T("old")}}.
     </span>
 	<span class="form-refine show-xs" style="margin-bottom: 2px;">
-		<span class="spacing">Sort by</span>
+		<span class="spacing">{T("sort_by")}}</span>
 		<select name="sort" class="form-input">
 			<option value="0">None</option>
 			<option value="1"{{if Search.SortType == "1"}}selected{{end}}>{{T("name")}}</option>
 			<option value="4"{{if Search.SortType == "4"}}selected{{end}}>{{T("size")}}</option>
 			<option value="5"{{if Search.SortType == "5"}}selected{{end}}>{{T("seeders")}}</option>
 			<option value="6"{{if Search.SortType == "6"}}selected{{end}}>{{T("leechers")}}</option>
-			<option value="7"{{if Search.SortType == "7"}}selected{{end}}>{{T("downloads")}}</option>
+			<option value="7"{{if Search.SortType == "7"}}selected{{end}}>{{T("completed")}}</option>
 			<option value="2"{{if Search.SortType == "2"}}selected{{end}}>{{T("date")}}</option>
 		</select>
 		<select name="order" class="form-input">

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -65,7 +65,7 @@
     {{ T("old")}}.
     </span>
 	<span class="form-refine show-xs" style="margin-bottom: 2px;">
-		<span class="spacing">{T("sort_by")}}</span>
+		<span class="spacing">{{T("sort_by")}}</span>
 		<select name="sort" class="form-input">
 			<option value="0">None</option>
 			<option value="1"{{if Search.SortType == "1"}}selected{{end}}>{{T("name")}}</option>
@@ -76,8 +76,8 @@
 			<option value="2"{{if Search.SortType == "2"}}selected{{end}}>{{T("date")}}</option>
 		</select>
 		<select name="order" class="form-input">
-			<option value="false">{{T("ascending")}}</option>
-			<option value="true"{{if Search.SortOrder}}selected{{end}}>{{T("descending")}}</option>
+			<option value="true">{{T("ascending")}}</option>
+			<option value="false"{{if !Search.SortOrder}}selected{{end}}>{{T("descending")}}</option>
 		</select>
 	</span>
     </div>

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -1624,6 +1624,10 @@
     "translation": "Refine your search"
   },
   {
+    "id": "refine",
+    "translation": "Refine"
+  },
+  {
     "id": "between",
     "translation": "Between"
   },
@@ -1644,10 +1648,6 @@
     "translation": "Years"
   },
   {
-    "id": "refine",
-    "translation": "Refine"
-  },
-  {
     "id": "large",
     "translation": "large."
   },
@@ -1666,6 +1666,18 @@
   {
     "id": "show",
     "translation": "Show"
+  },
+  {
+    "id": "sort_by",
+    "translation": "Sort by"
+  },
+  {
+    "id": "ascending",
+    "translation": "Ascending"
+  },
+  {
+    "id": "descending",
+    "translation": "Descending"
   },
   {
     "id": "username_taken",


### PR DESCRIPTION
The sorting arrows get hidden at lower res, so i decided to show sorting inputs when this happens as to allow mobile users to sort stuff
![refine](https://user-images.githubusercontent.com/11745692/29256012-31914e56-80a7-11e7-87ec-6328c60c4244.png)
Tested and works
