### PR TITLE
Fix duplicate comment workaround that hid comments that shouldnt have been hidden

### DIFF
--- a/models/users/find.go
+++ b/models/users/find.go
@@ -95,7 +95,7 @@ func FindOldUploadsByUsername(username string) ([]uint, error) {
 // FindByID retrieves a user by ID.
 func FindByID(id uint) (*models.User, int, error) {
 	var user = &models.User{}
-	if models.ORM.Preload("Notifications", func(db *gorm.DB) *gorm.DB { return db.Order("id DESC") }).Last(user, id).RecordNotFound() {
+	if models.ORM.Preload("Notifications", func(db *gorm.DB) *gorm.DB { return db.Order("date DESC") }).Last(user, id).RecordNotFound() {
 		return user, http.StatusNotFound, errors.New("user_not_found")
 	}
 	var liked, likings []models.User
@@ -117,7 +117,7 @@ func FindRawByID(id uint) (*models.User, int, error) {
 
 func SessionByID(id uint) (*models.User, int, error) {
 	var user = &models.User{}
-	if models.ORM.Preload("Notifications", func(db *gorm.DB) *gorm.DB { return db.Order("id DESC") }).Where("user_id = ?", id).First(user).RecordNotFound() { // We only load unread notifications
+	if models.ORM.Preload("Notifications", func(db *gorm.DB) *gorm.DB { return db.Order("date DESC") }).Where("user_id = ?", id).First(user).RecordNotFound() { // We only load unread notifications
 		return user, http.StatusBadRequest, errors.New("user_not_found")
 	}
 	return user, http.StatusOK, nil
@@ -126,7 +126,7 @@ func SessionByID(id uint) (*models.User, int, error) {
 // FindForAdmin retrieves a user for an administrator, preloads torrents.
 func FindForAdmin(id uint) (*models.User, int, error) {
 	var user = &models.User{}
-	if models.ORM.Preload("Notifications", func(db *gorm.DB) *gorm.DB { return db.Order("id DESC") }).Preload("Torrents").Last(user, id).RecordNotFound() {
+	if models.ORM.Preload("Notifications", func(db *gorm.DB) *gorm.DB { return db.Order("date DESC") }).Preload("Torrents").Last(user, id).RecordNotFound() {
 		return user, http.StatusNotFound, errors.New("user_not_found")
 	}
 	var liked, likings []models.User

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -213,7 +213,7 @@
   {{previousComment := ""}}
   {{previousUser := 0}}
   {{range index, element := Torrent.Comments}}
-  {{if previousComment != element.Content || previousUser != element.UserID}}
+  {{if previousComment != element.Content || previousUser != element.UserID || element.UserID == 0}}
   <div class="torrent-info-box comment-box">
     <span class="comment-index">
       <a href="#comment_{{idx}}">{{idx}}</a>


### PR DESCRIPTION
It hid multiple anonymous users saying the same message in a row and we dont want that

Also,
- Fix notification order that was all over the place once you started deleting old notifications

It was being ordered by ID instead of date, and new notifications can have lower ID since notifications can be deleted