### PR TITLE
Make comment and users in admin panel ordered by newest to oldest

### DIFF
--- a/models/comments/interaction.go
+++ b/models/comments/interaction.go
@@ -12,7 +12,7 @@ func FindAll(limit int, offset int, conditions string, values ...interface{}) ([
 	var comments []models.Comment
 	var nbComments int
 	models.ORM.Model(&comments).Where(conditions, values...).Count(&nbComments)
-	models.ORM.Limit(limit).Offset(offset).Where(conditions, values...).Preload("User").Find(&comments)
+	models.ORM.Limit(limit).Offset(offset).Order("comment_id DESC").Where(conditions, values...).Preload("User").Find(&comments)
 	return comments, nbComments
 }
 

--- a/models/users/find.go
+++ b/models/users/find.go
@@ -141,6 +141,6 @@ func FindUsersForAdmin(limit int, offset int) ([]models.User, int) {
 	var users []models.User
 	var nbUsers int
 	models.ORM.Model(&users).Count(&nbUsers)
-	models.ORM.Preload("Torrents").Limit(limit).Offset(offset).Find(&users)
+	models.ORM.Preload("Torrents").Limit(limit).Offset(offset).Order("user_id DESC").Find(&users)
 	return users, nbUsers
 }


### PR DESCRIPTION
This will allow to look at newest users and comments from admin panel index without needing to go to the latest page everytime