### PR TITLE
Revert "Add background color to remake-checkbox"

### DIFF
--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -142,7 +142,7 @@
 
       <p>
         <input type="checkbox" value="true" name="remake" id="remake" class="form-torrent-remake"/>
-        <label class="remake" for="remake">{{ T("mark_as_remake")}}</label>
+        <label for="remake">{{ T("mark_as_remake")}}</label>
       </p>
       {{ yield errors(name="remake")}}
 


### PR DESCRIPTION
Reverts NyaaPantsu/nyaa#1499

> I'm not against adding a background for the remake checkbox that would be colored like remake torrents, however it'd need more designing than simply applying a class="remake"
![remake](https://user-images.githubusercontent.com/11745692/30023546-379724a4-9170-11e7-89c9-e3317ed6a8fc.png)
![remake2](https://user-images.githubusercontent.com/11745692/30023547-3798500e-9170-11e7-8e29-23f91cc0f915.png)
Also, the **for="remake"** needs to stay, it's there so that you can click on the text in order to check or uncheck the checkbox and as such is pretty useful