### PR TITLE
Removing filter on listing.jet.html

### DIFF
--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -52,7 +52,6 @@
   </thead>
   <tbody id="torrentListResults">
     {{ range Models}}
-	{{ if CategoryName(.Category, .SubCategory) != ""}}
     <tr id="torrent_{{ .ID }}" class="torrent-info {{if .Status == 2}}remake{{else if .Status == 3}}trusted{{else if .Status == 4}}aplus{{end}}" >
       {{ if User.HasAdmin() }}
       <td class="tr-cb hide">
@@ -106,7 +105,6 @@
         {{end}}
         <td class="tr-date home-td date-short hide-xs">{{.Date}}</td>
       </tr>
-	  {{end}}
       {{end}}
     </tbody>
   </table>


### PR DESCRIPTION
Filtering here would mean giving random number of results instead of showing constant number. And can mislead people to think that there are no results and also force people to switch pages more often.
For example, if there are 48 hentai results on the 50 results. It will display only 2 results on the page. People would therefore think that there are only two results for the search or would make them changing the page every two (or more) results instead of 50.
Finally this doesn't fix at all the results in the RSS feeds & the API endpoint.

The hentai results should be fixed in the scrapper (done).