### PR TITLE
Put right css class on category name & and remove it's styling

### DIFF
--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -13,7 +13,7 @@
   <table>
     <tr class="torrent-info-row">
       <td class="torrent-info-td torrent-info-label">{{  T("category") }}:</td>
-      <td class="torrent-info-td torrent-info-data" style="padding:0">
+      <td class="torrent-view-td torrent-info-data">
         <a href="{{URL.Parse("/search?c="+Torrent.Category+"_"+Torrent.SubCategory) }}">{{ CategoryName(Torrent.Category, Torrent.SubCategory) == "" ? T("unknown") : T(CategoryName(Torrent.Category, Torrent.SubCategory)) }}</a>
         <br/>
       </td>


### PR DESCRIPTION
![ss](https://user-images.githubusercontent.com/11745692/29364573-3067f068-8294-11e7-824c-9887adaa539b.png)
No more misalignement
![pic](https://user-images.githubusercontent.com/11745692/29364590-44e9d1f0-8294-11e7-9079-435313cf15c2.png)

Looks the same at regular res, as the forced padding was overwriting low-res-specific rules