### PR TITLE
Make golang theme toggler behave exactly like JS one & css fix

### DIFF
--- a/controllers/themeToggle/themeToggle.go
+++ b/controllers/themeToggle/themeToggle.go
@@ -15,22 +15,20 @@ func toggleThemeHandler(c *gin.Context) {
 
 	theme, err := c.Cookie("theme")
 	if err != nil {
-		theme = "g"
+		theme = config.DefaultTheme(false)
 	}
 	theme2, err := c.Cookie("theme2")
 	if err != nil {
-		theme2 = "tomorrow"
+		theme2 = config.DefaultTheme(true)
 	}
-	if theme == theme2 {
-		if theme == "tomorrow" {
-			theme2 = "g"
-		}
-		if theme != "tomorrow" {
-			theme2 = "tomorrow"
-		}
+	if theme != config.DefaultTheme(true) && theme2 != config.DefaultTheme(true) {
+		//None of the themes are dark ones, force the second one as the dark one
+		theme2 = config.DefaultTheme(true)
+	} else if  theme == theme2 {
+		//Both theme are dark ones, force the second one as the default (light) theme
+		theme2 = config.DefaultTheme(false)
 	}
-	//Get theme1 & theme2 value, set g.css & tomorrow.css by default
-	//Also check if both theme are identical which can happen at time
+	//Get theme1 & theme2 value
 	
 	// If logged in, update user theme (will not work otherwise)
 	user := router.GetUser(c)

--- a/public/css/themes/tomorrow.css
+++ b/public/css/themes/tomorrow.css
@@ -96,6 +96,9 @@ td.tr-le, .error-text {
 .btn-red {
     background-color: #cc6666;
 }
+.sukebei .btn-red {
+    color: #c5c8c6;
+}
 
 .alt-colors tr:nth-child(even) {
     background: hsla(244, 11%, 21%, 0.2);


### PR DESCRIPTION
- Make golang theme toggler behave exactly like JS one
- Make use of newly created default theme & default dark theme variables
- Fix red buttons on sukebei that had red text making it invisible