### PR TITLE
Prevent pagination from ever being bigger than container

### DIFF
--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -78,7 +78,7 @@
     {{end}}
     {{end}}
     {{end}}
-    <div class="pagination">
+    <div class="container pagination">
       {{ genNav(Navigation, URL, 15)|raw }}
     </div>
     <footer id="footer">


### PR DESCRIPTION
Prevent such thing from ever happening, should we want to show more than 25 pages in the pagination
![owo](https://user-images.githubusercontent.com/11745692/29905539-98b34060-8e0f-11e7-8582-543bfcc7c5b4.png)
After:
![after](https://user-images.githubusercontent.com/11745692/29905566-c0bf16d8-8e0f-11e7-85a7-94b5237d34d8.png)
