### PR TITLE
Fix Api documetation

### DIFF
--- a/apidoc/api_data.js
+++ b/apidoc/api_data.js
@@ -730,7 +730,7 @@ define({ "api": [
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "category",
+            "field": "c",
             "description": "<p>Torrent category.</p>"
           },
           {
@@ -884,7 +884,7 @@ define({ "api": [
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "category",
+            "field": "c",
             "description": "<p>Torrent category.</p>"
           },
           {
@@ -1109,7 +1109,7 @@ define({ "api": [
     }
   },
   {
-    "type": "post",
+    "type": "get",
     "url": "/user/",
     "title": "Get a private user profile",
     "version": "1.1.1",

--- a/apidoc/api_data.json
+++ b/apidoc/api_data.json
@@ -730,7 +730,7 @@
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "category",
+            "field": "c",
             "description": "<p>Torrent category.</p>"
           },
           {
@@ -884,7 +884,7 @@
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "category",
+            "field": "c",
             "description": "<p>Torrent category.</p>"
           },
           {
@@ -1109,7 +1109,7 @@
     }
   },
   {
-    "type": "post",
+    "type": "get",
     "url": "/user/",
     "title": "Get a private user profile",
     "version": "1.1.1",

--- a/apidoc/api_project.js
+++ b/apidoc/api_project.js
@@ -26,7 +26,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2017-10-16T09:11:10.675Z",
+    "time": "2017-10-18T18:26:13.462Z",
     "url": "http://apidocjs.com",
     "version": "0.17.6"
   }

--- a/apidoc/api_project.json
+++ b/apidoc/api_project.json
@@ -26,7 +26,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2017-10-16T09:11:10.675Z",
+    "time": "2017-10-18T18:26:13.462Z",
     "url": "http://apidocjs.com",
     "version": "0.17.6"
   }

--- a/controllers/api/api.go
+++ b/controllers/api/api.go
@@ -221,7 +221,7 @@ func APIViewHeadHandler(c *gin.Context) {
  * @apiParam {String} username Torrent uploader name.
  * @apiParam {String} name Torrent name.
  * @apiParam {String} magnet Torrent magnet URI.
- * @apiParam {String} category Torrent category.
+ * @apiParam {String} c Torrent category.
  * @apiParam {Boolean} remake Torrent is a remake.
  * @apiParam {String} description Torrent description.
  * @apiParam {Number} status Torrent status.
@@ -308,7 +308,7 @@ func APIUploadHandler(c *gin.Context) {
  * @apiParam {String} username Torrent uploader name.
  * @apiParam {Number} id Torrent ID.
  * @apiParam {String} name Torrent name.
- * @apiParam {String} category Torrent category.
+ * @apiParam {String} c Torrent category.
  * @apiParam {Boolean} remake Torrent is a remake.
  * @apiParam {String} description Torrent description.
  * @apiParam {Number} status Torrent status.

--- a/templates/template_test.go
+++ b/templates/template_test.go
@@ -60,7 +60,7 @@ func walkDirTest(dir string, t *testing.T) {
 	fakeActivity := &models.Activity{1, "t", "e", "s", 1, fakeUser}
 	fakeDB := &models.DatabaseDump{time.Now(), 3, "test", "test"}
 	fakeLanguage := &publicSettings.Language{"English", "en", "en-us"}
-	fakeTorrentRequest := &torrentValidator.TorrentRequest{Name: "test", Magnet: "", Category: "", Remake: false, Description: "", Status: 1, Hidden: false, CaptchaID: "", WebsiteLink: "", SubCategory: 0, Languages: nil, Infohash: "", SubCategoryID: 0, CategoryID: 0, Filesize: 0, Filepath: "", FileList: nil, Trackers: nil, Tags: torrentValidator.TagsRequest{}}
+	fakeTorrentRequest := &torrentValidator.TorrentRequest{Name: "test", Magnet: "", Category: "", Remake: false, Description: "", Status: 1, Hidden: false, CaptchaID: "", WebsiteLink: "", SubCategory: 0, Languages: nil, Infohash: "", CategoryID: 0, Filesize: 0, Filepath: "", FileList: nil, Trackers: nil, Tags: torrentValidator.TagsRequest{}}
 	fakeLogin := &userValidator.LoginForm{"test", "test", "/", "false"}
 	fakeRegistration := &userValidator.RegistrationForm{"test", "", "test", "test", "xxxx", "1"}
 	fakeReport := &models.TorrentReport{1, "test", 1, 1, time.Now(), fakeTorrent, fakeUser}

--- a/templates/template_test.go
+++ b/templates/template_test.go
@@ -60,7 +60,7 @@ func walkDirTest(dir string, t *testing.T) {
 	fakeActivity := &models.Activity{1, "t", "e", "s", 1, fakeUser}
 	fakeDB := &models.DatabaseDump{time.Now(), 3, "test", "test"}
 	fakeLanguage := &publicSettings.Language{"English", "en", "en-us"}
-	fakeTorrentRequest := &torrentValidator.TorrentRequest{Name: "test", Magnet: "", Category: "", Remake: false, Description: "", Status: 1, Hidden: false, CaptchaID: "", WebsiteLink: "", SubCategory: 0, Languages: nil, Infohash: "", CategoryID: 0, Filesize: 0, Filepath: "", FileList: nil, Trackers: nil, Tags: torrentValidator.TagsRequest{}}
+	fakeTorrentRequest := &torrentValidator.TorrentRequest{Name: "test", Magnet: "", Category: "", Remake: false, Description: "", Status: 1, Hidden: false, CaptchaID: "", WebsiteLink: "", Languages: nil, Infohash: "", SubCategoryID: 0, CategoryID: 0, Filesize: 0, Filepath: "", FileList: nil, Trackers: nil, Tags: torrentValidator.TagsRequest{}}
 	fakeLogin := &userValidator.LoginForm{"test", "test", "/", "false"}
 	fakeRegistration := &userValidator.RegistrationForm{"test", "", "test", "test", "xxxx", "1"}
 	fakeReport := &models.TorrentReport{1, "test", 1, 1, time.Now(), fakeTorrent, fakeUser}

--- a/utils/validator/torrent/forms.go
+++ b/utils/validator/torrent/forms.go
@@ -17,7 +17,6 @@ type TorrentRequest struct {
 	Hidden      bool     `json:"hidden,omitempty" form:"hidden"`
 	CaptchaID   string   `json:"-" form:"captchaID"`
 	WebsiteLink string   `validate:"uri" json:"website_link,omitempty" form:"website_link"`
-	SubCategory int      `json:"sub_category,omitempty" form:"sub_category"`
 	Languages   []string `json:"languages,omitempty" form:"languages"`
 
 	Infohash      string         `json:"hash,omitempty" form:"hash"`


### PR DESCRIPTION
Fix #1682
* Remove unused SubCategory field from struct TorrentRequest
* Change `category` argument in documentation to correct `c` (same key as the one in Search)