### PR TITLE
Fix wrong classname when adding tag with javascript

### DIFF
--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -254,7 +254,7 @@
         {{ range Config.Torrents.Tags.Types }}
         {{ yield tagForm(tagType=.) }}
         {{ end }}
-        <div class="form-input">
+        <div class="form-group">
         <label class="input-label" for="tag_{{Config.Torrents.Tags.Default}}">{{ T("tagtype_tags") }}</label>
         <input type="text" name="tag_{{Config.Torrents.Tags.Default}}" id="tag_{{Config.Torrents.Tags.Default}}" value="" />
         </div>


### PR DESCRIPTION
Resulted in borders around Descriptive Tags
![pic](https://user-images.githubusercontent.com/11745692/29757517-a7c90ef0-8bac-11e7-8837-e637d9b51953.png)
