### PR TITLE
alt attribute for ads images, fix missing tags on upload, fix wrong name for translation string

### DIFF
--- a/controllers/torrent/download.go
+++ b/controllers/torrent/download.go
@@ -5,37 +5,18 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/templates"
 	"github.com/NyaaPantsu/nyaa/models/torrents"
+	"github.com/NyaaPantsu/nyaa/utils/format"
 	"github.com/gin-gonic/gin"
 )
 
 // DownloadTorrent : Controller for downloading a torrent
 func DownloadTorrent(c *gin.Context) {
 	hash := c.Param("hash")
-
-	if hash == "" && len(config.Get().Torrents.FileStorage) == 0 {
-		//File not found, send 404
-		variables := templates.Commonvariables(c)
-		templates.Render(c, "errors/torrent_file_missing.jet.html", variables)
-		return
-	}
-
-	//Check if file exists and open
-	Openfile, err := os.Open(fmt.Sprintf("%s%c%s.torrent", config.Get().Torrents.FileStorage, os.PathSeparator, hash))
-	if err != nil {
-		//File not found, send 404
-		variables := templates.Commonvariables(c)
-		templates.Render(c, "errors/torrent_file_missing.jet.html", variables)
-		return
-	}
-	defer Openfile.Close() //Close after function return
-
-	//Get the file size
-	FileStat, _ := Openfile.Stat()                     //Get info from file
-	FileSize := strconv.FormatInt(FileStat.Size(), 10) //Get file size as a string
 
 	torrent, err := torrents.FindRawByHash(hash)
 
@@ -45,6 +26,45 @@ func DownloadTorrent(c *gin.Context) {
 		templates.Render(c, "errors/torrent_file_missing.jet.html", variables)
 		return
 	}
+	
+	if hash == "" && len(config.Get().Torrents.FileStorage) == 0 {
+		//File not found, send 404
+		variables := templates.Commonvariables(c)
+		var trackers []string
+		if torrent.Trackers == "" {
+			trackers = config.Get().Torrents.Trackers.Default
+		} else {
+			trackers = torrent.GetTrackersArray()
+		}
+		magnet := format.InfoHashToMagnet(strings.TrimSpace(torrent.Hash), torrent.Name, trackers...)
+		variables.Set("magnet", magnet)
+		templates.Render(c, "errors/torrent_file_missing.jet.html", variables)
+		return
+	}
+ 
+	//Check if file exists and open
+	Openfile, err := os.Open(fmt.Sprintf("%s%c%s.torrent", config.Get().Torrents.FileStorage, os.PathSeparator, hash))
+	if err != nil {
+		//File not found, send 404
+		variables := templates.Commonvariables(c)
+		var trackers []string
+		if torrent.Trackers == "" {
+			trackers = config.Get().Torrents.Trackers.Default
+		} else {
+			trackers = torrent.GetTrackersArray()
+		}
+		magnet := format.InfoHashToMagnet(strings.TrimSpace(torrent.Hash), torrent.Name, trackers...)
+		variables.Set("magnet", magnet)
+		templates.Render(c, "errors/torrent_file_missing.jet.html", variables)
+		return
+	}
+	defer Openfile.Close() //Close after function return
+
+	//Get the file size
+	FileStat, _ := Openfile.Stat()                     //Get info from file
+	FileSize := strconv.FormatInt(FileStat.Size(), 10) //Get file size as a string
+
+	
 
 	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.torrent\"", torrent.Name))
 	c.Header("Content-Type", "application/x-bittorrent")

--- a/public/css/classic.css
+++ b/public/css/classic.css
@@ -635,6 +635,6 @@ span.tag {
     border-radius: 0;
     padding: 7px 3px;
 }
-.upload-tag-table td {
-    padding-right: 5px!important;
+.upload-tag-table .form-group input, .upload-tag-table .form-group select {
+    width: 118px!important;   
 }

--- a/public/css/classic.css
+++ b/public/css/classic.css
@@ -584,8 +584,8 @@ span.tag {
     border-radius: 0;
     box-shadow: none;
     border: 1px solid #c5c5c5;
+    background: white;
 }
-
 
 .upload-form-table {
     width: auto;

--- a/public/css/classic.css
+++ b/public/css/classic.css
@@ -630,6 +630,9 @@ span.tag {
 .upload-form-table .CodeMirror-scroll, .upload-form-table .CodeMirror {
     min-height: 120px;
 }
+.upload-form-table .CodeMirror-scroll {
+    max-width: unset!important;
+}
 
 .form-input.language {
     border-radius: 0;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1940,6 +1940,12 @@ p.upload-rules {
 .upload-form-table .table-torrent-link input[type="text"] {
     width: 65%;
 }
+.upload-form-table .editor-statusbar {
+    position: relative;
+    margin-top: -27px;
+    margin-bottom: 2px;
+    z-index: 1;
+}
 #tag-h3 {
     margin: 0 0 7px;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -103,7 +103,7 @@ img[class$="-w"] {
 }
 
 .container, .modtools {
-    max-width: 1130px;
+    max-width: 1140px;
     margin: 0 auto;
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1925,7 +1925,7 @@ p.upload-rules {
 .upload-form-table .table-input-label, .upload-form-table td label{
     vertical-align: top;
 }
-.upload-form-table .upload-form-table .CodeMirror {
+.upload-form-table .CodeMirror {
     font-weight: normal;
 }
 .upload-form-table .table-input {

--- a/templates/errors/torrent_file_missing.jet.html
+++ b/templates/errors/torrent_file_missing.jet.html
@@ -3,6 +3,10 @@
 {{block content_body()}}
 <div style="text-align: center;">
   <h1>{{ T("err_no_torrent_file")}}</h1>
+    <a href="" class="form-input btn-green download" style="height: auto;">
+      <div class="icon-magnet"></div>{{ T("magnet_link")}}
+    </a>
+	<br/><br/>
   <img src="/img/no_torrent_file.jpg" alt="No torrent file"/>
 </div>
 {{end}} {{block mascot()}}<br />{{end}}

--- a/templates/errors/torrent_file_missing.jet.html
+++ b/templates/errors/torrent_file_missing.jet.html
@@ -3,10 +3,12 @@
 {{block content_body()}}
 <div style="text-align: center;">
   <h1>{{ T("err_no_torrent_file")}}</h1>
-    <a href="" class="form-input btn-green download" style="height: auto;">
+    {{ if magnet != "" }}
+    <a href="{{magnet}}" class="form-input btn-green download" style="height: auto;">
       <div class="icon-magnet"></div>{{ T("magnet_link")}}
     </a>
-	<br/><br/>
+    <br/><br/>
+    {{ end }}
   <img src="/img/no_torrent_file.jpg" alt="No torrent file"/>
 </div>
 {{end}} {{block mascot()}}<br />{{end}}

--- a/templates/layouts/partials/helpers/ad.jet.html
+++ b/templates/layouts/partials/helpers/ad.jet.html
@@ -2,25 +2,25 @@
 {{ if !kilo_strcmp(URL.String(), "/mod", 4, 1)  }}
     {{if Type < 4}}
         {{ if Sukebei() }}
-            <a href="https://jlist.com/category/adult-corner?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img class="jl-w" src="/img/Jlist/Onahole_728x90.jpg"></a>
+            <a href="https://jlist.com/category/adult-corner?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img alt="JList Onaholes" class="jl-w" src="/img/Jlist/Onahole_728x90.jpg"></a>
         {{else}}
-	      {{ if ID == 0}} <a href="https://jlist.com/category/games-computers?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img class="jl-w" src="/img/Jlist/Games_728x90.jpg"></a> {{ end }}
-	      {{ if ID == 1}} <a href="https://jlist.com/category/snacks-food?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img class="jl-w" src="/img/Jlist/Snacks_728x90.jpg"></a> {{ end }}
-	      {{ if ID == 2}} <a href="https://jlist.com/series/touhou-project?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img class="jl-w" src="/img/Jlist/Touhou_728x90.jpg"> {{ end }}
+	      {{ if ID == 0}} <a href="https://jlist.com/category/games-computers?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img alt="JList Games" class="jl-w" src="/img/Jlist/Games_728x90.jpg"></a> {{ end }}
+	      {{ if ID == 1}} <a href="https://jlist.com/category/snacks-food?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img alt="JList Snacks" class="jl-w" src="/img/Jlist/Snacks_728x90.jpg"></a> {{ end }}
+	      {{ if ID == 2}} <a href="https://jlist.com/series/touhou-project?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img alt="JList Touhou" class="jl-w" src="/img/Jlist/Touhou_728x90.jpg"> {{ end }}
         {{end}}
     {{else}}
-        <a href="https://weeb.shop/product/nyaa-pantsu-sticker"><img class="wb-w" src="/img/WeebShop/Stickers.png"></a>
+        <a href="https://weeb.shop/product/nyaa-pantsu-sticker"><img alt="WeebShop Stickers" class="wb-w" src="/img/WeebShop/Stickers.png"></a>
     {{end}}
 {{end}}
 {{end}}
 {{block ad_cube(ID=0)}}
 {{ if !kilo_strcmp(URL.String(), "/mod", 4, 1) }}
     {{ if Sukebei() }}
-        <a href="https://jlist.com/category/adult-corner?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img class="jl-c" src="/img/Jlist/Onahole_300x250.jpg"></a>
+        <a href="https://jlist.com/category/adult-corner?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img alt="WeebShop Stickers" class="jl-c" src="/img/Jlist/Onahole_300x250.jpg"></a>
     {{else}}
-        {{ if ID == 0}} <a href="https://jlist.com/category/games-computers?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img class="jl-c" src="/img/Jlist/Games_300x250.jpg"></a> {{ end }}
-        {{ if ID == 1}} <a href="https://jlist.com/category/snacks-food?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img class="jl-c" src="/img/Jlist/Snacks_300x250.jpg"></a> {{ end }}
-        {{ if ID == 2}} <a href="https://jlist.com/series/touhou-project?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img class="jl-c" src="/img/Jlist/Touhou_300x250.jpg"> {{ end }}
+        {{ if ID == 0}} <a href="https://jlist.com/category/games-computers?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img alt="JList Games" class="jl-c" src="/img/Jlist/Games_300x250.jpg"></a> {{ end }}
+        {{ if ID == 1}} <a href="https://jlist.com/category/snacks-food?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img alt="JList Snacks" class="jl-c" src="/img/Jlist/Snacks_300x250.jpg"></a> {{ end }}
+        {{ if ID == 2}} <a href="https://jlist.com/series/touhou-project?utm_source=NS&utm_medium=Nyaa&utm_campaign=sep17"><img alt="JList Touhou" class="jl-c" src="/img/Jlist/Touhou_300x250.jpg"> {{ end }}
     {{end}}
 {{end}}
 {{end}}

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -55,7 +55,6 @@
 		     <td class="table-input" style="font-weight: normal;"><input type="checkbox" value="true" name="remake" id="remake" class="form-torrent-remake"/><label for="remake">{{ T("mark_as_remake")}}</label> <input type="checkbox" value="true" name="hidden" id="hidden" class="form-torrent-hidden {{ if User.ID == 0 }}hidden{{end}}" {{ if User.ID == 0 }}disabled{{end}}><label for="hidden" {{ if User.ID == 0 }}class="hidden"{{end}}>{{ T("upload_as_anon")}}</label></td>
 		  </tr>
 		  <tr>
-		  <tr>
 		     <td class="table-input-label"><label for="website_link">{{ T("website_link")}}</label></td>
 		     <td class="table-input"><input name="website_link" id="website_link" placeholder="http://" class="form-input up-input" type="text" value="{{Form.WebsiteLink}}"/></td>
 		  </tr>

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -63,12 +63,12 @@
 		     <td class="table-input-label"><label for="desc">{{ T("torrent_description")}}</label></td>
 		     <td class="table-input"><textarea name="desc" id="desc" class="form-input up-input" style="height: 10rem;">{{Form.Description}}</textarea></td>
 		  </tr>
-		</tbody>
-	  </table>
+		  <tr>
+		     <td class="table-input-label">{{ T("torrent_tags")}}:</td>
+		     <td class="table-input">
 
 	  <table class="upload-tag-table">
 		<tbody>
-			<tr><td colspan="3"><h3 id="tag-h3">{{ T("torrent_tags")}}</h3></td></tr>
 			<tr>
 			{{ range _, tag := Config.Torrents.Tags.Types}}
 				<td>
@@ -100,6 +100,10 @@
 				{{end}}
 			{{ end }}
 			</tr>
+		</tbody>
+	  </table>
+			 </td>
+		  </tr>
 		</tbody>
 	  </table>
 

--- a/templates/site/torrents/upload.jet.html
+++ b/templates/site/torrents/upload.jet.html
@@ -43,6 +43,7 @@
 			  </select>
 			 </td>
 		  </tr>
+		  <tr>
 		     <td class="table-input-label">{{ T("torrent_language")}}</td>
 		     <td class="table-input">
 			   <div class="form-input language">

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -91,7 +91,7 @@
         {{end}}
         {{ if Torrent.Dlsite != "" }}
         <span class="tag accepted">
-          <span class="tag-text votable"><a href="http://www.dlsite.com/home/work/=/product_id/{{ Torrent.Dlsite }}.html">{{ T("tagtype_dlsite") }}: RJ{{ Torrent.Dlsite }}</a></span>
+          <span class="tag-text votable"><a href="http://www.dlsite.com/home/work/=/product_id/{{ Torrent.Dlsite }}.html">{{ T("tagtype_dlsite") }}: {{ Torrent.Dlsite }}</a></span>
           <a href="/search?dlsite={{ Torrent.Dlsite }}" title="{{ T("filter") }}"><i class="icon-search"></i></a>
         </span>
         {{end}}

--- a/templates/template_test.go
+++ b/templates/template_test.go
@@ -293,6 +293,7 @@ func mockupCommonvariables(t *testing.T) jet.VarMap {
 	variables.Set("Infos", make(map[string][]string))
 	variables.Set("Errors", make(map[string][]string))
 	variables.Set("UserProfile", &models.User{})
+	variables.Set("magnet", "test")
 	variables = templateFunctions(variables)
 	return variables
 }

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -42,4 +42,4 @@
 * + terms_conditions_full
 ## 2017/09/17
 * + torrent_name
-* + upload_rules
+* + read_rules

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -1,5 +1,5 @@
 [{
-    "id": "upload_rules",
+    "id": "read_rules",
     "translation": "Please read <a href=\"/faq#rules\">the rules</a> before uploading."
   },
   {


### PR DESCRIPTION
- Ad alt attribute to ads \<img\>, removing the html errors they caused
- Fix misplaced \<tr\> that caused HTML error but strangely did not break the table
- Fix wrong translation string name
- Fix tags that did not have backgrounds on classic theme
- Put tag inputs of upload in the main table
- Fix markdown scrolling visually broken on classic.css
- Magnet link button on torrent file missing page