### PR TITLE
Add toggle dark theme for non-JS users

### DIFF
--- a/controllers/router.go
+++ b/controllers/router.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/NyaaPantsu/nyaa/controllers/search"   // search controller
 	_ "github.com/NyaaPantsu/nyaa/controllers/settings" // settings controller
 	_ "github.com/NyaaPantsu/nyaa/controllers/static"   // static files
+	_ "github.com/NyaaPantsu/nyaa/controllers/themeToggle" // themeToggle controller
 	_ "github.com/NyaaPantsu/nyaa/controllers/torrent"  // torrent controller
 	_ "github.com/NyaaPantsu/nyaa/controllers/upload"   // upload controller
 	_ "github.com/NyaaPantsu/nyaa/controllers/user"     // user controller

--- a/controllers/themeToggle/router.go
+++ b/controllers/themeToggle/router.go
@@ -4,4 +4,5 @@ import "github.com/NyaaPantsu/nyaa/controllers/router"
 
 func init() {
 	router.Get().Any("/dark", toggleThemeHandler)
+	router.Get().Any("/dark/*redirect", toggleThemeHandler)
 }

--- a/controllers/themeToggle/router.go
+++ b/controllers/themeToggle/router.go
@@ -1,0 +1,7 @@
+package themeToggleController
+
+import "github.com/NyaaPantsu/nyaa/controllers/router"
+
+func init() {
+	router.Get().Any("/dark", toggleThemeHandler)
+}

--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -2,6 +2,7 @@ package themeToggleController
 
 import (
 	"net/http"
+	"log"
 
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/utils/timeHelper"
@@ -20,27 +21,14 @@ func toggleThemeHandler(c *gin.Context) {
 	if err != nil {
 		theme2 = "tomorrow"
 	}
-	if theme == theme2 {
-		if theme == "tomorrow" {
-			theme2 = "g"
-		}
-		if theme != "tomorrow" {
-			theme2 = "tomorrow"	
-		}
-	}
-	//Get theme & theme2 value, if not set by default is g.css & tomorrow.css
-	//if both theme are identical, which can happen, we fix it
-	
-	//Set value of redirect url, add #footer to get user back to same page position
-	redirectUrl = "https://nyaa.pantsu.cat/"
-	fmt.Sprintf(redirectUrl, "%s#footer", redirectUrl)
+	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
 
-	//Switch theme & thele2 value
+	//Switch theme & theme2 value
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme", Value: theme2, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme2", Value: theme, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})	
 	
-	//redirect user to page
-	c.Redirect(http.StatusSeeOther, redirectUrl)
+	//redirect user to page he was beforehand
+	c.Redirect(http.StatusSeeOther, c.Param("redirect"))
 	return
 }
 

--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -2,7 +2,6 @@ package themeToggleController
 
 import (
 	"net/http"
-	"log"
 
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/utils/timeHelper"
@@ -23,12 +22,16 @@ func toggleThemeHandler(c *gin.Context) {
 	}
 	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
 
+	//redirectUrl = "https://nyaa.pantsu.cat/"
+	//fmt.Sprintf(redirectUrl, "%s#footer", c.Param("redirect"))
+	
 	//Switch theme & theme2 value
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme", Value: theme2, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme2", Value: theme, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})	
 	
 	//redirect user to page he was beforehand
 	c.Redirect(http.StatusSeeOther, c.Param("redirect"))
+	//c.Redirect(http.StatusSeeOther, redirectUrl)
 	return
 }
 

--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -2,7 +2,6 @@ package themeToggleController
 
 import (
 	"net/http"
-	"fmt"
 
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/utils/timeHelper"
@@ -22,16 +21,13 @@ func toggleThemeHandler(c *gin.Context) {
 		theme2 = "tomorrow"
 	}
 	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
-
-	redirectUrl := c.Param("redirect")
-	fmt.Sprintf(redirectUrl, "%s#footer", redirectUrl)
 	
 	//Switch theme & theme2 value
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme", Value: theme2, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme2", Value: theme, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})	
 	
-	//redirect user to page he was beforehand
-	c.Redirect(http.StatusSeeOther, redirectUrl)
+	//Redirect user to page he was beforehand
+	c.Redirect(http.StatusSeeOther, c.Param("redirect")+"#footer")
 	return
 }
 

--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -12,6 +12,7 @@ import (
 // toggleThemeHandler : Controller to switch between theme1 & theme2
 func toggleThemeHandler(c *gin.Context) {
 
+	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
 	theme, err := c.Cookie("theme")
 	if err != nil {
 		theme = "g"
@@ -20,14 +21,13 @@ func toggleThemeHandler(c *gin.Context) {
 	if err != nil {
 		theme2 = "tomorrow"
 	}
-	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
 	
 	//Switch theme & theme2 value
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme", Value: theme2, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme2", Value: theme, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})	
 	
 	//Redirect user to page he was beforehand
-	c.Redirect(http.StatusSeeOther, c.Param("redirect")+"#footer")
+	c.Redirect(http.StatusSeeOther, c.Param("redirect") + "#footer")
 	return
 }
 

--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -2,6 +2,8 @@ package themeToggleController
 
 import (
 	"net/http"
+	"fmt"
+	"github.com/NyaaPantsu/nyaa/utils/log"
 
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/utils/timeHelper"
@@ -22,16 +24,15 @@ func toggleThemeHandler(c *gin.Context) {
 	}
 	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
 
-	//redirectUrl = "https://nyaa.pantsu.cat/"
-	//fmt.Sprintf(redirectUrl, "%s#footer", c.Param("redirect"))
+	redirectUrl := c.Param("redirect")
+	fmt.Sprintf(redirectUrl, "%s#footer", redirectUrl)
 	
 	//Switch theme & theme2 value
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme", Value: theme2, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme2", Value: theme, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})	
 	
 	//redirect user to page he was beforehand
-	c.Redirect(http.StatusSeeOther, c.Param("redirect"))
-	//c.Redirect(http.StatusSeeOther, redirectUrl)
+	c.Redirect(http.StatusSeeOther, redirectUrl)
 	return
 }
 

--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -3,7 +3,6 @@ package themeToggleController
 import (
 	"net/http"
 	"fmt"
-	"github.com/NyaaPantsu/nyaa/utils/log"
 
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/utils/timeHelper"

--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -1,0 +1,53 @@
+package themeToggleController
+
+import (
+	"net/http"
+
+	"github.com/NyaaPantsu/nyaa/config"
+	"github.com/NyaaPantsu/nyaa/utils/timeHelper"
+	"github.com/gin-gonic/gin"
+	
+)
+
+// toggleThemeHandler : Controller to switch between theme1 & theme2
+func toggleThemeHandler(c *gin.Context) {
+
+	theme, err := c.Cookie("theme")
+	if err != nil {
+		theme = "g"
+	}
+	theme2, err := c.Cookie("theme2")
+	if err != nil {
+		theme2 = "tomorrow"
+	}
+	if theme == theme2 {
+		if theme == "tomorrow" {
+			theme2 = "g"
+		}
+		if theme != "tomorrow" {
+			theme2 = "tomorrow"	
+		}
+	}
+	//Get theme & theme2 value, if not set by default is g.css & tomorrow.css
+	//if both theme are identical, which can happen, we fix it
+	
+	//Set value of redirect url, add #footer to get user back to same page position
+	redirectUrl = "https://nyaa.pantsu.cat/"
+	fmt.Sprintf(redirectUrl, "%s#footer", redirectUrl)
+
+	//Switch theme & thele2 value
+	http.SetCookie(c.Writer, &http.Cookie{Name: "theme", Value: theme2, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})
+	http.SetCookie(c.Writer, &http.Cookie{Name: "theme2", Value: theme, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})	
+	
+	//redirect user to page
+	c.Redirect(http.StatusSeeOther, redirectUrl)
+	return
+}
+
+func getDomainName() string {
+	domain := config.Get().Cookies.DomainName
+	if config.Get().Environment == "DEVELOPMENT" {
+		domain = ""
+	}
+	return domain
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -135,7 +135,6 @@ function startupCode() {
   if (document.cookie.includes("newVersion"))
     document.getElementById("commit").className = document.getElementById("commit").innerHTML != "unknown" ? "new" : "wew";
 
-  document.getElementById("dark-toggle").style.display = "initial"
   document.getElementById("dark-toggle").addEventListener("click", toggleTheme);
 
   if(document.cookie.includes("theme")) {

--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -84,7 +84,7 @@
     <footer id="footer">
       <div class="container footer center">
         <div class="footer-opt">
-          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" style="display: none" href="#"> - Toggle Dark Mode</a></p>
+          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark"> - Toggle Dark Mode</a></p>
         </div>
         <span><i>Powered by <a href="#">Nyaa Pantsu</a> v{{ Config.Version }} - commit <a id="commit" href="https://github.com/NyaaPantsu/nyaa/commit/{{ Config.Build }}">{{ Config.Build }}</a></i></span>
       </div>

--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -84,7 +84,7 @@
     <footer id="footer">
       <div class="container footer center">
         <div class="footer-opt">
-          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark/"> - Toggle Dark Mode</a></p>
+          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark/{{ URL.String()}}"> - Toggle Dark Mode</a></p>
         </div>
         <span><i>Powered by <a href="#">Nyaa Pantsu</a> v{{ Config.Version }} - commit <a id="commit" href="https://github.com/NyaaPantsu/nyaa/commit/{{ Config.Build }}">{{ Config.Build }}</a></i></span>
       </div>

--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -84,7 +84,7 @@
     <footer id="footer">
       <div class="container footer center">
         <div class="footer-opt">
-          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark?redirect="> - Toggle Dark Mode</a></p>
+          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark/"> - Toggle Dark Mode</a></p>
         </div>
         <span><i>Powered by <a href="#">Nyaa Pantsu</a> v{{ Config.Version }} - commit <a id="commit" href="https://github.com/NyaaPantsu/nyaa/commit/{{ Config.Build }}">{{ Config.Build }}</a></i></span>
       </div>

--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -84,7 +84,7 @@
     <footer id="footer">
       <div class="container footer center">
         <div class="footer-opt">
-          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark"> - Toggle Dark Mode</a></p>
+          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark?redirect="> - Toggle Dark Mode</a></p>
         </div>
         <span><i>Powered by <a href="#">Nyaa Pantsu</a> v{{ Config.Version }} - commit <a id="commit" href="https://github.com/NyaaPantsu/nyaa/commit/{{ Config.Build }}">{{ Config.Build }}</a></i></span>
       </div>


### PR DESCRIPTION
Having it only for JS users is pretty shit, after all we're not like (((them)))
If user has JS disabled, the toggle will now redirect to /dark page which will toggle the dark theme then redirect to the page the user was when clicking on the toggle