### PR TITLE
Fix sukebei fromID search

### DIFF
--- a/utils/search/sortmode.go
+++ b/utils/search/sortmode.go
@@ -21,7 +21,7 @@ type SortField struct {
 }
 
 var sortFields = []SortField{
-	{"id", "torrents.torrent_id"},
+	{"id", config.Get().Models.TorrentsTableName + ".torrent_id"},
 	{"name.raw", "torrent_name"},
 	{"date", "date"},
 	{"downloads", "downloads"},

--- a/utils/search/torrentParam.go
+++ b/utils/search/torrentParam.go
@@ -13,6 +13,7 @@ import (
 
 	elastic "gopkg.in/olivere/elastic.v5"
 
+	"github.com/NyaaPantsu/nyaa/config"
 	"github.com/NyaaPantsu/nyaa/models"
 	"github.com/NyaaPantsu/nyaa/models/torrents"
 	"github.com/NyaaPantsu/nyaa/utils/log"
@@ -390,11 +391,11 @@ func (p *TorrentParam) toDBQuery(c *gin.Context) *Query {
 	}
 
 	if p.FromID != 0 {
-		query.Append("torrents.torrent_id > ?", p.FromID)
+		query.Append(config.Get().Models.TorrentsTableName + ".torrent_id > ?", p.FromID)
 	}
 	if len(p.TorrentID) > 0 {
 		for _, id := range p.TorrentID {
-			query.Append("torrents.torrent_id = ?", id)
+			query.Append(config.Get().Models.TorrentsTableName + ".torrent_id = ?", id)
 		}
 	}
 	if p.FromDate != "" {


### PR DESCRIPTION
Some specific part of the queries were using the "torrents" table instead of relying on what was set in config which made it fail for any instance that had something else than the default name for the torrent table name