### PR TITLE
Prettier tags on upload

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1867,6 +1867,31 @@ span.tag {
     border-left: 1px solid #d8d8d8;
 }
 
+.upload-tag-form h3 {
+	margin: 10px 0;
+}
+
+.upload-tag-form .form-group {
+	width: 167px;
+	display:inline-block;
+	margin-bottom: 5px;
+	margin-right: 5px;
+}
+
+.upload-tag-form label {
+	display:inline-block;
+	width: 100%;
+	font-size: unset;
+	margin-bottom: 1px;
+}
+
+.upload-tag-form input,.upload-tag-form select {
+	height: 25px;
+	padding: 3px 3px;
+	width: 100%;
+}
+
+
 .show-xs {
     display: none;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -427,7 +427,7 @@ select.form-input {
 .box.refine .refine-container-2 {
     width: 48%;
     position: relative;
-	padding-top: 67px;
+    padding-top: 67px;
 }
 
 .refine-container-2 span.form-refine {
@@ -435,7 +435,7 @@ select.form-input {
 	max-width: 426px;
 }
 .refine-container-2 span.spacing {
-	width: 75px;
+	width: 69px;
 }
 .refine-container-2 input[type="number"],.refine-container-2 input[type="text"] {
 	margin-right: 4px;

--- a/templates/admin/paneltorrentedit.jet.html
+++ b/templates/admin/paneltorrentedit.jet.html
@@ -49,17 +49,16 @@
       <p class="help-block">{{ T("description_markdown_notice")}}</p>
       <textarea name="desc" id="desc" class="form-input up-input" rows="10">{{Form.Description}}</textarea>
     </div>
-		<div class="upload-tag-form" style="margin-bottom: 10px;">
-		  <h3 id="tag-h3">{{ T("torrent_tags")}}</h3>
-			{{ range Config.Torrents.Tags.Types }}
-			{{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
-			{{ end }}
-		  <div class="form-group">
-			<label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
-			<input type="text" name="tag_{{Config.Torrents.Tags.Default}}" class="form-input" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
-		  </div>
-			{{ yield errors(name="tags")}}
-		</div>
+    <div class="upload-tag-form" style="margin-bottom: 10px;">
+      <h3>{{ T("torrent_tags")}}</h3>
+      {{ range Config.Torrents.Tags.Types }}
+        {{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
+      {{ end }}
+      <div class="form-group">
+         <label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
+         <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" class="form-input" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
+      </div>
+    </div>
     <button type="submit" class="form-input up-input btn-green">{{ T("save_changes")}}</button>
   </form>
 </div>

--- a/templates/admin/paneltorrentedit.jet.html
+++ b/templates/admin/paneltorrentedit.jet.html
@@ -49,15 +49,17 @@
       <p class="help-block">{{ T("description_markdown_notice")}}</p>
       <textarea name="desc" id="desc" class="form-input up-input" rows="10">{{Form.Description}}</textarea>
     </div>
+    <div class="upload-tag-form" style="margin-bottom: 10px;">
       <h3>{{ T("torrent_tags")}}</h3>
       {{ range Config.Torrents.Tags.Types }}
       {{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
       {{ end }}
       <div class="form-group">
         <label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
-        <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
+        <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" class="form-input" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
       </div>
       {{ yield errors(name="tags")}}
+    </div>
     <button type="submit" class="form-input up-input btn-green">{{ T("save_changes")}}</button>
   </form>
 </div>

--- a/templates/admin/paneltorrentedit.jet.html
+++ b/templates/admin/paneltorrentedit.jet.html
@@ -49,15 +49,17 @@
       <p class="help-block">{{ T("description_markdown_notice")}}</p>
       <textarea name="desc" id="desc" class="form-input up-input" rows="10">{{Form.Description}}</textarea>
     </div>
-      <h3>{{ T("torrent_tags")}}</h3>
-      {{ range Config.Torrents.Tags.Types }}
-      {{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
-      {{ end }}
-      <div class="form-group">
-        <label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
-        <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
-      </div>
-      {{ yield errors(name="tags")}}
+		<div class="upload-tag-form" style="margin-bottom: 10px;">
+		  <h3 id="tag-h3">{{ T("torrent_tags")}}</h3>
+			{{ range Config.Torrents.Tags.Types }}
+			{{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
+			{{ end }}
+		  <div class="form-group">
+			<label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
+			<input type="text" name="tag_{{Config.Torrents.Tags.Default}}" class="form-input" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
+		  </div>
+			{{ yield errors(name="tags")}}
+		</div>
     <button type="submit" class="form-input up-input btn-green">{{ T("save_changes")}}</button>
   </form>
 </div>

--- a/templates/admin/paneltorrentedit.jet.html
+++ b/templates/admin/paneltorrentedit.jet.html
@@ -49,16 +49,15 @@
       <p class="help-block">{{ T("description_markdown_notice")}}</p>
       <textarea name="desc" id="desc" class="form-input up-input" rows="10">{{Form.Description}}</textarea>
     </div>
-    <div class="upload-tag-form" style="margin-bottom: 10px;">
       <h3>{{ T("torrent_tags")}}</h3>
       {{ range Config.Torrents.Tags.Types }}
-        {{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
+      {{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
       {{ end }}
       <div class="form-group">
-         <label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
-         <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" class="form-input" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
+        <label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
+        <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
       </div>
-    </div>
+      {{ yield errors(name="tags")}}
     <button type="submit" class="form-input up-input btn-green">{{ T("save_changes")}}</button>
   </form>
 </div>

--- a/templates/layouts/partials/helpers/tags.jet.html
+++ b/templates/layouts/partials/helpers/tags.jet.html
@@ -1,16 +1,17 @@
-{{ block tag(tag=nil,accepted=false,torrent=nil,user=nil) }}
-    {{ if isset(user) && isset(tag) }}
-        {{if accepted || user.ID > 0 }}
-            <span class="tag{{ if !accepted }} pending{{else}} accepted{{end}}" title="Tag: {{ tag.Type }} ({{ if !accepted }}{{ tag.Total }}{{else}}{{ T("accepted") }}{{end}})"{{ if !accepted }} data-weight="{{ tag.Total }}"{{end}}>
-            <span class="tag-text{{ if user.ID > 0 }} votable{{end}}">
-                {{ if tag.Type != Config.Torrents.Tags.Default }}{{ T("tagtype_" + tag.Type) }}: {{end}}{{ T(tag.GetName()) }}
-            </span>
-                {{ if !accepted }}
-                    <a href="/torrent/tag/{{ if user.Tags.Contains(tag) }}remove?id={{torrent.ID}}&tag={{ tag.Tag }}&type={{ tag.Type }}{{else}}add?id={{torrent.ID}}&tag_{{ tag.Type }}={{ tag.Tag }}{{end}}" class="tag-form {{ if user.Tags.Contains(tag) }}minus{{else}}plus{{end}}{{if accepted}} accepted{{end}}"></a>
-                {{ else }}
-                    <a href="/search?tags={{ tag.Tag }}" title="{{ T("filter") }}"><i style="padding: 0px 0px 2px;" class="icon-search"></i></a>
-                {{ end }}
-            </span>
-        {{ end }}
-    {{ end }}
+{{ block tagForm(tagType=nil,acceptedTag=nil) }}
+  {{ if isset(tagType) }}
+    <div class="form-group">
+      <label class="input-label" for="tag_{{ tagType.Name }}">{{T("tagtype_" + tagType.Name) }}</label>
+      {{ if len(tagType.Defaults) > 0 && tagType.Defaults[0] != "db" }}
+      <select id="tag_{{ tagType.Name }}" class="tagtype form-input" name="tag_{{ tagType.Name }}">
+        <option value="">{{ T("tagvalue_select") }}</option>
+      {{ range _, option := tagType.Defaults }}
+        <option value="{{ option }}"{{ if isset(acceptedTag) && acceptedTag.Tag == option }} selected{{end}}>{{ T("tagvalue_" + option) }}</option>
+      {{ end }}
+      </select>
+      {{ else }}
+      <input id="tag_{{ tagType.Name }}" class="tagtype form-input" name="tag_{{ tagType.Name }}"{{ if isset(acceptedTag) }} value="{{ acceptedTag.Tag }}"{{ end }}>
+      {{ end }}
+    </div>
+  {{ end }}
 {{ end }}

--- a/templates/site/torrents/edit.jet.html
+++ b/templates/site/torrents/edit.jet.html
@@ -53,15 +53,17 @@
       <p class="help-block">{{ T("description_markdown_notice")}}</p>
       <textarea style="height: 10rem;" id="desc" name="desc" class="form-input up-input" rows="10">{{Form.Description}}</textarea>
     </div>
-    <h3>{{ T("torrent_tags")}}</h3>
-    {{ range Config.Torrents.Tags.Types }}
-    {{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
-    {{ end }}
-    <div class="form-group">
-      <label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
-      <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
-    </div>
-    {{ yield errors(name="tags")}}
+		<div class="upload-tag-form" style="margin-bottom: 10px;">
+		  <h3 id="tag-h3">{{ T("torrent_tags")}}</h3>
+			{{ range Config.Torrents.Tags.Types }}
+			{{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
+			{{ end }}
+		  <div class="form-group">
+			<label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
+			<input type="text" name="tag_{{Config.Torrents.Tags.Default}}" class="form-input" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
+		  </div>
+			{{ yield errors(name="tags")}}
+		</div>
     <button type="submit" class="form-input up-input">{{ T("save_changes")}}</button>
     <br/>
     <br/>

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -162,15 +162,17 @@
       <p>{{ T("description_markdown_notice")}}</p>
       <textarea name="desc" id="desc" class="form-input up-input" style="height: 10rem;">{{Form.Description}}</textarea>
 
-      <h3 id="tag-h3" style="display:none;">{{ T("torrent_tags")}}</h3>
+      <div class="upload-tag-form">
+        <h3 id="tag-h3">{{ T("torrent_tags")}}</h3>
         {{ range Config.Torrents.Tags.Types }}
         {{ yield tagForm(tagType=., acceptedTag=Form.Tags.Get(.Name)) }}
         {{ end }}
-      <div class="form-group">
+        <div class="form-group">
         <label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
-        <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
-      </div>
+        <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" class="form-input" id="tag_{{Config.Torrents.Tags.Default}}" value="{{ Form.Tags.Get(Config.Torrents.Tags.Default).Tag }}" />
+        </div>
         {{ yield errors(name="tags")}}
+      </div>
       <div style="width: 240px">
         {{yield captcha(captchaid=Form.CaptchaID)}}
       </div>


### PR DESCRIPTION
Turns this
![before](https://user-images.githubusercontent.com/11745692/29754831-ac6f607c-8b8d-11e7-8217-6061476f8e50.png)
Into this
![after](https://user-images.githubusercontent.com/11745692/29754832-af58b644-8b8d-11e7-93f0-c3b0fa28e7a4.png)
![after2](https://user-images.githubusercontent.com/11745692/29754833-af6a8702-8b8d-11e7-8cdc-97cd9f602960.png)
![after3](https://user-images.githubusercontent.com/11745692/29754834-af746e84-8b8d-11e7-88cd-c5458ad86ea0.png)

Edit too:
![pic](https://user-images.githubusercontent.com/11745692/29754881-b931f83c-8b8e-11e7-9bdc-c163d4d6368c.png)
