### PR TITLE
Add possibility of reporting without JS, add report reason for NSFW content, Add possibility of getting a torrent by Hash in refine

### DIFF
--- a/controllers/oauth/callback.go
+++ b/controllers/oauth/callback.go
@@ -80,7 +80,7 @@ func CallbackHandler(conf gooauth.Config) func(c *gin.Context) {
 			return
 		}
 
-		messages.AddInfo("infos", fmt.Sprintf("%s", token.Raw))
+		messages.AddInfo("infos", fmt.Sprintf("%s", token))
 		templateVariables := templates.Commonvariables(c)
 		templateVariables.Set("Code", c.Request.URL.Query().Get("code"))
 		templateVariables.Set("AccessToken", token.AccessToken)

--- a/controllers/oauth/callback.go
+++ b/controllers/oauth/callback.go
@@ -80,7 +80,7 @@ func CallbackHandler(conf gooauth.Config) func(c *gin.Context) {
 			return
 		}
 
-		messages.AddInfo("infos", fmt.Sprintf("%s", token.raw))
+		//messages.AddInfo("infos", fmt.Sprintf("%s", token))
 		templateVariables := templates.Commonvariables(c)
 		templateVariables.Set("Code", c.Request.URL.Query().Get("code"))
 		templateVariables.Set("AccessToken", token.AccessToken)

--- a/controllers/oauth/callback.go
+++ b/controllers/oauth/callback.go
@@ -80,7 +80,7 @@ func CallbackHandler(conf gooauth.Config) func(c *gin.Context) {
 			return
 		}
 
-		messages.AddInfo("infos", fmt.Sprintf("%s", token))
+		messages.AddInfo("infos", fmt.Sprintf("%s", token.Raw))
 		templateVariables := templates.Commonvariables(c)
 		templateVariables.Set("Code", c.Request.URL.Query().Get("code"))
 		templateVariables.Set("AccessToken", token.AccessToken)

--- a/controllers/oauth/callback.go
+++ b/controllers/oauth/callback.go
@@ -80,7 +80,7 @@ func CallbackHandler(conf gooauth.Config) func(c *gin.Context) {
 			return
 		}
 
-		messages.AddInfo("infos", fmt.Sprintf("%s", token))
+		messages.AddInfo("infos", fmt.Sprintf("%s", token.raw))
 		templateVariables := templates.Commonvariables(c)
 		templateVariables.Set("Code", c.Request.URL.Query().Get("code"))
 		templateVariables.Set("AccessToken", token.AccessToken)

--- a/controllers/search/search.go
+++ b/controllers/search/search.go
@@ -68,9 +68,10 @@ func SearchHandler(c *gin.Context) {
 			//We already fetched the torrent so we can directly show the template without needing to do a search.AuthorizedQuery
 		} else {
 			variables := templates.Commonvariables(c)
+			searchForm.ShowRefine = true
 			variables.Set("Search", searchForm)
 			templates.Render(c, "errors/no_results.jet.html", variables)
-			//The hash hasn't been found so no point in showing any result
+			//The hash hasn't been found so no point in showing any result, but we do want to show the refine so that the user can search another hash or remove it from the search
 		}
 		return
 	}

--- a/controllers/search/search.go
+++ b/controllers/search/search.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NyaaPantsu/nyaa/controllers/router"
 	"github.com/NyaaPantsu/nyaa/models"
 	"github.com/NyaaPantsu/nyaa/templates"
+	"github.com/NyaaPantsu/nyaa/models/torrents"
 	"github.com/NyaaPantsu/nyaa/utils/search"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
@@ -58,6 +59,17 @@ func SearchHandler(c *gin.Context) {
 		//Must redirect him to user search instead of simply showing "no torrents found!"
 	}
 	
+	if c.Query("hash") != "" {
+		torrent, err := torrents.FindRawByHash(c.Query("hash"))
+		if err == nil {
+			templates.ModelList(c, "site/torrents/listing.jet.html", models.TorrentsToJSON([]models.Torrent{torrent}), templates.Navigation{1, 1, 0, "/search"}, searchForm)
+		} else {
+			variables := templates.Commonvariables(c)
+			variables.Set("Search", searchForm)
+			templates.Render(c, "errors/no_results.jet.html", variables)
+		}
+		return
+	}
 	
 	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrAdmin(uint(userID)))
 	if err != nil {

--- a/controllers/search/search.go
+++ b/controllers/search/search.go
@@ -4,6 +4,7 @@ import (
 	"html"
 	"net/http"
 	"strconv"
+	"strings"
 	"fmt"
 
 	"math"
@@ -60,13 +61,16 @@ func SearchHandler(c *gin.Context) {
 	}
 	
 	if c.Query("hash") != "" {
-		torrent, err := torrents.FindRawByHash(c.Query("hash"))
+		torrent, err := torrents.FindRawByHash(strings.TrimSpace(c.Query("hash")))
+		//Wanna make sure to remove spaces because user copy-pasting hashes might include spaces at time
 		if err == nil {
 			templates.ModelList(c, "site/torrents/listing.jet.html", models.TorrentsToJSON([]models.Torrent{torrent}), templates.Navigation{1, 1, 0, "/search"}, searchForm)
+			//We already fetched the torrent so we can directly show the template without needing to do a search.AuthorizedQuery
 		} else {
 			variables := templates.Commonvariables(c)
 			variables.Set("Search", searchForm)
 			templates.Render(c, "errors/no_results.jet.html", variables)
+			//The hash hasn't been found so no point in showing any result
 		}
 		return
 	}

--- a/models/tag_test.go
+++ b/models/tag_test.go
@@ -15,7 +15,7 @@ func TestTagsType(t *testing.T) {
 		assert.NotEmpty(tagConf.Name, "A name must be provided for a tag type")
 		assert.NotEmpty(tagConf.Field, "You need to provide a field from the torrent Struct for '%s' tag type in config", tagConf.Name)
 		if tagConf.Defaults != nil && len(tagConf.Defaults) == 0 {
-			t.Log("For '%s', you provided a defaults attributes but it is empty. You should remove the attribute or fill it", tagConf.Name)
+			t.Logf("For '%s', you provided a defaults attributes but it is empty. You should remove the attribute or fill it", tagConf.Name)
 		}
 		field := reflect.ValueOf(torrent).Elem().FieldByName(tagConf.Field)
 		assert.True(field.IsValid(), "The field '%s' provided for '%s' doesn't exist", tagConf.Field, tagConf.Name)

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2424,11 +2424,7 @@ td.notification-status.notification-unread {
 	color: white;
 }
 
-.torrent-report-table td, .torrent-report-table th {
-	width: 165px;
-}
 .td-report-message  {
-	width: auto!important;
     white-space: normal;
     word-break: break-word;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -443,12 +443,13 @@ select.form-input {
 .refine-container-2 span.form-refine {
     float: right;
     max-width: 426px;
+    margin-bottom: 5px;
 }
 .refine-container-2 span.spacing {
     width: 69px;
 }
 .refine-container-2 input[type="number"],.refine-container-2 input[type="text"] {
-    margin-bottom: 5px;
+    margin-bottom: 0;
     width: 85px!important;
 }
 .refine-date {
@@ -2424,7 +2425,11 @@ td.notification-status.notification-unread {
 	color: white;
 }
 
+.torrent-report-table td, .torrent-report-table th {
+	width: 165px;
+}
 .td-report-message  {
+	width: auto!important;
     white-space: normal;
     word-break: break-word;
 }

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -82,6 +82,8 @@
 			  <option value="{{vq}}">{{T("tagvalue_" + vq)}}</option>
 			  {{end}}
 			</select>
+			<span style="margin: 0 5px;">Hash:</span>
+			<input type="text" name="hash" placeholder="Torrent hash" class="form-input" value="" style="width: 218px!important">
 		  </span>
 		  <span class="form-refine">
 			<span class="spacing">Tags:</span>

--- a/templates/site/torrents/report.jet.html
+++ b/templates/site/torrents/report.jet.html
@@ -24,7 +24,7 @@
         <br />
 	{{ if !Sukebei()}}
         <input type="radio" name="report_type" value="nsfw_content" id="nsfw_content" required/>
-        <label for="other">{{  T("nsfw_content") }}</label>
+        <label for="nsfw_content">{{  T("nsfw_content") }}</label>
         <br />
 	{{end}}
         <input type="radio" name="report_type" value="other" id="other" required/>

--- a/templates/site/torrents/report.jet.html
+++ b/templates/site/torrents/report.jet.html
@@ -8,7 +8,7 @@
     <h1>{{  T("report_torrent_number", Form.ID) }}</h1>
     <form role="form" method="POST">
       {{ yield csrf_field() }}
-      <div style="text-align:left">
+      <div style="text-align:left;margin-bottom: 8px;">
         <h3>{{  T("report_type") }}</h3>
         <input type="radio" name="report_type" value="illegal_content" id="illegal" required/>
         <label for="illegal">{{  T("illegal_content") }}</label>
@@ -22,10 +22,20 @@
         <input type="radio" name="report_type" value="duplicate_deprecated" id="dup" required/>
         <label for="dup">{{  T("duplicate_deprecated") }}</label>
         <br />
+        <input type="radio" name="report_type" value="nsfw_content" id="nsfw_content" required/>
+        <label for="other">{{  T("nsfw_content") }}</label>
+        <br />
+        <input type="radio" name="report_type" value="other" id="other" required/>
+        <label for="other">{{  T("other") }}</label>
+        <br />
+	      <h4>{{  T("report_message") }}</h4>
+	      <input type="text" class="form-input" name="report_message" placeholder="(Optional, 60 characters max)" maxlength="60">
       </div>
+      {{if User.ID == 0}}
       <div class="comment-captcha">
         {{yield captcha(captchaid=Form.CaptchaID)}}
       </div>
+      {{end}}
       <input id="confirm_changes"  class="form-input up-input btn-green" name="submit_report" type="submit" value="{{  T("yes")}}"/>
     </form>
   </div>

--- a/templates/site/torrents/report.jet.html
+++ b/templates/site/torrents/report.jet.html
@@ -22,9 +22,11 @@
         <input type="radio" name="report_type" value="duplicate_deprecated" id="dup" required/>
         <label for="dup">{{  T("duplicate_deprecated") }}</label>
         <br />
+	{{ if !Sukebei()}}
         <input type="radio" name="report_type" value="nsfw_content" id="nsfw_content" required/>
         <label for="other">{{  T("nsfw_content") }}</label>
         <br />
+	{{end}}
         <input type="radio" name="report_type" value="other" id="other" required/>
         <label for="other">{{  T("other") }}</label>
         <br />

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -161,7 +161,7 @@
     <a id="torrent-download-link" href="{{if Torrent.TorrentLink == ""}}/download/{{Torrent.Hash}}{{else}}{{Torrent.TorrentLink}}{{end}}" class="form-input download{{ if !torrentFileExists(Torrent.Hash, Torrent.TorrentLink)}} hidden{{end}}" style="float:left;height: auto;">
       <div class="icon-floppy"></div>{{ T("torrent_file")}}
     </a>
-    <a id="reportPopup" href="#" class="form-input">{{  T("report_btn") }}</a>
+    <a id="reportPopup" href="/report/{{Torrent.ID}}" class="form-input">{{  T("report_btn") }}</a>
     {{ if User.ID > 0}}
     {{ if User.HasAdmin()}}
     <form method="POST" action="/mod/torrent/delete" class="delete-form">

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -273,7 +273,7 @@
         <label for="dup">{{  T("duplicate_deprecated") }}</label><br />
 	{{ if !Sukebei()}}
         <input type="radio" name="report_type" value="nsfw_content" id="nsfw_content" required/>
-        <label for="other">{{  T("nsfw_content") }}</label><br/>
+        <label for="nsfw_content">{{  T("nsfw_content") }}</label><br/>
 	{{end}}
         <input type="radio" name="report_type" value="other" id="other" required/>
         <label for="other">{{  T("other") }}</label><br />

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -271,7 +271,9 @@
         <label for="wrongcat">{{  T("wrong_category") }}</label><br />
         <input type="radio" name="report_type" value="duplicate_deprecated" id="dup" required/>
         <label for="dup">{{  T("duplicate_deprecated") }}</label><br />
-        <input type="radio" name="report_type" value="other" id="other"" required/>
+        <input type="radio" name="report_type" value="nsfw_content" id="nsfw_content" required/>
+        <label for="other">{{  T("nsfw_content") }}</label>
+        <input type="radio" name="report_type" value="other" id="other" required/>
         <label for="other">{{  T("other") }}</label><br />
 	<h4>{{  T("report_message") }}</h4>
 	<input type="text" class="form-input" name="report_message" placeholder="(Optional, 60 characters max)" maxlength="60">

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -271,8 +271,10 @@
         <label for="wrongcat">{{  T("wrong_category") }}</label><br />
         <input type="radio" name="report_type" value="duplicate_deprecated" id="dup" required/>
         <label for="dup">{{  T("duplicate_deprecated") }}</label><br />
+	{{ if !Sukebei()}}
         <input type="radio" name="report_type" value="nsfw_content" id="nsfw_content" required/>
-        <label for="other">{{  T("nsfw_content") }}</label>
+        <label for="other">{{  T("nsfw_content") }}</label><br/>
+	{{end}}
         <input type="radio" name="report_type" value="other" id="other" required/>
         <label for="other">{{  T("other") }}</label><br />
 	<h4>{{  T("report_message") }}</h4>

--- a/templates/template_functions_test.go
+++ b/templates/template_functions_test.go
@@ -386,7 +386,7 @@ func TestFileSize(t *testing.T) {
 	for _, test := range tests {
 		value := fileSize(test.TestSize, T, test.TestShowUnknown)
 		if value != test.Expected {
-			t.Errorf("Unexpected value from the function fileSize, got '%s', wanted '%s' for '%d' with '%b'", value, test.Expected, test.TestSize, test.TestShowUnknown)
+			t.Errorf("Unexpected value from the function fileSize, got '%s', wanted '%s' for '%d' with '%t'", value, test.Expected, test.TestSize, test.TestShowUnknown)
 		}
 	}
 }
@@ -660,7 +660,7 @@ func Teststrcmp(t *testing.T) {
  	for _, test := range tests {
  		value := strcmp(test.TestString, test.TestString2, -1, 0)
  		if value != test.Expected {
- 			t.Errorf("Unexpected value from the function strcmp, got '%b' by comparing '%s' to '%s' starting at '%d' and ending after '%d', wanted '%b'", value, test.TestString, test.TestString2, test.TestStart, test.TestEnd, test.Expected)
+ 			t.Errorf("Unexpected value from the function strcmp, got '%t' by comparing '%s' to '%s' starting at '%d' and ending after '%d', wanted '%t'", value, test.TestString, test.TestString2, test.TestStart, test.TestEnd, test.Expected)
  		}
 	}
  }
@@ -700,7 +700,7 @@ func Teststrcmp(t *testing.T) {
  	for _, test := range tests {
  		value := strfind(test.TestString, test.TestString2, test.TestStart)
  		if value != test.Match {
- 			t.Errorf("Unexpected value from the function strfind, got '%b' by comparing '%s' to '%s' starting from %d, wanted '%b'", value, test.TestString, test.TestString2, test.TestStart, test.Match)
+ 			t.Errorf("Unexpected value from the function strfind, got '%t' by comparing '%s' to '%s' starting from %d, wanted '%t'", value, test.TestString, test.TestString2, test.TestStart, test.Match)
  		}
 	}
  }
@@ -795,7 +795,7 @@ func testFormatDate(t *testing.T) {
  	for _, test := range tests {
 		value := formatDate(test.TestDate, test.TestFullDate)
  		if value != test.Expected {
- 			t.Errorf("Unexpected value from the function formatDate, got '%s' from '%s' and '%d', wanted '%s'", value, test.TestDate, test.TestFullDate, test.Expected)
+ 			t.Errorf("Unexpected value from the function formatDate, got '%s' from '%s' and '%t', wanted '%s'", value, test.TestDate, test.TestFullDate, test.Expected)
  		}
 	}
  }

--- a/templates/template_functions_test.go
+++ b/templates/template_functions_test.go
@@ -386,7 +386,7 @@ func TestFileSize(t *testing.T) {
 	for _, test := range tests {
 		value := fileSize(test.TestSize, T, test.TestShowUnknown)
 		if value != test.Expected {
-			t.Errorf("Unexpected value from the function fileSize, got '%s', wanted '%s' for '%d' with '%d'", value, test.Expected, test.TestSize, test.TestShowUnknown)
+			t.Errorf("Unexpected value from the function fileSize, got '%s', wanted '%s' for '%d' with '%b'", value, test.Expected, test.TestSize, test.TestShowUnknown)
 		}
 	}
 }
@@ -660,7 +660,7 @@ func Teststrcmp(t *testing.T) {
  	for _, test := range tests {
  		value := strcmp(test.TestString, test.TestString2, -1, 0)
  		if value != test.Expected {
- 			t.Errorf("Unexpected value from the function strcmp, got '%t', wanted '%t'", value, test.Expected, test.TestString, test.TestString)
+ 			t.Errorf("Unexpected value from the function strcmp, got '%b' by comparing '%s' to '%s' starting at '%d' and ending after '%d', wanted '%b'", value, test.TestString, test.TestString2, test.TestStart, test.TestEnd, test.Expected)
  		}
 	}
  }
@@ -700,7 +700,7 @@ func Teststrcmp(t *testing.T) {
  	for _, test := range tests {
  		value := strfind(test.TestString, test.TestString2, test.TestStart)
  		if value != test.Match {
- 			t.Errorf("Unexpected value from the function strfind, got '%t', wanted '%t'", value, test.Match, test.TestString, test.TestString)
+ 			t.Errorf("Unexpected value from the function strfind, got '%b' by comparing '%s' to '%s' starting from %d, wanted '%b'", value, test.TestString, test.TestString2, test.TestStart, test.Match)
  		}
 	}
  }
@@ -769,7 +769,7 @@ func Teststrcmp(t *testing.T) {
 		}
 		value := formatThemeName(test.TestPath, T)
  		if value != test.Expected {
- 			t.Errorf("Unexpected value from the function formatThemeName, got '%t' from '%s', wanted '%t'", value, test.TestPath, test.Expected)
+ 			t.Errorf("Unexpected value from the function formatThemeName, got '%s' from '%s', wanted '%s'", value, test.TestPath, test.Expected)
  		}
 	}
  }
@@ -795,7 +795,7 @@ func testFormatDate(t *testing.T) {
  	for _, test := range tests {
 		value := formatDate(test.TestDate, test.TestFullDate)
  		if value != test.Expected {
- 			t.Errorf("Unexpected value from the function formatDate, got '%t' from '%s' and '%d', wanted '%t'", value, test.TestDate, test.TestFullDate, test.Expected)
+ 			t.Errorf("Unexpected value from the function formatDate, got '%s' from '%s' and '%d', wanted '%s'", value, test.TestDate, test.TestFullDate, test.Expected)
  		}
 	}
  }

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -86,3 +86,5 @@
 * + duration
 * - removed: delay
 * + create_anouncement_success
+## 2017/11/04
+* + nsfw_content

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -804,6 +804,10 @@
     "translation": "Duplicate / Deprecated"
   },
   {
+    "id": "nsfw_content",
+    "translation": "NSFW content"
+  },
+  {
     "id": "other",
     "translation": "Other"
   },


### PR DESCRIPTION
There was a /report/:id page but it wasn't being used, it now is
Added a "NSFW content" report reason
Add input to get a torrent by hash in refine and by the ?hash get parameter, though it only match exact hash and as such overrides any other search parameter