### PR TITLE
Add failsafe to prevent theme1 & theme2 being dentical at time

### DIFF
--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -12,7 +12,6 @@ import (
 // toggleThemeHandler : Controller to switch between theme1 & theme2
 func toggleThemeHandler(c *gin.Context) {
 
-	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
 	theme, err := c.Cookie("theme")
 	if err != nil {
 		theme = "g"
@@ -21,6 +20,16 @@ func toggleThemeHandler(c *gin.Context) {
 	if err != nil {
 		theme2 = "tomorrow"
 	}
+	if theme == theme2 {
+		if theme == "tomorrow" {
+			theme2 = "g"
+		}
+		if theme != "tomorrow" {
+			theme2 = "tomorrow"
+		}
+	}
+	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
+	//Also check if both theme are identical which can happen at time
 	
 	//Switch theme & theme2 value
 	http.SetCookie(c.Writer, &http.Cookie{Name: "theme", Value: theme2, Domain: getDomainName(), Path: "/", Expires: timeHelper.FewDaysLater(365)})

--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -84,7 +84,7 @@
     <footer id="footer">
       <div class="container footer center">
         <div class="footer-opt">
-          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark/{{ URL.String()}}"> - Toggle Dark Mode</a></p>
+          <p><a href="/settings">{{ T("change_settings") }}</a><a id="dark-toggle" href="/dark{{ URL.String()}}"> - Toggle Dark Mode</a></p>
         </div>
         <span><i>Powered by <a href="#">Nyaa Pantsu</a> v{{ Config.Version }} - commit <a id="commit" href="https://github.com/NyaaPantsu/nyaa/commit/{{ Config.Build }}">{{ Config.Build }}</a></i></span>
       </div>


### PR DESCRIPTION
e.g. disable JS, click the dark theme toggle twice in order to make sure you have the cookies created, you should have g.css as your theme
Then go in settings and set your theme to tomorrow.
Now both theme1 & theme2 will be tomorrow and clicking the dark theme toggle will simply refresh the page.
There already is a JS failsafe for this but it's also needed for those with JS disabled