### PR TITLE
Increase max torrent per page, fix HTML errors, other fixes

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -170,7 +170,7 @@ users:
   default_notifications_settings: {"new_torrent": true, "new_torrent_email": false, "new_comment": true, "new_comment_email": false, "new_responses": false, "new_responses_email": false, "new_follower": false, "new_follower_email": false, "followed": false, "followed_email": false}
 navigation:
   torrents_per_page: 50
-  max_torrents_per_page: 300
+  max_torrents_per_page: 500
 log:
 # AccessLogFilePath : Path to logs access
   access_log_filepath: log/access

--- a/controllers/moderator/index.go
+++ b/controllers/moderator/index.go
@@ -13,7 +13,7 @@ import (
 // IndexModPanel : Controller for showing index page of Mod Panel
 func IndexModPanel(c *gin.Context) {
 	offset := 10
-	torrents, _, _ := torrents.FindAll(offset, 0)
+	torrents, _, _ := torrents.FindAllOrderBy("torrent_id DESC", offset, 0)
 	users, _ := users.FindUsersForAdmin(offset, 0)
 	comments, _ := comments.FindAll(offset, 0, "", "")
 	torrentReports, _, _ := reports.GetAll(offset, 0)

--- a/controllers/settings/settings.go
+++ b/controllers/settings/settings.go
@@ -31,7 +31,7 @@ func SeePublicSettingsHandler(c *gin.Context) {
 // ChangePublicSettingsHandler : Controller for changing the current language and theme
 func ChangePublicSettingsHandler(c *gin.Context) {
 	theme := c.PostForm("theme")
-	lang := c.PostForm("language")
+	lang := c.PostForm("lang")
 	mascot := c.PostForm("mascot")
 	mascotURL := c.PostForm("mascot_url")
 	altColors := c.PostForm("altColors")

--- a/public/css/themes/classic.css
+++ b/public/css/themes/classic.css
@@ -348,7 +348,7 @@ span.comment-user:hover {
     margin: 1px 0;
 }
 
-#solution {
+.solution {
     margin-top: -3px;
 }
 

--- a/public/css/themes/classic.css
+++ b/public/css/themes/classic.css
@@ -265,10 +265,10 @@ select.form-input {
 .website-nav .pagination span {
     min-width: auto;
 }
-.website-nav #page-prev{
+.website-nav .page-prev{
     float: left;
 }
-.website-nav #page-next{
+.website-nav .page-next{
     float: right;
 }
 

--- a/templates/layouts/partials/helpers/captcha.jet.html
+++ b/templates/layouts/partials/helpers/captcha.jet.html
@@ -11,7 +11,7 @@
       {{ T("captcha_audio") }}
     </a>
   </audio>
-  <input class="form-input up-input form-control" type="text" name="solution" id="solution" style="display:block;" placeholder="{{ T("captcha")}}" autocomplete="off" required />
+  <input class="form-input up-input form-control" type="text" name="solution" class="solution" style="display:block;" placeholder="{{ T("captcha")}}" autocomplete="off" required />
 </div>
 {{end}}
 {{end}}

--- a/templates/layouts/partials/helpers/oldNav.jet.html
+++ b/templates/layouts/partials/helpers/oldNav.jet.html
@@ -5,7 +5,7 @@
 		<tr>
 		{{ range _, cat := GetCategories(true, false) }}
 			<td>{{if Search.Category == cat.ID ||(len(Search.Category) > 2 && Search.Category[:2] == cat.ID)}}<b>{{ T(cat.Name) }}</b>{{else}}<a href="{{genSearchWithCategory(URL, cat.ID, Search.SearchURL)}}">{{ T(cat.Name) }}</a>{{end}}</td>
-			{{ if _ % 3 == 2}}
+			{{ if _ % 3 == 2 && _ + 1 != len(GetCategories(true, false)) }}
 			</tr>
 			<tr>
 			{{end}}

--- a/templates/layouts/partials/helpers/search.jet.html
+++ b/templates/layouts/partials/helpers/search.jet.html
@@ -34,7 +34,7 @@
       <option value="3" {{if Search.Status == 3}}selected{{end}}>{{ T("trusted")}}</option>
       <option value="4" {{if Search.Status == 4}}selected{{end}}>A+</option>
     </select>
-    {{ T("limit_torrent_count")}}: <input type="number" name="limit" value="{{ Navigation.MaxItemPerPage }}" class="form-input spacing" min="1" max="300"/>
+    {{ T("limit_torrent_count")}}: <input type="number" name="limit" value="{{ Navigation.MaxItemPerPage }}" class="form-input spacing" min="1" max="500"/>
     {{ T("from_user") }}: <input type="text" name="user" placeholder="Username/#ID" value="{{ Search.User == "" ? (Search.UserID == 0 ? "" : ("#" + Search.UserID)) : Search.User  }}" class="form-input refine-user"/>
   </span>
   <span class="form-refine">

--- a/templates/site/user/public/settings.jet.html
+++ b/templates/site/user/public/settings.jet.html
@@ -8,7 +8,7 @@
     <div id="settings-container">
       <span class="form-group">
       <h3>{{ T("language")}}</h3>
-      <select id="language" name="language" class="form-input">
+      <select id="language" name="lang" class="form-input">
         {{ range translatedName := Form.Languages }}
         <option value="{{ translatedName[2] }}" {{ if Form.Current == translatedName[2] }}selected{{end}}>{{ translatedName[0] }}</option>
         {{ end }}
@@ -67,21 +67,29 @@
 {{ block footer_js()}}
 <!-- JS Function for selecting multiple checkboxes -->
 <script type="text/javascript">
-  var SaveButton = document.querySelector('button[type="submit"')
+  var SaveButton = document.querySelector('form[method="POST"] button[type="submit"]')
   
   //Golang settings.go controller set cookies for the domain variable in config, if we are currently on a mirror this will mean that the cookie will not be set for the right website
-  if(UserID == 0 && Mirror)
+  
+  if(UserID == 0)
 	SaveButton.addEventListener("click", function(e) {
-		var OptionSelected = document.getElementById("theme-selector").selectedIndex
-		document.cookie = "theme=" + document.querySelector("#theme-selector :nth-child(" + OptionSelected + ")").value + ";path=/;expires=" + farFutureString + ";domain=" + domain
-		//Set theme cookie
+		var formInputs = document.querySelectorAll("form[method='POST'] input"),
+			formSelect = document.querySelectorAll("form[method='POST'] select")
+			
+			
+		for(var i = 0; i < formInputs.length; i++) {
+			var setting = formInputs[i]
+			if(setting.name == "csrf_token") continue
+			document.cookie = setting.name + "=" + setting.value + ";path=/;expires=" + farFutureString + ";domain=" + domain
+		}
 		
-		OptionSelected = document.getElementById("language").selectedIndex
-		document.cookie = "lang=" + document.querySelector("#language :nth-child(" + OptionSelected + ")").value + ";path=/;expires=" + farFutureString + ";domain=" + domain
-		//Set language cookie
-		
-		//Will have to do the rest
-		
+		for(var i = 0; i < formSelect.length; i++) {
+			var setting = formSelect[i],
+				selectValues = setting.querySelectorAll("option")
+			
+			document.cookie = setting.name + "=" + selectValues[setting.selectedIndex].value + ";path=/;expires=" + farFutureString + ";domain=" + domain
+		}	
+	
 		window.location.replace("/")
 		e.preventDefault()
 	})

--- a/templates/template_functions.go
+++ b/templates/template_functions.go
@@ -149,7 +149,7 @@ func genNav(nav Navigation, currentURL *url.URL, pagesSelectable int) template.H
 			display = ""
 			href = " href=\"" + "/" + nav.Route + "/1" + "?" + currentURL.RawQuery + "\""
 		}
-		ret = ret + "<a id=\"page-prev\"" + display + href + " aria-label=\"Previous\"><span aria-hidden=\"true\">&laquo;</span></a>"
+		ret = ret + "<a class=\"page-prev\"" + display + href + " aria-label=\"Previous\"><span aria-hidden=\"true\">&laquo;</span></a>"
 		
 		startValue := 1
 		if nav.CurrentPage > pagesSelectable/2 {
@@ -178,7 +178,7 @@ func genNav(nav Navigation, currentURL *url.URL, pagesSelectable int) template.H
 			display = ""
 			href = " href=\"" + "/" + nav.Route + "/" + strconv.Itoa(int(maxPages)) + "?" + currentURL.RawQuery + "\""
 		}
-		ret = ret + "<a id=\"page-next\"" + display + href +" aria-label=\"Next\"><span aria-hidden=\"true\">&raquo;</span></a>"
+		ret = ret + "<a class=\"page-next\"" + display + href +" aria-label=\"Next\"><span aria-hidden=\"true\">&raquo;</span></a>"
 			
 		itemsThisPageStart := nav.MaxItemPerPage*(nav.CurrentPage-1) + 1
 		itemsThisPageEnd := nav.MaxItemPerPage * nav.CurrentPage


### PR DESCRIPTION
- Fix multiple HTML errors
- Increase max torrent per page from 300 to 500
- Fix settings for non-logged in users in mirrors, in JS
- Fix order of torrents in admin panel index, oldest one were being shown first