### PR TITLE
Update last-scraped date on view even if stats.go return unknown stats & other things

### DIFF
--- a/controllers/user/router.go
+++ b/controllers/user/router.go
@@ -26,7 +26,7 @@ func init() {
 	// User Profile specific routes
 	userRoutes := router.Get().Group("/user")
 	{
-		userRoutes.GET("", UserProfileHandler)
+		userRoutes.GET("", RedirectToUserSearch)
 		userRoutes.GET("/:id", UserProfileHandler)
 		userRoutes.GET("/:id/:username", UserProfileHandler)
 		userRoutes.GET("/:id/:username/follow", UserFollowHandler)

--- a/models/torrent.go
+++ b/models/torrent.go
@@ -357,9 +357,9 @@ func (t *Torrent) ToJSON() TorrentJSON {
 		statsObsolete[0] = true
 		//The displayed stats are obsolete, S/D/L will show "Unknown"
 	}
-	if time.Since(scrape.LastScrape).Hours() > 1460 || (scrape.Seeders == 0 && scrape.Leechers == 0 && scrape.Completed == 0 && time.Since(scrape.LastScrape).Hours() > 24) {
+	if time.Since(scrape.LastScrape).Hours() > 730 || (scrape.Seeders == 0 && scrape.Leechers == 0 && scrape.Completed == 0 && time.Since(scrape.LastScrape).Hours() > 12) {
 		statsObsolete[1] = true
-		//The stats need to be refreshed, either because they are valid and older than two months (not as reliable) OR if they are unknown but have been scraped more than 24h ago
+		//The stats need to be refreshed, either because they are valid and older than one months (not as reliable) OR if they are unknown but have been scraped more than 12h ago
 	}
 	
 	t.ParseLanguages()

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -653,12 +653,25 @@ th {
 }
 .website-nav #nav-category-list {
     width: 70%;
-    margin-bottom: 13px;
+    margin-bottom: 7px;
 }
 .website-nav .pagination a {
     display: inline!important;
 }
-
+.sub-category-list {
+    padding-left: 16px;
+	font-size: 12px;
+	margin-bottom: 9px;
+}
+.sub-category-list span{
+	display: block;
+}
+.sub-category-list span:before {
+	content: '-» ';
+}
+.sub-category-list span:first-child:before {
+	content: '';
+}
 textarea {
     max-width: 100%;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1212,6 +1212,7 @@ html, body {
     border-radius: 0 4px 4px 0;
     text-align: left;
     padding: 10px 10px 15px 10px;
+    position: relative;
 }
 
 .profile-content h3 {

--- a/templates/layouts/partials/helpers/oldNav.jet.html
+++ b/templates/layouts/partials/helpers/oldNav.jet.html
@@ -1,12 +1,14 @@
 <div class="box refine website-nav">
 <table id="nav-category-list">
 	<tbody>
+		{{ ShowSubcat := "" }}
 		<tr><td>{{if Search.Category == ""}}<b>{{ T("all_categories")}}</b>{{else}}<a href="{{genSearchWithCategory(URL, "_")}}">{{ T("all_categories")}}</a>{{end}}</td></tr>
 		<tr>
 		{{ range _, cat := GetCategories(true, false) }}
-			<td>{{if Search.Category == cat.ID }}<b>{{ T(cat.Name) }}</b>{{else}}<a href="{{genSearchWithCategory(URL, cat.ID)}}">{{ T(cat.Name) }}</a>{{end}}</td>
+			<td>{{if Search.Category == cat.ID ||(len(Search.Category) > 2 && Search.Category[:2] == cat.ID)}}<b>{{ T(cat.Name) }}</b>{{else}}<a href="{{genSearchWithCategory(URL, cat.ID)}}">{{ T(cat.Name) }}</a>{{end}}</td>
 			{{ if _ % 3 == 2}}
-			</tr><tr>
+			</tr>
+			<tr>
 			{{end}}
 			{{if _ + 1 == len(GetCategories(true, false)) }}
 			</tr>{{end}}
@@ -14,6 +16,23 @@
 		</tr>
 	</tbody>
 </table>
+{{ if Search.Category != ""}}
+<div class="sub-category-list">
+	{{ Categories := GetCategory(Search.Category[:1], true)}}
+	{{offset := len(Categories[0].Name) + 3 }}
+	{{ range _, cat := Categories}}
+		<span>
+		{{ if _ > 0}}
+		{{if Search.Category == cat.ID}}<b>{{ T(cat.Name)[offset:] }}</b>{{else}}
+		<a href="{{genSearchWithCategory(URL, cat.ID)}}">{{ T(cat.Name)[offset:] }}</a>{{end}}
+		{{else}}
+		{{if Search.Category == cat.ID}}<b>{{ T(cat.Name) }}</b>{{else}}
+		<a href="{{genSearchWithCategory(URL, cat.ID)}}">{{ T(cat.Name) }}</a>{{end}}
+		{{end}}
+		</span>
+	{{end}}
+</div>
+{{end}}
 <table id="sort-list-order">
 	<tbody>
 		<tr>

--- a/templates/layouts/partials/helpers/oldNav.jet.html
+++ b/templates/layouts/partials/helpers/oldNav.jet.html
@@ -1,7 +1,6 @@
 <div class="box refine website-nav">
 <table id="nav-category-list">
 	<tbody>
-		{{ ShowSubcat := "" }}
 		<tr><td>{{if Search.Category == ""}}<b>{{ T("all_categories")}}</b>{{else}}<a href="{{genSearchWithCategory(URL, "_")}}">{{ T("all_categories")}}</a>{{end}}</td></tr>
 		<tr>
 		{{ range _, cat := GetCategories(true, false) }}

--- a/templates/layouts/partials/helpers/oldNav.jet.html
+++ b/templates/layouts/partials/helpers/oldNav.jet.html
@@ -18,7 +18,7 @@
 {{ if Search.Category != ""}}
 <div class="sub-category-list">
 	{{ Categories := GetCategory(Search.Category[:1], true)}}
-	{{offset := len(Categories[0].Name) + 3 }}
+	{{offset := len(T(Categories[0].Name)) + 3 }}
 	{{ range _, cat := Categories}}
 		<span>
 		{{ if _ > 0}}

--- a/templates/layouts/partials/helpers/oldNav.jet.html
+++ b/templates/layouts/partials/helpers/oldNav.jet.html
@@ -18,16 +18,10 @@
 {{ if Search.Category != ""}}
 <div class="sub-category-list">
 	{{ Categories := GetCategory(Search.Category[:1], true)}}
-	{{offset := len(T(Categories[0].Name)) + 3 }}
 	{{ range _, cat := Categories}}
 		<span>
-		{{ if _ > 0}}
-		{{if Search.Category == cat.ID}}<b>{{ T(cat.Name)[offset:] }}</b>{{else}}
-		<a href="{{genSearchWithCategory(URL, cat.ID)}}">{{ T(cat.Name)[offset:] }}</a>{{end}}
-		{{else}}
 		{{if Search.Category == cat.ID}}<b>{{ T(cat.Name) }}</b>{{else}}
-		<a href="{{genSearchWithCategory(URL, cat.ID)}}">{{ T(cat.Name) }}</a>{{end}}
-		{{end}}
+		<a href="{{genSearchWithCategory(URL, cat.ID)}}">{{ T(cat.Name)}}</a>{{end}}
 		</span>
 	{{end}}
 </div>

--- a/templates/layouts/partials/helpers/oldNav.jet.html
+++ b/templates/layouts/partials/helpers/oldNav.jet.html
@@ -17,8 +17,7 @@
 </table>
 {{ if Search.Category != ""}}
 <div class="sub-category-list">
-	{{ Categories := GetCategory(Search.Category[:1], true)}}
-	{{ range _, cat := Categories}}
+	{{ range _, cat := GetCategory(Search.Category[:1], true)}}
 		<span>
 		{{if Search.Category == cat.ID}}<b>{{ T(cat.Name) }}</b>{{else}}
 		<a href="{{genSearchWithCategory(URL, cat.ID)}}">{{ T(cat.Name)}}</a>{{end}}

--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -93,7 +93,7 @@
         <td class="tr-size home-td hide-xs">
           {{ fileSize(.Filesize, T) }}
         </td>
-        {{if .LastScrape.IsZero || formatDateRFC(.LastScrape) == "0001-01-01T00:00:00Z"}}
+        {{if .StatsObsolete[0] }}
         <td class="tr-se home-td hide-smol">-</td>
         <td class="tr-le home-td hide-smol">-</td>
         <td class="tr-dl home-td hide-xs">-</td>

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -317,14 +317,14 @@
   Query.Get('/stats/{{Torrent.ID}}', function (data) {
     if(typeof data.seeders != "undefined" && data.seeders != -1) {
       seeders.innerHTML = "<span>" + data.seeders + "</span>"
-      leechers.innerHTML = "<span>" +data.leechers + "</span>"
-      downloads.innerHTML = "<span>" +data.downloads + "</span>"
-	  scrapeDate.innerText = new Date().toLocaleString(document.getElementsByTagName("html")[0].getAttribute("lang"), "ymdOpt")
+      leechers.innerHTML = "<span>" + data.leechers + "</span>"
+      downloads.innerHTML = "<span>" + data.downloads + "</span>"
     } else {
       seeders.innerHTML = oldStats[0]
       leechers.innerHTML = oldStats[1]
       downloads.innerHTML = oldStats[2]
     }
+    scrapeDate.innerText = new Date().toLocaleString(document.getElementsByTagName("html")[0].getAttribute("lang"), "ymdOpt")
   })
 </script>
 {{end}}

--- a/templates/site/user/torrents.jet.html
+++ b/templates/site/user/torrents.jet.html
@@ -49,7 +49,7 @@
 </table>
   <div class="user-torrent-search">
   <div class="pagination">
-    <a href="/search?userID={{ UserProfile.ID }}" aria-label="Next">
+    <a href="/user/{{UserProfile.ID}}/{{UserProfile.Username}}/search" aria-label="Next">
       <span style="display:block;border-right:1px solid;">
         {{  T("see_more_torrents_from", UserProfile.Username) }}
       </span>


### PR DESCRIPTION
- Update last-scraped date on view even if stats.go return unknown stats, it previously updated to "Unknown" before
- Increase stat scraping frequency
- Make /user redirects to user search instead of profile 0
- Add subcategory display in old navigation
- Fix way to wide user search input & user search link, that was overlapping on the full length of the profile sidebar