### PR TITLE
Make AltColors enabled by default

### DIFF
--- a/utils/publicSettings/publicSettings.go
+++ b/utils/publicSettings/publicSettings.go
@@ -190,7 +190,7 @@ func GetAltColorsFromRequest(c *gin.Context) bool {
 	if err == nil {
 		return cookie == "true"
 	}
-	return false
+	return true
 }
 
 // GetMascotFromRequest : Gets the user selected theme from the request


### PR DESCRIPTION
Aeshetically looks better so i decided to make it enabled by default
Normally i'd do the necessary changes in the css instead but i want more feedback before making the permanent change