### PR TITLE
Fix Search by ID

### DIFF
--- a/utils/search/sortmode.go
+++ b/utils/search/sortmode.go
@@ -21,7 +21,7 @@ type SortField struct {
 }
 
 var sortFields = []SortField{
-	{"id", "torrent_id"},
+	{"id", "torrents.torrent_id"},
 	{"name.raw", "torrent_name"},
 	{"date", "date"},
 	{"downloads", "downloads"},

--- a/utils/search/torrentParam.go
+++ b/utils/search/torrentParam.go
@@ -387,11 +387,11 @@ func (p *TorrentParam) toDBQuery(c *gin.Context) *Query {
 	}
 
 	if p.FromID != 0 {
-		query.Append("torrent_id > ?", p.FromID)
+		query.Append("torrents.torrent_id > ?", p.FromID)
 	}
 	if len(p.TorrentID) > 0 {
 		for _, id := range p.TorrentID {
-			query.Append("torrent_id = ?", id)
+			query.Append("torrents.torrent_id = ?", id)
 		}
 	}
 	if p.FromDate != "" {


### PR DESCRIPTION
torrent_id is a column from both torrents and scrapes tables. So you have to specify for which table you want to filter torrent_id.
Fix #1589