### PR TITLE
Fix cookie warning constantly showing & JS cookies on mirror

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -161,10 +161,12 @@ function startupCode() {
     if (userCommitVersion != commitVersion || userWebsiteVersion != websiteVersion)
       resetCookies()
   }
+  if(!window.location.host.includes(domain)) domain = window.location.host
   
   if(document.getElementById("cookie-warning-close") != null) {
 	document.getElementById("cookie-warning-close").addEventListener("click", function (e) {
       document.getElementById("cookie-warning").outerHTML = "";
+      document.cookie = "EU_Cookie=true;path=/;expires=" + farFutureString + ";domain=" + domain
     })
   }
 	  

--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -44,7 +44,7 @@
   <nav id="header" class="header">
     {{block menu()}}{{end}}
   </nav>
-  {{ AdType := kilo_rand(1) }}
+  {{ AdType := kilo_rand(2) }}
   <div id="content" class="{{ block contclass()}}{{end}}">
     <div class="content container center">
       {{ yield infos()}}

--- a/templates/layouts/partials/base.jet.html
+++ b/templates/layouts/partials/base.jet.html
@@ -7,7 +7,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="keywords" content="torrents, pantsu, anime, manga, sukebei, nyaapassu, horriblesubs, nyaa{{if Sukebei()}}, hentai{{end}}, dlsite"/>
+  <meta name="keywords" content="nyaa, torrents, pantsu, anime, manga, sukebei, nyaapassu, horriblesubs{{if Sukebei()}}, hentai{{end}}, dlsite"/>
   <meta name="description" content='The leading open-source community-based nyaa.se successor, suitable for all anime and manga needs. にゃんぱす~!'/>
   <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
   <title>{{if Sukebei()}}Sukebei{{else}}Nyaa{{end}} Pantsu{{block titleBase()}}{{end}}</title>

--- a/templates/site/static/faq.jet.html
+++ b/templates/site/static/faq.jet.html
@@ -13,11 +13,11 @@
 
         <h2 id="links">{{ T("links_replacement_mirror")}}</h2>
         <a href="{{Config.WebAddress.Nyaa}}">Nyaa - {{GetHostname(Config.WebAddress.Nyaa)}}</a><br />
-        <a href="{{Config.WebAddress.Sukebei}}">Sukebei - {{GetHostname(Config.WebAddress.Sukebei)}}</a><br />
+        <a href="{{Config.WebAddress.Sukebei}}">Sukebei - {{GetHostname(Config.WebAddress.Sukebei)}}</a><br /><br />
         <a href="https://nyoo.moe/">Nyaa - https://nyoo.moe/ (Mirror)</a><br />
-        <a href="https://sukebei.nyoo.moe/">Sukebei - https://sukebei.nyoo.moe/ (Mirror)</a><br />
+        <a href="https://sukebei.nyoo.moe/">Sukebei - https://sukebei.nyoo.moe/ (Mirror)</a><br /><br />
         <a href="https://nyaa.pt/">Nyaa - https://nyaa.pt/ (Mirror)</a><br />
-        <a href="https://sukebei.nyaa.pt/">Sukebei - https://sukebei.nyaa.pt/ (Mirror)</a><br />
+        <a href="https://sukebei.nyaa.pt/">Sukebei - https://sukebei.nyaa.pt/ (Mirror)</a><br /><br />
         <a href="https://dpzz6tjaqbl3ttba.onion/">Nyaa - dpzz6tjaqbl3ttba.onion (Mirror)</a><br />
         <a href="https://34knbgrnvicofdgz.onion/">Sukebei - 34knbgrnvicofdgz.onion (Mirror)</a><br />
 


### PR DESCRIPTION
- EU cookie warning was constantly showing up on mirror because the cookie was set on .pantsu.cat
- JS cookies were using the domain variable, the domain variable is directly tied to the domain variable in default_config which is bad for mirrors, so the JS now checks if the website is part of the domain and if it is not (mirror), it changes the domain variable value to current (full) domain
- Space mirrors better in FAQ
- Put nyaa as first keyword in html head