### PR TITLE
Fix <br> tag duplicated

### DIFF
--- a/utils/sanitize/markdown.go
+++ b/utils/sanitize/markdown.go
@@ -310,6 +310,7 @@ func repairHTMLTags(brokenHTML string) string {
 // ParseBBCodes returns the bbcode compiler with the bbcode tags to parse
 func ParseBBCodes(msg string) string {
 	msg = BBCodesRenderer.Compile(msg)
+	msg = strings.Replace(msg, "<br>", "\n", -1)
 	// For some reason, BBCodes compiler return escaped html
 	// We need to unescape it
 	return html.UnescapeString(msg)

--- a/utils/sanitize/markdown_test.go
+++ b/utils/sanitize/markdown_test.go
@@ -36,6 +36,7 @@ func TestParseBBCodes(t *testing.T) {
 		{"", ""},
 		{"&gt;", "&gt;"},                       // keep escaped html
 		{"<b>lol</b>", "<b>lol</b>"},           // keep html tags
+		{"ddd\nddd", "ddd\nddd"},               // keep html tags
 		{"[b]lol[/b]", "<b>lol</b>"},           // Convert bbcodes
 		{"[u][b]lol[/u]", "<u><b>lol</b></u>"}, // Close unclosed tags
 	}
@@ -71,7 +72,8 @@ func TestSanitize(t *testing.T) {
 		Result string
 	}{
 		{"", ""},
-		{"[b]lol[/b]", "<b>lol</b>"},                                                                                                                                                                                                        // Should convert bbcodes
+		{"[b]lol[/b]", "<b>lol</b>"}, // Should convert bbcodes
+		{"ddd\nddd", "ddd\nddd"},
 		{"&gt;", "&gt;"},                                                                                                                                                                                                                    // keep escaped html
 		{"<b>lol</b>", "<b>lol</b>"},                                                                                                                                                                                                        // keep html tags
 		{"<b><u>lol</b>", "<b><u>lol</u></b>"},                                                                                                                                                                                              // close unclosed tags encapsulated


### PR DESCRIPTION
The bug came from bbcode parser which transforms \n with \<br\>.
So I just remove the br tag in bbcode parser before applying the mardown parser.
Fix #1480