### PR TITLE
Fix wrong behavior when opening refine through JS & replace farFutureString() function by variable

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,8 +1,12 @@
 // @source https://github.com/NyaaPantsu/nyaa/tree/dev/public/js
 // @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat
 
-// Switches between themes when a new one is selected
+//String that will contain a far future date, used multiple times throughout multiple functions
+var farFutureString 
+//Array that will contain the themes that the user will switch between when triggering the function a few lines under
+var UserTheme
 
+// Switches between themes when a new one is selected
 function switchThemes() {
   var themeName = document.getElementById("theme-selector").value
   var head = document.getElementsByTagName("head")[0]
@@ -94,7 +98,7 @@ function resetCookies() {
   }
 
   //Set new version in cookie
-  document.cookie = "commit=" + commitVersion + ";expires=" + farFutureString()
+  document.cookie = "commit=" + commitVersion + ";expires=" + farFutureString
 
   var oneHour = new Date()
   oneHour.setTime(oneHour.getTime() + 1 * 3600 * 1500)
@@ -110,9 +114,11 @@ else
     startupCode()
   })
 
- var UserTheme
-
 function startupCode() {
+  farFutureString = new Date()
+  farFutureString.setTime(farFutureString.getTime() + 50 * 36000 * 15000)
+  farFutureString = farFutureString.toUTCString()
+  
   var shiftWindow = function () {
     scrollBy(0, -70)
   }
@@ -164,7 +170,7 @@ function startupCode() {
     if(UserTheme[0] == UserTheme[1])
       UserTheme[1] = "g"
     //If tomorrow is twice in UserTheme, which happens when the user already has tomorrow as his default theme and toggle the dark mode for the first time, we set the second theme as g.css
-    document.cookie = "theme2=" + UserTheme[1] + ";path=/;domain=pantsu.cat;expires=" + farFutureString()
+    document.cookie = "theme2=" + UserTheme[1] + ";path=/;domain=pantsu.cat;expires=" + farFutureString
     //Set cookie for future theme2 uses
   }
   
@@ -177,9 +183,8 @@ function toggleTheme(e) {
 
   document.getElementById("theme").href = "/css/" + CurrentTheme + ".css";
   
-  var farFuture = farFutureString()
-  document.cookie = "theme=" + CurrentTheme + ";path=/;domain=pantsu.cat;expires=" + farFuture
-  document.cookie = "theme2=" + (CurrentTheme == UserTheme[0] ? UserTheme[1] : UserTheme[0]) + ";path=/;domain=pantsu.cat;expires=" + farFuture
+  document.cookie = "theme=" + CurrentTheme + ";path=/;domain=pantsu.cat;expires=" + farFutureString
+  document.cookie = "theme2=" + (CurrentTheme == UserTheme[0] ? UserTheme[1] : UserTheme[0]) + ";path=/;domain=pantsu.cat;expires=" + farFutureString
   e.preventDefault()
 }
 
@@ -211,11 +216,5 @@ function humanFileSize(bytes, si) {
   var k = si ? 1000 : 1024
   var i = ~~(Math.log(bytes) / Math.log(k))
   return i == 0 ? bytes + " B" : (bytes / Math.pow(k, i)).toFixed(1) + " " + "KMGTPEZY" [i - 1] + (si ? "" : "i") + "B"
-}
-
-function farFutureString() {
-  var farFuture = new Date()
-  farFuture.setTime(farFuture.getTime() + 50 * 36000 * 15000)
-  return farFuture.toUTCString()
 }
 // @license-end

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -78,8 +78,8 @@ function dateDiff( str1, str2 ) {
     return isNaN( diff ) ? NaN : {
         diff : diff,
 	m  : Math.floor( diff /     60000 %   60 ),
-        h  : -Math.floor( diff /  3600000 %   24 ),
-        d  : -Math.floor( diff / 86400000        )
+        h  : Math.floor( diff /  3600000 %   24 ),
+        d  : Math.floor( diff / 86400000        )
     };
 }
 parseAllDates()

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -197,9 +197,9 @@ document.getElementsByClassName("form-input refine")[0].addEventListener("click"
   if(document.getElementsByClassName("form-input search-box")[0].value == "" || location.pathname != "/")
   {
     document.getElementsByClassName("box refine")[0].style.display = document.getElementsByClassName("box refine")[0].style.display == "none" ? "block" : "none"
-    if (document.getElementsByClassName("form-input refine-searchbox")[0].value != document.getElementsByClassName("form-input search-box")[0].value)
+    if (document.getElementsByClassName("form-input refine-searchbox")[0].value == "")
       document.getElementsByClassName("form-input refine-searchbox")[0].value = document.getElementsByClassName("form-input search-box")[0].value
-    if (document.getElementsByClassName("form-input refine-category")[0].selectedIndex != document.getElementsByClassName("form-input form-category")[0].selectedIndex)
+    if (document.getElementsByClassName("form-input refine-category")[0].selectedIndex == 0)
       document.getElementsByClassName("form-input refine-category")[0].selectedIndex = document.getElementsByClassName("form-input form-category")[0].selectedIndex
     if (document.getElementsByClassName("box refine")[0].style.display == "block")
       scrollTo(0, 0)


### PR DESCRIPTION
It was doing two wrong things:
If the searchbox in refine is not equal to searchbox in refine, set refine searchbox's value to be like the header's one. This make the condition completely useless as setting refine searchbox's value every time would accomplish exactly the same thing.
Same as above but for category instead.
This behavior wasn't intended and was a mistake from akuma when **enhancing** the code: the conditions were supposed to check if refine form was empty instead of not equal, in order to carry over the value from header when opened the first time but not overwrite them if the user has already started putting value in the refine form.

Also, replaced the farFutureString() function by a variable. The function, which itself creates a variable and calls 3 different functions on top of doing some math, was being called multiple times throughout the code (2 at startup, 1 when toggling theme) which did not serve purpose. Instead we execute these functions only once at the very start of the code and proceed to store the final result in a variable, variable that is now being used whenever the code needs a string containing a far future date.
It might create a problem if an user decides to keep the same page open for over a year, but i don't think that is very likely to happen.

Also fix date difference being negative (_-20 days old_ changed to **20 days old)**