### PR TITLE
Janitor

### DIFF
--- a/controllers/activities/activities.go
+++ b/controllers/activities/activities.go
@@ -32,7 +32,7 @@ func ActivityListHandler(c *gin.Context) {
 	}
 	var conditions []string
 	var values []interface{}
-	if userid != "" && currentUser.HasAdmin() {
+	if userid != "" && currentUser.IsModerator() {
 		conditions = append(conditions, "user_id = ?")
 		values = append(values, userid)
 	}

--- a/controllers/api/api.go
+++ b/controllers/api/api.go
@@ -433,7 +433,7 @@ func APISearchHandler(c *gin.Context) {
 		userID = 0
 	}
 
-	_, torrentSearch, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(userID)))
+	_, torrentSearch, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(userID)), currentUser.CurrentOrJanitor(uint(userID)))
 
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)

--- a/controllers/api/api.go
+++ b/controllers/api/api.go
@@ -433,7 +433,7 @@ func APISearchHandler(c *gin.Context) {
 		userID = 0
 	}
 
-	_, torrentSearch, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(user)))
+	_, torrentSearch, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(userID)))
 
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)

--- a/controllers/api/api.go
+++ b/controllers/api/api.go
@@ -433,7 +433,7 @@ func APISearchHandler(c *gin.Context) {
 		userID = 0
 	}
 
-	_, torrentSearch, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrAdmin(uint(userID)))
+	_, torrentSearch, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.IsJanitor())
 
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)

--- a/controllers/api/api.go
+++ b/controllers/api/api.go
@@ -433,7 +433,7 @@ func APISearchHandler(c *gin.Context) {
 		userID = 0
 	}
 
-	_, torrentSearch, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.IsJanitor())
+	_, torrentSearch, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(user)))
 
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)

--- a/controllers/feed/helpers.go
+++ b/controllers/feed/helpers.go
@@ -86,7 +86,7 @@ func getTorrentList(c *gin.Context) (torrents []models.Torrent, createdAsTime ti
 		user = 0
 	}
 
-	_, torrents, _, err = search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrAdmin(uint(user)))
+	_, torrents, _, err = search.AuthorizedQuery(c, pagenum, currentUser.IsJanitor())
 
 	return
 }

--- a/controllers/feed/helpers.go
+++ b/controllers/feed/helpers.go
@@ -86,7 +86,7 @@ func getTorrentList(c *gin.Context) (torrents []models.Torrent, createdAsTime ti
 		user = 0
 	}
 
-	_, torrents, _, err = search.AuthorizedQuery(c, pagenum, currentUser.IsJanitor())
+	_, torrents, _, err = search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(user)))
 
 	return
 }

--- a/controllers/feed/helpers.go
+++ b/controllers/feed/helpers.go
@@ -86,7 +86,7 @@ func getTorrentList(c *gin.Context) (torrents []models.Torrent, createdAsTime ti
 		user = 0
 	}
 
-	_, torrents, _, err = search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(user)))
+	_, torrents, _, err = search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(user)), currentUser.CurrentOrJanitor(uint(user)))
 
 	return
 }

--- a/controllers/middlewares/middlewares.go
+++ b/controllers/middlewares/middlewares.go
@@ -39,7 +39,7 @@ func ErrorMiddleware() gin.HandlerFunc {
 func ModMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		currentUser := router.GetUser(c)
-		if !currentUser.HasAdmin() {
+		if !currentUser.IsJanitor() {
 			NotFoundHandler(c)
 		}
 		c.Next()

--- a/controllers/moderator/comments.go
+++ b/controllers/moderator/comments.go
@@ -61,10 +61,19 @@ func CommentsListPanel(c *gin.Context) {
 
 // CommentDeleteModPanel : Controller for deleting a comment
 func CommentDeleteModPanel(c *gin.Context) {
-	id, _ := strconv.ParseInt(c.PostForm("id"), 10, 32)
+	id, err := strconv.ParseInt(c.PostForm("id"), 10, 32)
+	if err != nil {
+		c.Redirect(http.StatusSeeOther, "/mod/comments")
+		return
+	}
+	
 	comment, _, err := comments.Delete(uint(id))
 	if err == nil {
-		activities.Log(&models.User{}, comment.Identifier(), "delete", "comment_deleted_by", strconv.Itoa(int(comment.ID)), comment.User.Username, router.GetUser(c).Username)
+		username := "れんちょん"
+		if comment.UserID != 0 {
+			username = comment.User.Username
+		}
+		activities.Log(&models.User{}, comment.Identifier(), "delete", "comment_deleted_by", strconv.Itoa(int(comment.ID)), username, router.GetUser(c).Username)
 	}
 
 	c.Redirect(http.StatusSeeOther, "/mod/comments?deleted")

--- a/controllers/moderator/helpers.go
+++ b/controllers/moderator/helpers.go
@@ -53,7 +53,7 @@ func torrentManyAction(c *gin.Context) {
 		messages.AddErrorTf("errors", "no_status_exist", status)
 		status = -1
 	}
-	if !currentUser.HasAdmin() {
+	if !currentUser.IsModerator() {
 		if c.PostForm("status") != "" { // Condition to check if a user try to change torrent status without having the right permission
 			if (status == models.TorrentStatusTrusted && !currentUser.IsTrusted()) || status == models.TorrentStatusAPlus || status == 0 {
 				status = models.TorrentStatusNormal
@@ -64,7 +64,7 @@ func torrentManyAction(c *gin.Context) {
 		}
 		withReport = false // Users should not be able to remove reports
 	}
-	if c.PostForm("owner") != "" && currentUser.HasAdmin() { // We check that the user given exist and if not we return an error
+	if c.PostForm("owner") != "" && currentUser.IsModerator() { // We check that the user given exist and if not we return an error
 		_, _, errorUser := users.FindForAdmin(uint(owner))
 		if errorUser != nil {
 			messages.AddErrorTf("errors", "no_user_found_id", owner)

--- a/controllers/moderator/index.go
+++ b/controllers/moderator/index.go
@@ -13,7 +13,7 @@ import (
 // IndexModPanel : Controller for showing index page of Mod Panel
 func IndexModPanel(c *gin.Context) {
 	offset := 10
-	torrents, _, _ := torrents.FindAllOrderBy("torrent_id DESC", offset, 0)
+	torrents, _, _ := torrents.FindAllForAdminsOrderBy("torrent_id DESC", offset, 0)
 	users, _ := users.FindUsersForAdmin(offset, 0)
 	comments, _ := comments.FindAll(offset, 0, "", "")
 	torrentReports, _, _ := reports.GetAll(offset, 0)

--- a/controllers/moderator/index.go
+++ b/controllers/moderator/index.go
@@ -21,6 +21,6 @@ func IndexModPanel(c *gin.Context) {
 	templates.PanelAdmin(c, torrents, models.TorrentReportsToJSON(torrentReports), users, comments)
 }
 
-func GuideModPanel(c *gin.Context) {
+func GuidelinesModPanel(c *gin.Context) {
 	templates.Static(c, "admin/guidelines.jet.html")
 }

--- a/controllers/moderator/index.go
+++ b/controllers/moderator/index.go
@@ -20,3 +20,7 @@ func IndexModPanel(c *gin.Context) {
 
 	templates.PanelAdmin(c, torrents, models.TorrentReportsToJSON(torrentReports), users, comments)
 }
+
+func GuideModPanel(c *gin.Context) {
+	templates.Static(c, "admin/guidelines.jet.html")
+}

--- a/controllers/moderator/router.go
+++ b/controllers/moderator/router.go
@@ -46,8 +46,11 @@ func init() {
 		modRoutes.GET("/torrent", TorrentEditModPanel)
 		modRoutes.POST("/torrent", TorrentPostEditModPanel)
 
-		/* Torrent delete routes */
+		/* Torrent delete routs */
 		modRoutes.POST("/torrent/delete", TorrentDeleteModPanel)
+		
+		/* Guidelines route */
+		modRoutes.Any("/guidelines", GuidelinesModPanel)
 
 		/* Announcement edit view */
 		modRoutes.GET("/announcement/form", addAnnouncement)

--- a/controllers/moderator/torrents.go
+++ b/controllers/moderator/torrents.go
@@ -120,38 +120,43 @@ func TorrentPostEditModPanel(c *gin.Context) {
 
 // TorrentDeleteModPanel : Controller for deleting a torrent
 func TorrentDeleteModPanel(c *gin.Context) {
-	id, _ := strconv.ParseInt(c.PostForm("id"), 10, 32)
-	definitely := c.Request.URL.Query()["definitely"]
-
 	var returnRoute = "/mod/torrents"
-	torrent, errFind := torrents.FindByID(uint(id))
-	if errFind == nil {
-		var err error
-		if definitely != nil {
-			_, _, err = torrent.DefinitelyDelete()
-			returnRoute = "/mod/torrents/deleted"
-		} else {
-			_, _, err = torrent.Delete(false)
-		}
-		
-		//delete reports of torrent
-		query := &search.Query{}
-		query.Append("torrent_id", id)
-		reports, _, _ := reports.FindOrderBy(query, "", 0, 0)
-		for _, report := range reports {
-			report.Delete()
-		}
-		
-		if err == nil {
-			if torrent.Uploader == nil {
-				torrent.Uploader = &models.User{}
+	currentUser := router.GetUser(c)
+	
+	if currentUser.IsModerator() {
+		id, _ := strconv.ParseInt(c.PostForm("id"), 10, 32)
+		definitely := c.Request.URL.Query()["definitely"]
+
+		torrent, errFind := torrents.FindByID(uint(id))
+		if errFind == nil {
+			var err error
+			if definitely != nil {
+				_, _, err = torrent.DefinitelyDelete()
+				returnRoute = "/mod/torrents/deleted"
+			} else {
+				_, _, err = torrent.Delete(false)
 			}
-			_, username := torrents.HideUser(torrent.UploaderID, torrent.Uploader.Username, torrent.Hidden)
-			activities.Log(&models.User{}, torrent.Identifier(), "delete", "torrent_deleted_by", strconv.Itoa(int(torrent.ID)), username, router.GetUser(c).Username)
+			
+			//delete reports of torrent
+			query := &search.Query{}
+			query.Append("torrent_id", id)
+			reports, _, _ := reports.FindOrderBy(query, "", 0, 0)
+			for _, report := range reports {
+				report.Delete()
+			}
+			
+			if err == nil {
+				if torrent.Uploader == nil {
+					torrent.Uploader = &models.User{}
+				}
+				_, username := torrents.HideUser(torrent.UploaderID, torrent.Uploader.Username, torrent.Hidden)
+				activities.Log(&models.User{}, torrent.Identifier(), "delete", "torrent_deleted_by", strconv.Itoa(int(torrent.ID)), username, currentUser.Username)
+			}
 		}
+		c.Redirect(http.StatusSeeOther, returnRoute+"?deleted")
 	}
 
-	c.Redirect(http.StatusSeeOther, returnRoute+"?deleted")
+	c.Redirect(http.StatusSeeOther, returnRoute)
 }
 
 // DeleteTagsModPanel : Controller for deleting all torrent tags

--- a/controllers/search/search.go
+++ b/controllers/search/search.go
@@ -76,7 +76,7 @@ func SearchHandler(c *gin.Context) {
 		return
 	}
 	
-	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrAdmin(uint(userID)))
+	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.IsJanitor())
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/controllers/search/search.go
+++ b/controllers/search/search.go
@@ -76,7 +76,7 @@ func SearchHandler(c *gin.Context) {
 		return
 	}
 	
-	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.IsJanitor())
+	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(user))))
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/controllers/search/search.go
+++ b/controllers/search/search.go
@@ -76,7 +76,7 @@ func SearchHandler(c *gin.Context) {
 		return
 	}
 	
-	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(user))))
+	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(userID)))
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/controllers/search/search.go
+++ b/controllers/search/search.go
@@ -76,7 +76,7 @@ func SearchHandler(c *gin.Context) {
 		return
 	}
 	
-	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(userID)))
+	searchParam, torrents, nbTorrents, err := search.AuthorizedQuery(c, pagenum, currentUser.CurrentOrJanitor(uint(userID)), currentUser.IsJanitor())
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/controllers/torrent/comment.go
+++ b/controllers/torrent/comment.go
@@ -10,8 +10,10 @@ import (
 	"github.com/NyaaPantsu/nyaa/models/comments"
 	"github.com/NyaaPantsu/nyaa/models/torrents"
 	"github.com/NyaaPantsu/nyaa/utils/captcha"
+	"github.com/NyaaPantsu/nyaa/utils/filelist"
 	msg "github.com/NyaaPantsu/nyaa/utils/messages"
 	"github.com/NyaaPantsu/nyaa/utils/sanitize"
+	"github.com/NyaaPantsu/nyaa/templates"
 	"github.com/gin-gonic/gin"
 )
 
@@ -57,5 +59,13 @@ func PostCommentHandler(c *gin.Context) {
 			messages.Error(err)
 		}
 	}
-	ViewHandler(c)
+	
+	captchaID := ""
+	//Generate a captcha
+	if currentUser.NeedsCaptcha() {
+		captchaID = captcha.GetID()
+	}
+	
+	folder := filelist.FileListToFolder(torrent.FileList, "root")
+	templates.Torrent(c, torrent.ToJSON(), folder, captchaID)
 }

--- a/controllers/torrent/comment.go
+++ b/controllers/torrent/comment.go
@@ -57,6 +57,5 @@ func PostCommentHandler(c *gin.Context) {
 			messages.Error(err)
 		}
 	}
-	url := "/view/" + strconv.FormatUint(uint64(torrent.ID), 10)
-	c.Redirect(302, url)
+	ViewHandler(c)
 }

--- a/controllers/torrent/comment.go
+++ b/controllers/torrent/comment.go
@@ -34,6 +34,9 @@ func PostCommentHandler(c *gin.Context) {
 			messages.AddErrorT("errors", "bad_captcha")
 		}
 	}
+	if currentUser.IsBanned() {
+	    messages.AddErrorT("errors", "account_banned")
+	}
 	content := sanitize.Sanitize(c.PostForm("comment"), "comment")
 	
 	userID := currentUser.ID

--- a/controllers/torrent/delete.go
+++ b/controllers/torrent/delete.go
@@ -25,7 +25,7 @@ func TorrentDeleteUserPanel(c *gin.Context) {
 				torrent.Uploader = &models.User{}
 			}
 			_, username := torrents.HideUser(torrent.UploaderID, torrent.Uploader.Username, torrent.Hidden)
-			if currentUser.HasAdmin() { // We hide username on log activity if user is not admin and torrent is hidden
+			if currentUser.IsModerator() { // We hide username on log activity if user is not admin and torrent is hidden
 				activities.Log(&models.User{}, torrent.Identifier(), "delete", "torrent_deleted_by", strconv.Itoa(int(torrent.ID)), username, currentUser.Username)
 			} else {
 				activities.Log(&models.User{}, torrent.Identifier(), "delete", "torrent_deleted_by", strconv.Itoa(int(torrent.ID)), username, username)

--- a/controllers/torrent/edit.go
+++ b/controllers/torrent/edit.go
@@ -52,7 +52,7 @@ func TorrentPostEditUserPanel(c *gin.Context) {
 			messages.AddErrorT("errors", "fail_torrent_update")
 		}
 		if !messages.HasErrors() {
-			upload.UpdateTorrent(&uploadForm, torrent, currentUser).Update(currentUser.HasAdmin())
+			upload.UpdateTorrent(&uploadForm, torrent, currentUser).Update(currentUser.IsModerator())
 			c.Redirect(http.StatusSeeOther, fmt.Sprintf("/view/%d?success_edit", id))
 			return
 		}

--- a/controllers/torrent/stats.go
+++ b/controllers/torrent/stats.go
@@ -45,16 +45,16 @@ func GetStatsHandler(c *gin.Context) {
 	if len(torrent.Trackers) > 3 {
 		for _, line := range strings.Split(torrent.Trackers[3:], "&tr=") {
 			tracker, error := url.QueryUnescape(line)
-			if error == nil && strings.Contains(tracker, "udp://") {
+			if error == nil && strings.HasPrefix(tracker, "udp") {
 				Trackers = append(Trackers, tracker)
 			}
 			//Cannot scrape from http trackers so don't put them in the array
 		}
 	}
 	
-	for _, line := range config.Get().Torrents.Trackers.Default {
-		if !contains(Trackers, line) {
-			Trackers = append(Trackers, line)
+	for _, tracker := range config.Get().Torrents.Trackers.Default {
+		if !contains(Trackers, tracker) && strings.HasPrefix(tracker, "udp")  {
+			Trackers = append(Trackers, tracker)
 		}
 	}
 

--- a/controllers/torrent/view.go
+++ b/controllers/torrent/view.go
@@ -20,23 +20,6 @@ func ViewHandler(c *gin.Context) {
 	messages := msg.GetMessages(c)
 	user := router.GetUser(c)
 
-	// Display success message on upload
-	if c.Request.URL.Query()["success"] != nil {
-		messages.AddInfoT("infos", "torrent_uploaded")
-	}
-	// Display success message on edit
-	if c.Request.URL.Query()["success_edit"] != nil {
-		messages.AddInfoT("infos", "torrent_updated")
-	}
-	// Display wrong captcha error message
-	if c.Request.URL.Query()["badcaptcha"] != nil {
-		messages.AddErrorT("errors", "bad_captcha")
-	}
-	// Display reported successful message
-	if c.Request.URL.Query()["reported"] != nil {
-		messages.AddInfoTf("infos", "report_msg", id)
-	}
-
 	// Retrieve the torrent
 	torrent, err := torrents.FindByID(uint(id))
 
@@ -66,6 +49,27 @@ func ViewHandler(c *gin.Context) {
 		captchaID = captcha.GetID()
 	}
 	
+	// Display success message on upload
+	if c.Request.URL.Query()["success"] != nil {
+		if torrent.IsBlocked() {
+			messages.AddInfoT("infos", "torrent_uploaded_locked")
+		} else {
+			messages.AddInfoT("infos", "torrent_uploaded")
+		}
+	}
+	// Display success message on edit
+	if c.Request.URL.Query()["success_edit"] != nil {
+		messages.AddInfoT("infos", "torrent_updated")
+	}
+	// Display wrong captcha error message
+	if c.Request.URL.Query()["badcaptcha"] != nil {
+		messages.AddErrorT("errors", "bad_captcha")
+	}
+	// Display reported successful message
+	if c.Request.URL.Query()["reported"] != nil {
+		messages.AddInfoTf("infos", "report_msg", id)
+	}
+
 	if c.Request.URL.Query()["followed"] != nil {
 		messages.AddInfoTf("infos", "user_followed_msg", b.UploaderName)
 	}

--- a/controllers/upload/upload.go
+++ b/controllers/upload/upload.go
@@ -58,6 +58,8 @@ func UploadPostHandler(c *gin.Context) {
 		uploadForm.Status = models.TorrentStatusRemake
 	} else if user.IsTrusted() {
 		uploadForm.Status = models.TorrentStatusTrusted
+	} else if user.IsBanned() {
+		uploadForm.Status = models.TorrentStatusBlocked
 	}
 
 	err = torrents.ExistOrDelete(uploadForm.Infohash, user)

--- a/controllers/user/profile.go
+++ b/controllers/user/profile.go
@@ -53,12 +53,14 @@ func UserProfileBan(c *gin.Context) {
 		userProfile, _, errorUser := users.FindForAdmin(uint(id))
 		if errorUser == nil && !userProfile.IsModerator() {
 				action := "user_unbanned_by"
+				message := "?unbanned"
 				if userProfile.ToggleBan() {
 					action = "user_banned_by"
+					message = "?banned"
 				}
 				
 				activities.Log(&models.User{}, fmt.Sprintf("user_%d", id), "edit", action, userProfile.Username, strconv.Itoa(int(id)), currentUser.Username)
-				c.Redirect(http.StatusSeeOther, fmt.Sprintf("/user/%d/%s", id, c.Param("username")))
+				c.Redirect(http.StatusSeeOther, fmt.Sprintf("/user/%d/%s", id, c.Param("username") + message))
 		} else {
 			c.AbortWithStatus(http.StatusNotFound)
 		}

--- a/controllers/user/profile.go
+++ b/controllers/user/profile.go
@@ -211,7 +211,7 @@ func UserProfileFormHandler(c *gin.Context) {
 			userForm.Username = userProfile.Username
 			userForm.Status = userProfile.Status
 		} else {
-			if userProfile.Status != userForm.Status && (userForm.Status == 2 || userForm.Status == 4){
+			if userProfile.Status != userForm.Status && (userForm.Status == 2){
 				messages.AddErrorT("errors", "elevating_user_error")
 			}
 		}

--- a/controllers/user/profile.go
+++ b/controllers/user/profile.go
@@ -57,7 +57,7 @@ func UserProfileBan(c *gin.Context) {
 					action = "user_banned_by"
 				}
 				
-				activities.Log(&models.User{}, fmt.Sprintf("user_%d", id), "delete", action, userProfile.Username, strconv.Itoa(int(id)), currentUser.Username)
+				activities.Log(&models.User{}, fmt.Sprintf("user_%d", id), "edit", action, userProfile.Username, strconv.Itoa(int(id)), currentUser.Username)
 				c.Redirect(http.StatusSeeOther, fmt.Sprintf("/user/%d/%s", id, c.Param("username")))
 		} else {
 			c.AbortWithStatus(http.StatusNotFound)

--- a/controllers/user/profile.go
+++ b/controllers/user/profile.go
@@ -226,14 +226,14 @@ func UserProfileFormHandler(c *gin.Context) {
 					userForm.Email = userProfile.Email // reset, it will be set when user clicks verification
 				}
 			}
-			var err error
-			userProfile, _, err = users.UpdateFromRequest(c, &userForm, &userSettingsForm, currentUser, uint(id))
+			user, _, err := users.UpdateFromRequest(c, &userForm, &userSettingsForm, currentUser, uint(id))
 			if err != nil {
 				messages.Error(err)
 			}
 
 			if !messages.HasErrors() {
 				messages.AddInfoT("infos", "profile_updated")
+				userProfile = user
 			}
 		}
 	}

--- a/controllers/user/profile.go
+++ b/controllers/user/profile.go
@@ -189,14 +189,10 @@ func UserProfileFormHandler(c *gin.Context) {
 		validator.ValidateForm(&userForm, messages)
 		if !messages.HasErrors() {
 			if userForm.Email != userProfile.Email {
-				if currentUser.IsModerator() {
-					userProfile.Email = userForm.Email
-				} else {
-					email.SendVerificationToUser(currentUser, userForm.Email)
-					messages.AddInfoTf("infos", "email_changed", userForm.Email)
-					userForm.Email = userProfile.Email // reset, it will be set when user clicks verification
-				}
-			}
+				email.SendVerificationToUser(currentUser, userForm.Email)
+ 				messages.AddInfoTf("infos", "email_changed", userForm.Email)
+ 				userForm.Email = userProfile.Email // reset, it will be set when user clicks verification
+            }
 			user, _, err := users.UpdateFromRequest(c, &userForm, &userSettingsForm, currentUser, uint(id))
 			if err != nil {
 				messages.Error(err)

--- a/controllers/user/profile.go
+++ b/controllers/user/profile.go
@@ -178,7 +178,7 @@ func UserProfileFormHandler(c *gin.Context) {
 	if !messages.HasErrors() {
 		c.Bind(&userForm)
 		c.Bind(&userSettingsForm)
-		if !currentUser.HasAdmin() {
+		if !currentUser.IsModerator() {
 			userForm.Username = userProfile.Username
 			userForm.Status = userProfile.Status
 		} else {
@@ -189,7 +189,7 @@ func UserProfileFormHandler(c *gin.Context) {
 		validator.ValidateForm(&userForm, messages)
 		if !messages.HasErrors() {
 			if userForm.Email != userProfile.Email {
-				if currentUser.HasAdmin() {
+				if currentUser.IsModerator() {
 					userProfile.Email = userForm.Email
 				} else {
 					email.SendVerificationToUser(currentUser, userForm.Email)

--- a/controllers/user/profile.go
+++ b/controllers/user/profile.go
@@ -33,8 +33,10 @@ func UserProfileDelete(c *gin.Context) {
 			if err == nil && currentUser.CurrentUserIdentical(userProfile.ID) {
 				cookies.Clear(c)
 			}
-		}
 		templates.Static(c, "site/static/delete_success.jet.html")
+		}
+	} else {
+		c.AbortWithStatus(http.StatusNotFound)
 	}
 }
 

--- a/controllers/user/router.go
+++ b/controllers/user/router.go
@@ -38,6 +38,7 @@ func init() {
 		userRoutes.GET("/:id/:username/feed", feedController.RSSHandler)
 		userRoutes.GET("/:id/:username/feed/:page", feedController.RSSHandler)
 		userRoutes.POST("/:id/:username/delete", UserProfileDelete)
+		userRoutes.POST("/:id/:username/ban", UserProfileBan)
 	}
 	
 	router.Get().Any("/username", RedirectToUserSearch)

--- a/models/torrent.go
+++ b/models/torrent.go
@@ -21,7 +21,6 @@ import (
 	"github.com/NyaaPantsu/nyaa/utils/format"
 	"github.com/NyaaPantsu/nyaa/utils/log"
 	"github.com/NyaaPantsu/nyaa/utils/sanitize"
-	"github.com/anacrolix/torrent"
 	"github.com/bradfitz/slice"
 	"github.com/fatih/structs"
 )
@@ -452,26 +451,6 @@ func (t *Torrent) Update(unscope bool) (int, error) {
 	cache.C.Delete(t.Identifier())
 
 	return http.StatusOK, nil
-}
-
-func (t *Torrent) CreateFileList(Files []torrent.File) ([]File, error) {
-	var createdFilelist []File
-	t.Filesize = 0
-	
-	for _, uploadedFile := range Files {
-		file := File{TorrentID: t.ID, Filesize: uploadedFile.Length()}
-		err := file.SetPath(uploadedFile.FileInfo().Path)
-		if err != nil {
-			return []File{}, err
-		}
-		createdFilelist = append(createdFilelist, file)
-		t.Filesize  += uploadedFile.Length()
-		ORM.Create(&file)
-	}
-	
-	t.FileList = createdFilelist
-	t.Update(false)
-	return createdFilelist, nil
 }
 
 // UpdateUnscope : Update a torrent based on model

--- a/models/torrents/find.go
+++ b/models/torrents/find.go
@@ -193,6 +193,11 @@ func FindAllOrderBy(orderBy string, limit int, offset int) ([]models.Torrent, in
 	return FindOrderBy(nil, orderBy, limit, offset)
 }
 
+// FindAllForAdminsOrderBy : Get all torrents ordered by parameters
+func FindAllForAdminsOrderBy(orderBy string, limit int, offset int) ([]models.Torrent, int, error) {
+    return findOrderBy(nil, orderBy, limit, offset, true, true, false)
+}
+
 // FindAll : Get all torrents without order
 func FindAll(limit int, offset int) ([]models.Torrent, int, error) {
 	return FindOrderBy(nil, "", limit, offset)

--- a/models/torrents/find.go
+++ b/models/torrents/find.go
@@ -156,7 +156,7 @@ func findOrderBy(parameters Query, orderBy string, limit int, offset int, countA
 		dbQuery = dbQuery.Preload("Uploader")
 	}
 	if countAll {
-		dbQuery = dbQuery.Preload("Comments")
+		dbQuery = dbQuery.Preload("Comments").Preload("OldComments")
 	}
 
 	if conditions != "" {

--- a/models/user.go
+++ b/models/user.go
@@ -159,12 +159,14 @@ func (u *User) GetUnreadNotifications() int {
 	return u.UnreadNotifications
 }
 
-// ToggleBan : Ban/Unban an user an user
-func (u *User) ToggleBan() {
+// ToggleBan : Ban/Unban an user an user, return true if the user is now banned
+func (u *User) ToggleBan() bool {
 	if u.IsBanned() {
 		u.Status = UserStatusMember
+		return false
 	} else {
 		u.Status = UserStatusBanned
+		return true
 	}
 }
 

--- a/models/user.go
+++ b/models/user.go
@@ -179,6 +179,14 @@ func (u *User) CurrentOrAdmin(userID uint) bool {
 	log.Debugf("user.ID == userID %d %d %s", u.ID, userID, u.ID == userID)
 	return (u.IsModerator() || u.ID == userID)
 }
+// CurrentOrJanitor check that user has janitor permission or user is the current user.
+func (u *User) CurrentOrJanitor(userID uint) bool {
+	if userID == 0 && !u.IsJanitor() {
+		return false
+	}
+	log.Debugf("user.ID == userID %d %d %s", u.ID, userID, u.ID == userID)
+	return (u.IsJanitor() || u.ID == userID)
+}
 
 // CurrentUserIdentical check that userID is same as current user's ID.
 // TODO: Inline this (won't go do this for us?)

--- a/models/user.go
+++ b/models/user.go
@@ -163,11 +163,11 @@ func (u *User) GetUnreadNotifications() int {
 func (u *User) ToggleBan() bool {
 	if u.IsBanned() {
 		u.Status = UserStatusMember
-		return false
 	} else {
 		u.Status = UserStatusBanned
-		return true
 	}
+	u.Update()
+	return u.IsBanned()
 }
 
 

--- a/models/user.go
+++ b/models/user.go
@@ -196,6 +196,9 @@ func (u *User) CanUpload() bool {
 
 // GetRole : Get the status/role of a user
 func (u *User) GetRole() string {
+	if u.ID == 0 {
+		return ""	
+	}
 	switch u.Status {
 	case UserStatusBanned:
 		return "userstatus_banned"

--- a/models/user.go
+++ b/models/user.go
@@ -137,7 +137,7 @@ func (u *User) IsModerator() bool {
 	return u.Status == UserStatusModerator
 }
 
-// IsModerator : Return true if user is janitor OR moderator
+// IsJanitor : Return true if user is janitor OR moderator
 func (u *User) IsJanitor() bool {
 	return u.Status == UserStatusJanitor || u.Status == UserStatusModerator
 }
@@ -159,6 +159,16 @@ func (u *User) GetUnreadNotifications() int {
 	return u.UnreadNotifications
 }
 
+// ToggleBan : Ban/Unban an user an user
+func (u *User) ToggleBan() {
+	if u.IsBanned() {
+		u.Status = UserStatusMember
+	} else {
+		u.Status = UserStatusBanned
+	}
+}
+
+
 // CurrentOrAdmin check that user has admin permission or user is the current user.
 func (u *User) CurrentOrAdmin(userID uint) bool {
 	if userID == 0 && !u.IsModerator() {
@@ -177,7 +187,7 @@ func (u *User) CurrentUserIdentical(userID uint) bool {
 // NeedsCaptcha : Check if a user needs captcha
 func (u *User) NeedsCaptcha() bool {
 	// Trusted members & Moderators don't
-	return !(u.IsTrusted() || u.IsModerator())
+	return !(u.IsTrusted() || u.IsJanitor())
 }
 
 // CanUpload :  Check if a user can upload  or if upload is enabled in config

--- a/models/user.go
+++ b/models/user.go
@@ -29,6 +29,8 @@ const (
 	UserStatusModerator = 2
 	// UserStatusScraped : Int for User status scrapped
 	UserStatusScraped = 3
+	// UserStatusModerator : Int for User status moderator
+	UserStatusJanitor = 4
 )
 
 // User model
@@ -135,6 +137,11 @@ func (u *User) IsModerator() bool {
 	return u.Status == UserStatusModerator
 }
 
+// IsModerator : Return true if user is janitor OR moderator
+func (u *User) IsJanitor() bool {
+	return u.Status == UserStatusJanitor || u.Status == UserStatusModerator
+}
+
 // IsScraped : Return true if user is a scrapped user
 func (u *User) IsScraped() bool {
 	return u.Status == UserStatusScraped
@@ -150,11 +157,6 @@ func (u *User) GetUnreadNotifications() int {
 		}
 	}
 	return u.UnreadNotifications
-}
-
-// HasAdmin checks that user has an admin permission. Deprecated
-func (u *User) HasAdmin() bool {
-	return u.IsModerator()
 }
 
 // CurrentOrAdmin check that user has admin permission or user is the current user.
@@ -203,6 +205,8 @@ func (u *User) GetRole() string {
 		return "userstatus_scraped"
 	case UserStatusTrusted:
 		return "userstatus_trusted"
+	case UserStatusJanitor:
+		return "userstatus_janitor"
 	case UserStatusModerator:
 		return "userstatus_moderator"
 	}

--- a/models/users/helpers.go
+++ b/models/users/helpers.go
@@ -44,10 +44,7 @@ func Exists(email string, pass string) (user *models.User, status int, err error
 		status, err = http.StatusUnauthorized, errors.New("incorrect_password")
 		return
 	}
-	if userExist.IsBanned() {
-		status, err = http.StatusUnauthorized, errors.New("account_banned")
-		return
-	}
+
 	if userExist.IsScraped() {
 		status, err = http.StatusUnauthorized, errors.New("account_need_activation")
 		return

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -664,7 +664,7 @@ th {
     width: auto;
 }
 .website-nav table tr {
-    background: none!important;	
+    background: none!important;    
 }
 .website-nav #nav-category-list {
     width: 70%;
@@ -675,17 +675,17 @@ th {
 }
 .sub-category-list {
     padding-left: 16px;
-	font-size: 12px;
-	margin-bottom: 9px;
+    font-size: 12px;
+    margin-bottom: 9px;
 }
 .sub-category-list span{
-	display: block;
+    display: block;
 }
 .sub-category-list span:before {
-	content: '-» ';
+    content: '-» ';
 }
 .sub-category-list span:first-child:before {
-	content: '';
+    content: '';
 }
 textarea {
     max-width: 100%;
@@ -939,6 +939,9 @@ html, body {
     .upload-form-table .table-input-label {
         width: 25%!important;
     }
+    .notification-status {
+        width: 100px;
+    }
 }
 
 @media (max-height: 750px),(max-width: 500px) {
@@ -1030,12 +1033,28 @@ html, body {
     .upload-form-table .table-input-label {
         display: none;
     }
-	.torrent-view-data {
- 		display: table!important;
- 	}
- 	.torrent-view-data td, .torrent-view-data table {
- 		width: 100%!important;
- 	}
+    .torrent-view-data {
+         display: table!important;
+     }
+     .torrent-view-data td, .torrent-view-data table {
+         width: 100%!important;
+     }
+    .notification-status {
+        width: 41px!important;
+        font-size: 0;
+    }
+    #clear-notification a {
+        display: block;
+        margin-left: 0px!important;
+        float: none!important;
+        margin-top: 2px;
+    }
+    .notification-table {
+        margin-bottom: 108px!important;
+    }
+    .notification-date {
+        width: 100px!important;
+    }
 }
 
 @media (max-width: 440px) {
@@ -1240,7 +1259,7 @@ html, body {
 }
 
 .comment-content :first-child {
-	margin-top: 8px;
+    margin-top: 8px;
 }
 .comment-content :last-child {
     margin-bottom: 2px;
@@ -1254,7 +1273,7 @@ html, body {
 }
 
 .comment-form textarea {
-    margin-bottom: 0;	
+    margin-bottom: 0;    
 }
 
 .comment-form h3 {
@@ -1853,7 +1872,7 @@ summary:after {
     width: 12px;
     font-size: 1.5em;
     font-weight: bold;
-	outline: none;
+    outline: none;
 }
 
 details[open] summary:after {
@@ -2093,32 +2112,32 @@ p.upload-rules a {
 }
 
 .upload-form-table details {
-	margin-bottom: 4px;
+    margin-bottom: 4px;
 }
 #anidex-upload-info > div {
-	height: auto;
-	padding: 10px 6px;
-	border-top: none;
+    height: auto;
+    padding: 10px 6px;
+    border-top: none;
 }
 #anidex-upload-info p {
-	margin-bottom: 4px;
+    margin-bottom: 4px;
 }
 #anidex-upload-info p:first-child {
-	margin-top: 0;
+    margin-top: 0;
 }
 #anidex-upload-info > div > div {
-	margin-left: 9px;
+    margin-left: 9px;
 }
 
 #anidex-upload-info > div input[type="text"], #anidex-upload-info > div select {
-	margin-bottom: 4px;
-	
+    margin-bottom: 4px;
+    
 }
 #anidex-upload-info > div select {
-	width: calc(100% - 8px);
+    width: calc(100% - 8px);
 }
 #anidex-upload-info > div select[name="anidex_form_category"] option{
-	color: #000;
+    color: #000;
     text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
     font-size: 14px;
     font-weight: bold;
@@ -2401,39 +2420,39 @@ form.delete-form button.form-input.btn-red {
     margin-bottom: 44px;
 }
 .notification-table td {
-	text-align: center;
-	padding: 6px 0;
-	border-bottom: 1px solid;
+    text-align: center;
+    padding: 6px 0;
+    border-bottom: 1px solid;
 }
 .notification-table tr:hover td {
-	filter: brightness(1.2);
+    filter: brightness(1.2);
 }
 .notification-status {
-	width: 140px;
+    width: 140px;
 }
 .notification-event {
-	text-align: left!important;
-	padding: 6px 10px!important;
+    text-align: left!important;
+    padding: 6px 10px!important;
 }
 .notification-date {
-	width: 195px;
+    width: 195px;
 }
 td.notification-status {
-	border: 1px solid black;
+    border: 1px solid black;
 }
 td.notification-status {
-	background-color: #e4e4e4;
+    background-color: #e4e4e4;
 }
 td.notification-status.notification-unread {
-	background-color: rgb(161, 211, 253);
-	color: white;
+    background-color: rgb(161, 211, 253);
+    color: white;
 }
 
 .torrent-report-table td, .torrent-report-table th {
-	width: 195px;
+    width: 195px;
 }
 .td-report-message  {
-	width: auto!important;
+    width: auto!important;
     white-space: normal;
     word-break: break-word;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1062,7 +1062,7 @@ html, body {
 }
 
 .profile-sidebar {
-    display: inline-block;
+    display: block;
 }
 
 .profile-usertitle {
@@ -1088,7 +1088,9 @@ html, body {
 }
 
 .profile-usermenu {
-    min-width: 170px;
+    width: 170px;
+    margin: 0 auto;
+    max-width: calc(100% - 16px);
 }
 .profile-usermenu a {
     display: block;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1795,7 +1795,6 @@ input.filelist-checkbox:checked+table.table-filelist {
 }
 
 [class^="btn-"] {
-    font-weight: bold;
     color: white;
 }
 
@@ -2392,11 +2391,11 @@ form.delete-form button.form-input.btn-red {
     bottom: 8px;
     right: 8px;
     position: absolute;
-	width: calc(100% - 16px);
+    width: calc(100% - 16px);
 }
 #clear-notification a {
-	float: right;
-	margin-left: 3px;
+    float: right;
+    margin-left: 3px;
 }
 .notification-table {
     margin-bottom: 44px;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -899,8 +899,8 @@ html, body {
         width: 100% !important;
         margin-bottom: 15px;
     }
-    .profile-panel .user-search {
-        max-width: none;
+    .profile-usermenu, .profile-panel .user-search {
+        width: 200px!important;
     }
     .header .h-user {
         width: 46px;
@@ -1087,7 +1087,7 @@ html, body {
     border-radius: 6px;
 }
 
-.profile-usermenu {
+.profile-usermenu, .profile-panel .user-search {
     width: 170px;
     margin: 0 auto;
     max-width: calc(100% - 16px);
@@ -2309,7 +2309,6 @@ table.multiple-upload {
 }
 .profile-panel .user-search {
     padding: 0;
-    max-width: 170px;
 }
 
 .user-search [type="text"] {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1092,8 +1092,9 @@ html, body {
     margin: 0 auto;
     max-width: calc(100% - 16px);
 }
-.profile-usermenu a {
+.profile-usermenu a, .profile-usermenu button {
     display: block;
+    width: 100%;
     margin-bottom: 11px;
 }
 .profile-usermenu .icon-rss-squared {

--- a/templates/admin/guidelines.jet.html
+++ b/templates/admin/guidelines.jet.html
@@ -1,0 +1,9 @@
+{{ extends "layouts/index_admin" }}
+{{block title()}}{{ T("moderation_guidelines") }}{{end}}
+{{ block content_body()}}
+<div class="results box form-box">
+  <h1>{{  T("
+{{block title()}}{{ T("moderation_guidelines") }}</h1>
+  <img src="https://www.themarysue.com/wp-content/uploads/2016/09/harassment-guide.png">
+</div>
+{{end}}

--- a/templates/admin/guidelines.jet.html
+++ b/templates/admin/guidelines.jet.html
@@ -2,8 +2,7 @@
 {{block title()}}{{ T("moderation_guidelines") }}{{end}}
 {{ block content_body()}}
 <div class="results box form-box">
-  <h1>{{  T("
-{{block title()}}{{ T("moderation_guidelines") }}</h1>
+  <h1>{{ T("moderation_guidelines") }}</h1>
   <img src="https://www.themarysue.com/wp-content/uploads/2016/09/harassment-guide.png">
 </div>
 {{end}}

--- a/templates/admin/guidelines.jet.html
+++ b/templates/admin/guidelines.jet.html
@@ -1,7 +1,7 @@
 {{ extends "layouts/index_admin" }}
 {{block title()}}{{ T("moderation_guidelines") }}{{end}}
 {{ block content_body()}}
-<div class="results box form-box">
+<div class="results box">
   <h1>{{ T("moderation_guidelines") }}</h1>
   <img src="https://www.themarysue.com/wp-content/uploads/2016/09/harassment-guide.png">
 </div>

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -14,7 +14,7 @@
     </thead>
     <tbody>
       {{range Torrents}}
-      <tr {{ if .Status == 5}}class="locked hidden"{{end}}>
+      <tr {{ if .IsBlocked() }}class="locked hidden"{{end}}>
         <td class="tr-name home-td">
           <a href="/view/{{.ID }}">{{ .Name }}</a>
           <a href="/mod/torrent?id={{.ID}}" class="form-input btn-blue float-right">{{  T("edit") }}</a>
@@ -23,10 +23,17 @@
           <a href="/mod/torrents?userID={{.UploaderID}}">{{ .UploaderID }}</a>
         </td>
         <td class="tr-size home-td">
+		{{ if User.IsModerator() }}
 		  <form method="POST" action="/mod/torrent/delete">
 			<input type="hidden" name="id" value="{{ .ID }}">
 		    <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
 		  </form>
+		{{else}}
+	    <form method="POST" action="/mod/torrent/block" class="delete-form">
+		<input type="hidden" name="id" value="{{ .ID }}">
+		<button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if .IsBlocked() }}{{  T("torrent_unblock") }}{{else}}{{  T("torrent_block") }}{{end}}</button>
+	    </form>
+		{{end}}
         </td>
       </tr>
       {{end}}

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -20,11 +20,11 @@
           <a href="/mod/torrent?id={{.ID}}" class="form-input btn-blue float-right">{{  T("edit") }}</a>
         </td>
         <td class="tr-size home-td">
-          <a href="/mod/torrents?userID={{.UploaderID}}">{{ .UploaderID }}</a>
+          <a href="/mod/torrents?userID={{.UploaderID}}">{{ .Uploader.Username }}</a>
         </td>
         <td class="tr-size home-td">
 		{{ if User.IsModerator() }}
-		  <form method="POST" action="/mod/torrent/delete">
+		  <form method="POST" action="/mod/torrent/delete" class="delete-form">
 			<input type="hidden" name="id" value="{{ .ID }}">
 		    <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
 		  </form>

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -95,10 +95,12 @@
           <a href="/user/{{.ID}}/{{.Username }}">{{ .Username }}</a>
         </td>
         <td class="tr-size home-td">{{if .ID > 0}}
-		  <form method="POST" action="/user/{{.ID}}/{{.Username }}/delete" >
-		    {{ yield csrf_field()}}
-		    <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{ T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
-		  </form>
+			  <form method="POST" action="/user/{{.ID}}/{{.Username }}/ban">
+				   {{ yield csrf_field()}}
+				   {{ if User.IsModerator() }}
+				  <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
+				   {{end}}
+				  <button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{ if !.IsBanned() }}{{  T("ban") }}{{else}}{{  T("unban") }}{{end}}</button>
           {{end}}
         </td>
       </tr>

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -20,7 +20,7 @@
           <a href="/mod/torrent?id={{.ID}}" class="form-input btn-blue float-right">{{  T("edit") }}</a>
         </td>
         <td class="tr-size home-td">
-          <a href="/mod/torrents?userID={{.UploaderID}}">{{ .Uploader.Username }}</a>
+          <a href="/mod/torrents?userID={{.UploaderID}}">{{ if .Uploader }}{{.Uploader.Username }}{{else}}れんちょん{{end}}</a>
         </td>
         <td class="tr-size home-td">
 		{{ if User.IsModerator() }}

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -14,7 +14,7 @@
     </thead>
     <tbody>
       {{range Torrents}}
-      <tr {{ if .IsBlocked() }}class="locked hidden"{{end}}>
+      <tr {{ if .IsBlocked() }}class="locked"{{end}}>
         <td class="tr-name home-td">
           <a href="/view/{{.ID }}">{{ .Name }}</a>
           <a href="/mod/torrent?id={{.ID}}" class="form-input btn-blue float-right">{{  T("edit") }}</a>

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -14,7 +14,7 @@
     </thead>
     <tbody>
       {{range Torrents}}
-      <tr>
+      <tr {{ if .Status == 5}}class="locked hidden"{{end}}>
         <td class="tr-name home-td">
           <a href="/view/{{.ID }}">{{ .Name }}</a>
           <a href="/mod/torrent?id={{.ID}}" class="form-input btn-blue float-right">{{  T("edit") }}</a>

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -95,12 +95,16 @@
           <a href="/user/{{.ID}}/{{.Username }}">{{ .Username }}</a>
         </td>
         <td class="tr-size home-td">{{if .ID > 0}}
+			 {{ if User.IsModerator() }}
 			  <form method="POST" action="/user/{{.ID}}/{{.Username }}/ban">
 				   {{ yield csrf_field()}}
-				   {{ if User.IsModerator() }}
 				  <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
-				   {{end}}
+			  </form>
+			 {{end}}
+			  <form method="POST" action="/user/{{.ID}}/{{.Username }}/ban">
+				   {{ yield csrf_field()}}
 				  <button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{ if !.IsBanned() }}{{  T("ban") }}{{else}}{{  T("unban") }}{{end}}</button>
+			  </form>
           {{end}}
         </td>
       </tr>

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -28,12 +28,11 @@
 			<input type="hidden" name="id" value="{{ .ID }}">
 		    <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
 		  </form>
-		{{else}}
+		{{end}}
 	    <form method="POST" action="/mod/torrent/block" class="delete-form">
 		<input type="hidden" name="id" value="{{ .ID }}">
 		<button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if .IsBlocked() }}{{  T("torrent_unblock") }}{{else}}{{  T("torrent_block") }}{{end}}</button>
 	    </form>
-		{{end}}
         </td>
       </tr>
       {{end}}
@@ -95,16 +94,16 @@
           <a href="/user/{{.ID}}/{{.Username }}">{{ .Username }}</a>
         </td>
         <td class="tr-size home-td">{{if .ID > 0}}
-			 {{ if User.IsModerator() }}
-			  <form method="POST" action="/user/{{.ID}}/{{.Username }}/ban">
+			{{ if User.IsModerator() }}
+			  <form method="POST" action="/user/{{.ID}}/{{.Username }}/delete" class="delete-form">
 				   {{ yield csrf_field()}}
-				  <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
+				<button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
 			  </form>
-			 {{end}}
-			  <form method="POST" action="/user/{{.ID}}/{{.Username }}/ban">
+			{{end}}
+			<form method="POST" action="/user/{{.ID}}/{{.Username }}/ban" class="delete-form">
 				   {{ yield csrf_field()}}
-				  <button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{ if !.IsBanned() }}{{  T("ban") }}{{else}}{{  T("unban") }}{{end}}</button>
-			  </form>
+			<button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if .IsBanned() }}{{  T("unban") }}{{else}}{{  T("ban") }}{{end}}</button>
+			</form>
           {{end}}
         </td>
       </tr>

--- a/templates/admin/index.jet.html
+++ b/templates/admin/index.jet.html
@@ -24,10 +24,11 @@
         </td>
         <td class="tr-size home-td">
 		{{ if User.IsModerator() }}
-		  <form method="POST" action="/mod/torrent/delete" class="delete-form">
-			<input type="hidden" name="id" value="{{ .ID }}">
-		    <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
-		  </form>
+	    <form method="POST" action="/mod/torrent/delete" class="delete-form">
+		<input type="hidden" name="id" value="{{ .ID }}">
+		 {{ if .IsDeleted() }}<input type="hidden" name="definitely" value="true">{{ end }}
+		<button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }} {{ if !.IsDeleted() }}{{  T("delete") }}{{else}}{{  T("delete_definitely_torrent_warning ")}}{{end}}')) return false;"><i class="icon-trash"></i>{{ if .IsDeleted() }}{{  T("delete_definitely") }}{{else}}{{  T("delete") }}{{end}}</button>
+	    </form>
 		{{end}}
 	    <form method="POST" action="/mod/torrent/block" class="delete-form">
 		<input type="hidden" name="id" value="{{ .ID }}">

--- a/templates/admin/torrentlist.jet.html
+++ b/templates/admin/torrentlist.jet.html
@@ -59,12 +59,13 @@
 		<input type="hidden" name="id" value="{{ .ID }}">
 		<button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if .IsBlocked }}{{  T("torrent_unblock") }}{{else}}{{  T("torrent_block") }}{{end}}</button>
 	    </form>
+		{{ if User.IsModerator() }}
 	    <form method="POST" action="/mod/torrent/delete" class="delete-form">
 		<input type="hidden" name="id" value="{{ .ID }}">
 		 {{ if .IsDeleted }}<input type="hidden" name="definitely" value="true">{{ end }}
 		<button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }} {{ if !.IsDeleted }}{{  T("delete") }}{{else}}{{  T("delete_definitely_torrent_warning ")}}{{end}}')) return false;"><i class="icon-trash"></i>{{ if .IsDeleted }}{{  T("delete_definitely") }}{{else}}{{  T("delete") }}{{end}}</button>
 	    </form>
-            
+            {{end}}
           </td>
         </tr>
         {{end}}

--- a/templates/admin/torrentlist.jet.html
+++ b/templates/admin/torrentlist.jet.html
@@ -43,7 +43,7 @@
             <input type="checkbox" class="selectable" name="torrent_id" value="{{.ID }}" />
           </td>
           <td class="tr-name home-td">
-            <a href="/view/{{ .ID }}">{{ .Name }}</a> {{ if !.IsDeleted }}
+            <a href="/view/{{ .ID }}">{{ .Name }}</a> {{ if User.IsModerator() }}
             <a href="/mod/torrent?id={{.ID}}" class="form-input btn-blue float-right">
               {{  T("edit")}}
             </a> {{end}}
@@ -62,8 +62,8 @@
 		{{ if User.IsModerator() }}
 	    <form method="POST" action="/mod/torrent/delete" class="delete-form">
 		<input type="hidden" name="id" value="{{ .ID }}">
-		 {{ if .IsDeleted }}<input type="hidden" name="definitely" value="true">{{ end }}
-		<button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }} {{ if !.IsDeleted }}{{  T("delete") }}{{else}}{{  T("delete_definitely_torrent_warning ")}}{{end}}')) return false;"><i class="icon-trash"></i>{{ if .IsDeleted }}{{  T("delete_definitely") }}{{else}}{{  T("delete") }}{{end}}</button>
+		 {{ if .IsDeleted() }}<input type="hidden" name="definitely" value="true">{{ end }}
+		<button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }} {{ if !.IsDeleted() }}{{  T("delete") }}{{else}}{{  T("delete_definitely_torrent_warning ")}}{{end}}')) return false;"><i class="icon-trash"></i>{{ if .IsDeleted() }}{{  T("delete_definitely") }}{{else}}{{  T("delete") }}{{end}}</button>
 	    </form>
             {{end}}
           </td>

--- a/templates/admin/torrentlist.jet.html
+++ b/templates/admin/torrentlist.jet.html
@@ -38,7 +38,7 @@
       </thead>
       <tbody>
         {{ range Models}}
-        <tr>
+        <tr {{ if .Status == 5}}class="locked hidden"{{end}}>
           <td class="tr-cb">
             <input type="checkbox" class="selectable" name="torrent_id" value="{{.ID }}" />
           </td>

--- a/templates/admin/torrentlist.jet.html
+++ b/templates/admin/torrentlist.jet.html
@@ -57,7 +57,7 @@
           <td class="tr-actions home-td"> <form></form>
 	    <form method="POST" action="/mod/torrent/block" class="delete-form">
 		<input type="hidden" name="id" value="{{ .ID }}">
-		<button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if .IsBlocked() }}{{  T("torrent_unblock") }}{{else}}{{  T("torrent_block") }}{{end}}</button>
+		<button type="submit" class="form-input btn-orange" {{ if !User.IsModerator() }}onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"{{end}}><i class="icon-trash"></i>{{ if .IsBlocked() }}{{  T("torrent_unblock") }}{{else}}{{  T("torrent_block") }}{{end}}</button>
 	    </form>
 		{{ if User.IsModerator() }}
 	    <form method="POST" action="/mod/torrent/delete" class="delete-form">

--- a/templates/admin/torrentlist.jet.html
+++ b/templates/admin/torrentlist.jet.html
@@ -57,7 +57,7 @@
           <td class="tr-actions home-td"> <form></form>
 	    <form method="POST" action="/mod/torrent/block" class="delete-form">
 		<input type="hidden" name="id" value="{{ .ID }}">
-		<button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if .IsBlocked }}{{  T("torrent_unblock") }}{{else}}{{  T("torrent_block") }}{{end}}</button>
+		<button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if .IsBlocked() }}{{  T("torrent_unblock") }}{{else}}{{  T("torrent_block") }}{{end}}</button>
 	    </form>
 		{{ if User.IsModerator() }}
 	    <form method="POST" action="/mod/torrent/delete" class="delete-form">

--- a/templates/admin/userlist.jet.html
+++ b/templates/admin/userlist.jet.html
@@ -13,7 +13,7 @@
     </thead>
     <tbody>
       {{ range Models}}
-      <tr>
+      <tr {{ if .IsBanned() }}class="locked hidden"{{end}}>
         <td class="tr-name home-td">
           <a href="/user/{{.ID}}/{{.Username }}">{{ .Username }}</a>
         </td>
@@ -21,7 +21,10 @@
           {{if .ID > 0}}
 			  <form method="POST" action="/user/{{.ID}}/{{.Username }}/delete">
 				   {{ yield csrf_field()}}
+				   {{ if User.IsModerator() }}
 				  <button type="submit" class="form-input btn-red" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{  T("delete") }}</button>
+				   {{end}}
+				  <button type="submit" class="form-input btn-orange" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i> {{ if !.IsBanned() }}{{  T("ban") }}{{else}}{{  T("unban") }}{{end}}</button>
 			  </form>
           {{end}}
         </td>

--- a/templates/errors/torrent_file_missing.jet.html
+++ b/templates/errors/torrent_file_missing.jet.html
@@ -7,7 +7,7 @@
     <a href="{{magnet}}" class="form-input btn-green download" style="height: auto;">
       <div class="icon-magnet"></div>{{ T("magnet_link")}}
     </a>
-    {{ if !isset(Errors[name])}}<br/><p>{{ T("pending_torrent") }}</p>{{end}}<br/><br/>
+    {{ if !isset(Errors["errors"])}}<br/><p>{{ T("pending_torrent") }}</p>{{end}}<br/><br/>
     {{ end }}
   <img src="/img/no_torrent_file.jpg" alt="No torrent file"/>
 </div>

--- a/templates/layouts/partials/helpers/badgemenu.jet.html
+++ b/templates/layouts/partials/helpers/badgemenu.jet.html
@@ -1,6 +1,6 @@
 {{ import "csrf" }}
 {{block badge_user()}}
-<div class="h-user">
+<div class="h-user {{ if User.IsBanned() }}hidden{{end}}">
   {{if User.ID > 0 }}
   <button href="#" class="nav-btn">
     <div class="user-avatar small">
@@ -12,7 +12,7 @@
     </span>
   </button>
   <div class="user-menu">
-    <a class="nav-btn" href="/user/{{ User.ID }}/{{ User.Username }}">{{ T("profile")}}</a>
+    <a class="nav-btn" href="/user/{{ User.ID }}/{{ User.Username }}">{{ T("profile")}}{{ if User.IsBanned() }} {{T("banned")}}{{end}}</a>
     <a class="nav-btn notif" href="/notifications">
       {{  T("my_notifications")}}
       {{if User.GetUnreadNotifications() > 0}}<span class="badge">({{ User.GetUnreadNotifications() }})</span>{{end}}

--- a/templates/layouts/partials/helpers/badgemenu.jet.html
+++ b/templates/layouts/partials/helpers/badgemenu.jet.html
@@ -7,7 +7,7 @@
       <img src="{{getAvatar(User.MD5, 50)}}"/>
       {{if User.GetUnreadNotifications() > 0}}<span>{{User.GetUnreadNotifications()}}</span>{{end}}
     </div>
-    <span class="user-info" title="{{ User.Username}}">
+    <span class="user-info" title="{{ User.Username }}">
       <span class="hide-md">{{User.Username}}</span>
     </span>
   </button>
@@ -20,7 +20,7 @@
     <a class="nav-btn" href="/user/{{ User.ID }}/{{ User.Username }}/edit">
       {{ T("settings")}}
     </a>
-    {{if User.HasAdmin()}}
+    {{if User.IsJanitor()}}
     <a class="nav-btn" href="/mod">{{ T("moderation")}}</a>
     {{end}}
     <form action="/logout" method="POST">

--- a/templates/layouts/partials/helpers/badgemenu.jet.html
+++ b/templates/layouts/partials/helpers/badgemenu.jet.html
@@ -12,7 +12,7 @@
     </span>
   </button>
   <div class="user-menu">
-    <a class="nav-btn" href="/user/{{ User.ID }}/{{ User.Username }}">{{ T("profile")}}{{ if User.IsBanned() }} {{T("banned")}}{{end}}</a>
+    <a class="nav-btn" href="/user/{{ User.ID }}/{{ User.Username }}">{{ T("profile")}}{{ if User.IsBanned() }} ({{T("banned")}}){{end}}</a>
     <a class="nav-btn notif" href="/notifications">
       {{  T("my_notifications")}}
       {{if User.GetUnreadNotifications() > 0}}<span class="badge">({{ User.GetUnreadNotifications() }})</span>{{end}}

--- a/templates/layouts/partials/helpers/oldNav.jet.html
+++ b/templates/layouts/partials/helpers/oldNav.jet.html
@@ -13,7 +13,6 @@
 			{{ if _% 3 != 2}}{{ if _% 3 == 0}}<td></td>{{end}}<td></td>{{end}}
 			</tr>{{end}}
 		{{ end }}
-		</tr>
 	</tbody>
 </table>
 {{ if Search.Category != ""}}

--- a/templates/layouts/partials/menu/admin.jet.html
+++ b/templates/layouts/partials/menu/admin.jet.html
@@ -7,4 +7,5 @@
       <a href="{{URL.Parse("/mod/announcement")}}" class="nav-btn{{if strcmp(URL.String(), "/mod/announcement", 17, 5) }} active{{end}}">{{ T("announcements")}}</a>
       <a href="{{URL.Parse("/mod/reports")}}" class="nav-btn{{if URL.String() == "/mod/reports"}} active{{end}}">{{ T("torrent_reports")}}</a>
       <a href="{{URL.Parse("/mod/reassign")}}" class="nav-btn{{if URL.String() == "/mod/reassign"}} active{{end}}">{{ T("torrent_reassign")}}</a>
+      <a href="{{URL.Parse("/mod/guidelines")}}" class="nav-btn{{if URL.String() == "/mod/guidelines"}} active{{end}}">{{ T("guidelines")}}</a>
     </div>

--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -51,7 +51,7 @@
 		<a class="form-input" href="/user/{{UserProfile.ID}}/{{UserProfile.Username}}/edit">
 		  {{ T("settings")}}
 		</a> 
-		{{else if User.IsJanitor() }}
+		{{else if User.IsJanitor() && !UserProfile.IsJanitor() }}
 		<form method="POST" action="/user/{{UserProfile.ID}}/{{UserProfile.Username}}/ban">
 		    {{ yield csrf_field()}}
 		    <button type="submit" class="form-input btn-blue" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if UserProfile.IsBanned() }}{{  T("unban") }}{{else}}{{  T("ban") }}{{end}}</button>

--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -1,3 +1,4 @@
+{{ import "layouts/partials/helpers/csrf" }}
 {{ block profile_menu(route="profile") }}
 <div class="profile-sidebar">
   <!-- SIDEBAR USERPIC -->
@@ -45,12 +46,19 @@
     {{ if User.CurrentUserIdentical(UserProfile.ID) }}
     <a class="form-input" href="/notifications">{{  T("my_notifications")}}</a>
     {{end}}
-    {{if UserProfile.ID > 0 && User.CurrentOrAdmin(UserProfile.ID) }}
-    <a class="form-input" href="/user/{{UserProfile.ID}}/{{UserProfile.Username}}/edit">
-      {{ T("settings")}}
-    </a> 
+    {{if UserProfile.ID > 0}}
+		{{ if User.CurrentOrAdmin(UserProfile.ID) }}
+		<a class="form-input" href="/user/{{UserProfile.ID}}/{{UserProfile.Username}}/edit">
+		  {{ T("settings")}}
+		</a> 
+		{{else if User.IsJanitor() }}
+		<form method="POST" action="/user/{{UserProfile.ID}}/{{UserProfile.Username}}/ban">
+		    {{ yield csrf_field()}}
+		    <button type="submit" class="form-input btn-blue" onclick="if (!confirm('{{  T("are_you_sure") }}')) return false;"><i class="icon-trash"></i>{{ if UserProfile.IsBanned() }}{{  T("unban") }}{{else}}{{  T("ban") }}{{end}}</button>
+		</form>
+		{{end}}
     {{end}}
-    {{end}}
+	{{end}}
   </div>
   {{ if User.ID != UserProfile.ID }}
   <div class="user-search">

--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -1,6 +1,6 @@
 {{ import "layouts/partials/helpers/csrf" }}
 {{ block profile_menu(route="profile") }}
-<div class="profile-sidebar">
+<div class="profile-sidebar {{ if UserProfile.IsBanned() }} hidden{{end}}">
   <!-- SIDEBAR USERPIC -->
   <div class="profile-userpic">
     <img src="{{ getAvatar(UserProfile.MD5, 130) }}" alt="{{ UserProfile.Username }}"/>

--- a/templates/layouts/partials/menu/profile.jet.html
+++ b/templates/layouts/partials/menu/profile.jet.html
@@ -10,9 +10,11 @@
     <p class="profile-usertitle-name">
       {{ UserProfile.Username}}
     </p>
+    {{ if UserProfile.GetRole() != "" }}
     <p class="profile-usertitle-job">
       {{T(UserProfile.GetRole())}}
     </p>
+    {{end}}
     <p class="profile-usertitle-uploadcount">{{T("followers")}}: <b>{{len(UserProfile.Followers)}}</b><br/>{{ T("torrents_uploaded") }}:<b>{{ NbTorrents[0] }}</b><br>{{T("size")}}: <b>{{fileSize(NbTorrents[1], T, false)}}</b></p>
   </div>
   <!-- END SIDEBAR USER TITLE -->

--- a/templates/layouts/partials/torrent_item.jet.html
+++ b/templates/layouts/partials/torrent_item.jet.html
@@ -43,7 +43,7 @@ Templates.Add("torrents.item", function(torrent) {
     }
 
     return `<tr id="torrent_` + torrent.id + `" class="` + tr_class + `">
-        {{ if User.HasAdmin() }}
+        {{ if User.IsModerator() }}
         <td class="tr-cb` + cb_hide + `"` + cb_show + `>
             <input data-name="` + Templates.EncodeEntities(torrent.name) + `" type="checkbox" id="torrent_cb_` + torrent.id + `" name="torrent_id" value="` + torrent.id + `">
         </td>

--- a/templates/layouts/partials/torrent_item.jet.html
+++ b/templates/layouts/partials/torrent_item.jet.html
@@ -17,7 +17,7 @@ Templates.Add("torrents.item", function(torrent) {
     } else if (torrent.status == 4) {
             tr_class += " aplus"
     }
-    // {{ if User.HasAdmin() }}
+    // {{ if User.IsModerator() }}
     var cb_hide = (!TorrentsMod.enabled) ? " hide" : ""
     var cb_show = (TorrentsMod.enabled) ? ' style="display:table-cell;"' : ""
     // {{ end }}

--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -55,7 +55,7 @@
   </thead>
   <tbody id="torrentListResults" {{if AltColors}}class="alt-colors"{{end}}>
     {{ range Models}}
-    <tr id="torrent_{{ .ID }}" class="torrent-info {{if .Status == 2}}remake{{else if .Status == 3}}trusted{{else if .Status == 4}}aplus{{end}}" >
+    <tr id="torrent_{{ .ID }}" class="torrent-info {{if .Status == 2}}remake{{else if .Status == 3}}trusted{{else if .Status == 4}}aplus{{else if .Status == 5}}locked hidden{{end}}">
       {{ if User.IsModerator() }}
       <td class="tr-cb hide">
         <input data-name="{{ .Name }}" type="checkbox" id="torrent_cb_{{ .ID }}" name="torrent_id" value="{{ .ID }}"/>

--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -1,6 +1,6 @@
 {{ extends "layouts/index_site" }}
 {{ import "layouts/partials/helpers/search" }}
-{{block title()}}{{if Search.UserName == ""}}{{ T("home")}}{{else}}{{Search.UserName}}{{end}}{{end}}
+{{block title()}}{{if Search.UserName != ""}}{{Search.UserName}}{{else if Search.NameLike != ""}}{{Search.NameLike}}{{else if Search.Category != ""}}{{T(GetCategoryName(Search.Category))}}{{else}}{{ T("home")}}{{end}}{{end}}
 {{block contclass()}}{{if User.IsModerator() }}content-admin{{end}}{{end}}
 {{block content_body()}}
 {{ if OldNav || Theme == "classic"}}

--- a/templates/site/torrents/listing.jet.html
+++ b/templates/site/torrents/listing.jet.html
@@ -1,7 +1,7 @@
 {{ extends "layouts/index_site" }}
 {{ import "layouts/partials/helpers/search" }}
 {{block title()}}{{if Search.UserName == ""}}{{ T("home")}}{{else}}{{Search.UserName}}{{end}}{{end}}
-{{block contclass()}}{{if User.HasAdmin() }}content-admin{{end}}{{end}}
+{{block contclass()}}{{if User.IsModerator() }}content-admin{{end}}{{end}}
 {{block content_body()}}
 {{ if OldNav || Theme == "classic"}}
   {{ include "layouts/partials/helpers/oldNav" }}
@@ -11,7 +11,7 @@
   <table>
     <thead class="torrent-info">
       <tr>
-        {{ if User.HasAdmin() }}
+        {{ if User.IsModerator() }}
         <th class="tr-cb hide">
           <input type="checkbox" name="select_all" onchange="TorrentsMod.selectAll(this.checked)"/>
         </th>
@@ -56,7 +56,7 @@
   <tbody id="torrentListResults" {{if AltColors}}class="alt-colors"{{end}}>
     {{ range Models}}
     <tr id="torrent_{{ .ID }}" class="torrent-info {{if .Status == 2}}remake{{else if .Status == 3}}trusted{{else if .Status == 4}}aplus{{end}}" >
-      {{ if User.HasAdmin() }}
+      {{ if User.IsModerator() }}
       <td class="tr-cb hide">
         <input data-name="{{ .Name }}" type="checkbox" id="torrent_cb_{{ .ID }}" name="torrent_id" value="{{ .ID }}"/>
       </td>
@@ -108,7 +108,7 @@
     </tbody>
   </table>
 </div>
-{{ if User.HasAdmin() }}
+{{ if User.IsModerator() }}
 <div class="modtools">
   <button id="show_actions" class="form-input" data-toggle-text="{{ T("hide_mod_tools")}}">{{ T("show_mod_tools")}}</button>
   <span class="actions">
@@ -175,7 +175,7 @@
 <script type="text/javascript" src="{{ URL.Parse("/js/modal.js") }}"></script>
 <script type="text/javascript" src="{{ URL.Parse("/js/torrents.js") }}"></script>
 <script type="text/javascript" src="{{ URL.Parse("/js/translation.js") }}"></script>
-{{ if User.HasAdmin() }}
+{{ if User.IsModerator() }}
 <script type="text/javascript" src="{{ URL.Parse("/js/torrentsMod.js") }}"></script>
 <script type="text/javascript">
 // We add translations string

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -221,7 +221,7 @@
     </span>
     <span class="comment-userinfo"><img src="{{ getAvatar(comment.UserAvatar, 50) }}"/>
 	{{if comment.UserID > 0}}<a href="/user/{{comment.UserID}}/{{comment.Username}}" class="comment-user">{{comment.Username}}</a>{{if comment.UserStatus != ""}}<span class="user-status">{{T(comment.UserStatus)}}</span>{{end}}{{else}}
-	<span class="comment-user">れんちょん</span>{{end}}  
+	<span class="comment-user">{{ if comment.Username != ""}}{{comment.Username}}{{else}}れんちょん{{end}}</span>{{end}}  
     </span>
     <div class="comment-content">{{comment.Content|raw}}</div>
   </div>

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -52,7 +52,7 @@
     </tr>
     <tr class="torrent-info-row">
       <td class="torrent-info-td torrent-info-label">{{ T("size")}}:</td>
-      <td class="torrent-view-td torrent-info-data">{{ fileSize(Torrent.Filesize, T, true) }}</td>
+      <td class="torrent-view-td torrent-info-data torrent-info-size">{{ fileSize(Torrent.Filesize, T, true) }}</td>
     </tr>
     {{ if len(Torrent.Languages) > 0 && Torrent.Languages[0] != "" }}
     <tr class="torrent-info-row">
@@ -163,7 +163,7 @@
     </a>
     <a id="reportPopup" href="/report/{{Torrent.ID}}" class="form-input">{{  T("report_btn") }}</a>
     {{ if User.ID > 0}}
-    {{ if User.HasAdmin()}}
+    {{ if User.IsModerator()}}
     <form method="POST" action="/mod/torrent/delete" class="delete-form">
 		{{ yield csrf_field()}}
 		<input type="hidden" name="id" value="{{ Torrent.ID }}">
@@ -188,10 +188,14 @@
   <p>{{  T("no_description") }}</p>
   {{end}}
   <input type="checkbox" id="show-filelist" {{if len(Torrent.FileList) < 4 && len(Torrent.FileList) > 0}}checked{{end}}/>
-  <label class="torrent-hr filelist-control{{if len(Torrent.FileList) == 0}} hidden{{end}}" for="show-filelist">{{ T("files")}}</label>
+  <label class="torrent-hr filelist-control{{if len(Torrent.FileList) == 0}} hidden{{end}}" for="show-filelist">
+  {{ if len(Torrent.FileList) == 0 }}
+	<a href="/files/{{Torrent.ID}}">{{ T("files")}}</a>
+  {{else}}
+	{{ T("files")}}
+  {{end}}
+  </label>
   <div class="torrent-info-box{{if len(Torrent.FileList) == 0}} hidden{{end}}" id="filelist">
-    {{ if len(Torrent.FileList) > 0 }}
-    {* how do i concat lol *}
     <table class="table-filelist">
       <thead>
         <tr>
@@ -200,12 +204,13 @@
 	</tr>
       </thead>
       <tbody>
-        {{ yield make_treeview(treeviewData=makeTreeViewData(RootFolder, 0, "root")) }}
+	    {{ if len(Torrent.FileList) > 0 }}
+          {{ yield make_treeview(treeviewData=makeTreeViewData(RootFolder, 0, "root")) }}
+		{{else}}
+		<tr class="tr-filelist"><td colspan="2">{{  T("no_files") }}</td></tr>
+		{{end}}
       </tbody>
     </table>
-    {{ else }}
-    <p>{{  T("no_files") }}</p>
-    {{ end }}
   </div>
 
   <p class="torrent-hr" id="comments">{{ T("comments")}}</p>
@@ -336,9 +341,36 @@ Modal.Init({
   // order of apparition of the modals
   button: ["#reportPopup", "#tagPopup"]
 });
-</script>
+
+{{ if len(Torrent.FileList) == 0 }}
+  var FileListContainer = document.querySelector("#filelist tbody"),
+      FileListLabel = document.getElementsByClassName("filelist-control")[0],
+	  FileListOldHtml = FileListContainer.innerHTML
+	  
+	  FileListLabel.innerHTML = FileListLabel.innerText
+
+  FileListLabel.addEventListener("click", function (e) {
+    FileListContainer.innerHTML = "<tr class='tr-filelist'><td>{{T("loading_file_list")}}</td></tr>"
+    Query.Get('/stats/{{Torrent.ID}}?files', function (data) {
+      if(data.filelist != null) {
+        FileListContainer.innerHTML = ""
+        FileListLabel.style.opacity = 1
+        document.getElementById("filelist").style.opacity = 1
+		if(data.totalsize != "0.0 B") document.getElementsByClassName("torrent-info-size")[0].innerHTML = data.totalsize
+		
+        for(var i = 0; i < data.filelist.length; i++) {
+          var file = data.filelist[i]
+          if(file.filesize == "0.0 B") file.filesize = "{{T("unknown")}}"
+            FileListContainer.innerHTML = FileListContainer.innerHTML + '<tr class="tr-filelist '+ file.class +'"><td>'+ file.path +'</td><td>'+ file.filesize +'</td></tr>'
+          }
+	   } else {
+		FileListContainer.innerHTML = FileListOldHtml
+	   }
+	})
+  })
+ {{end}}
+
 {{ if !torrentFileExists(Torrent.Hash, Torrent.TorrentLink)}}
-<script type="text/javascript">
 	var torrentLink = document.getElementById("torrent-download-link"),
 	    oldDownloadHtml = torrentLink.innerHTML,
 	    downloadIconHtml = torrentLink.innerHTML.substring(0, torrentLink.innerHTML.indexOf("</div>") + 6),
@@ -378,10 +410,8 @@ Modal.Init({
 			}
 		});
 	}
-</script>
 {{end}}
 {{if Torrent.StatsObsolete[1] }}
-<script type="text/javascript">
   var seeders   = document.querySelector(".tr-se"),
       leechers  = document.querySelector(".tr-le"),
       downloads = document.querySelector(".tr-dl"),
@@ -408,9 +438,8 @@ Modal.Init({
     }
   })
   
-  
-</script>
 {{end}}
+</script>
 {{ if User.ID > 0 }}
 <script type="text/javascript" src="{{ URL.Parse("/js/template.js") }}"></script>
 <script type="text/javascript" src="{{ URL.Parse("/js/modal.js") }}"></script>

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -212,23 +212,23 @@
   {{idx := 1}}
   {{previousComment := ""}}
   {{previousUser := 0}}
-  {{range index, element := Torrent.Comments}}
-  {{if previousComment != element.Content || previousUser != element.UserID || element.UserID == 0}}
+  {{range _, comment := Torrent.Comments}}
+  {{if previousComment != comment.Content || previousUser != comment.UserID || comment.UserID == 0}}
   <div class="torrent-info-box comment-box">
     <span class="comment-index">
       <a href="#comment_{{idx}}">{{idx}}</a>
-      <small style="padding-left: 4px;" class="date-full">{{formatDate(element.Date, false)}}</small>
+      <small style="padding-left: 4px;" class="date-full">{{formatDate(comment.Date, false)}}</small>
     </span>
-    <span class="comment-userinfo"><img src="{{ getAvatar(element.UserAvatar, 50) }}"/>
-	{{if element.UserID > 0}}<a href="/user/{{element.UserID}}/{{element.Username}}" class="comment-user">{{element.Username}}</a>{{if element.UserStatus != ""}}<span class="user-status">{{T(element.UserStatus)}}</span>{{end}}{{else}}
+    <span class="comment-userinfo"><img src="{{ getAvatar(comment.UserAvatar, 50) }}"/>
+	{{if comment.UserID > 0}}<a href="/user/{{comment.UserID}}/{{comment.Username}}" class="comment-user">{{comment.Username}}</a>{{if comment.UserStatus != ""}}<span class="user-status">{{T(comment.UserStatus)}}</span>{{end}}{{else}}
 	<span class="comment-user">れんちょん</span>{{end}}  
     </span>
-    <div class="comment-content">{{element.Content|raw}}</div>
+    <div class="comment-content">{{comment.Content|raw}}</div>
   </div>
   {{idx = idx + 1}}
   {{end}}
-  {{previousComment = element.Content}}
-  {{previousUser = element.UserID}}
+  {{previousComment = comment.Content}}
+  {{previousUser = comment.UserID}}
   {{end}}
   {{ if len(Torrent.Comments) == 0 }}
     <p id="no-comment-message">{{ T("torrent_no_comments") }}</p>

--- a/templates/site/torrents/view.jet.html
+++ b/templates/site/torrents/view.jet.html
@@ -52,7 +52,7 @@
     </tr>
     <tr class="torrent-info-row">
       <td class="torrent-info-td torrent-info-label">{{ T("size")}}:</td>
-      <td class="torrent-view-td torrent-info-data torrent-info-size">{{ fileSize(Torrent.Filesize, T, true) }}</td>
+      <td class="torrent-view-td torrent-info-data">{{ fileSize(Torrent.Filesize, T, true) }}</td>
     </tr>
     {{ if len(Torrent.Languages) > 0 && Torrent.Languages[0] != "" }}
     <tr class="torrent-info-row">
@@ -188,14 +188,10 @@
   <p>{{  T("no_description") }}</p>
   {{end}}
   <input type="checkbox" id="show-filelist" {{if len(Torrent.FileList) < 4 && len(Torrent.FileList) > 0}}checked{{end}}/>
-  <label class="torrent-hr filelist-control{{if len(Torrent.FileList) == 0}} hidden{{end}}" for="show-filelist">
-  {{ if len(Torrent.FileList) == 0 }}
-	<a href="/files/{{Torrent.ID}}">{{ T("files")}}</a>
-  {{else}}
-	{{ T("files")}}
-  {{end}}
-  </label>
+  <label class="torrent-hr filelist-control{{if len(Torrent.FileList) == 0}} hidden{{end}}" for="show-filelist">{{ T("files")}}</label>
   <div class="torrent-info-box{{if len(Torrent.FileList) == 0}} hidden{{end}}" id="filelist">
+    {{ if len(Torrent.FileList) > 0 }}
+    {* how do i concat lol *}
     <table class="table-filelist">
       <thead>
         <tr>
@@ -204,13 +200,12 @@
 	</tr>
       </thead>
       <tbody>
-	    {{ if len(Torrent.FileList) > 0 }}
-          {{ yield make_treeview(treeviewData=makeTreeViewData(RootFolder, 0, "root")) }}
-		{{else}}
-		<tr class="tr-filelist"><td colspan="2">{{  T("no_files") }}</td></tr>
-		{{end}}
+        {{ yield make_treeview(treeviewData=makeTreeViewData(RootFolder, 0, "root")) }}
       </tbody>
     </table>
+    {{ else }}
+    <p>{{  T("no_files") }}</p>
+    {{ end }}
   </div>
 
   <p class="torrent-hr" id="comments">{{ T("comments")}}</p>
@@ -341,36 +336,9 @@ Modal.Init({
   // order of apparition of the modals
   button: ["#reportPopup", "#tagPopup"]
 });
-
-{{ if len(Torrent.FileList) == 0 }}
-  var FileListContainer = document.querySelector("#filelist tbody"),
-      FileListLabel = document.getElementsByClassName("filelist-control")[0],
-	  FileListOldHtml = FileListContainer.innerHTML
-	  
-	  FileListLabel.innerHTML = FileListLabel.innerText
-
-  FileListLabel.addEventListener("click", function (e) {
-    FileListContainer.innerHTML = "<tr class='tr-filelist'><td>{{T("loading_file_list")}}</td></tr>"
-    Query.Get('/stats/{{Torrent.ID}}?files', function (data) {
-      if(data.filelist != null) {
-        FileListContainer.innerHTML = ""
-        FileListLabel.style.opacity = 1
-        document.getElementById("filelist").style.opacity = 1
-		if(data.totalsize != "0.0 B") document.getElementsByClassName("torrent-info-size")[0].innerHTML = data.totalsize
-		
-        for(var i = 0; i < data.filelist.length; i++) {
-          var file = data.filelist[i]
-          if(file.filesize == "0.0 B") file.filesize = "{{T("unknown")}}"
-            FileListContainer.innerHTML = FileListContainer.innerHTML + '<tr class="tr-filelist '+ file.class +'"><td>'+ file.path +'</td><td>'+ file.filesize +'</td></tr>'
-          }
-	   } else {
-		FileListContainer.innerHTML = FileListOldHtml
-	   }
-	})
-  })
- {{end}}
-
+</script>
 {{ if !torrentFileExists(Torrent.Hash, Torrent.TorrentLink)}}
+<script type="text/javascript">
 	var torrentLink = document.getElementById("torrent-download-link"),
 	    oldDownloadHtml = torrentLink.innerHTML,
 	    downloadIconHtml = torrentLink.innerHTML.substring(0, torrentLink.innerHTML.indexOf("</div>") + 6),
@@ -410,8 +378,10 @@ Modal.Init({
 			}
 		});
 	}
+</script>
 {{end}}
 {{if Torrent.StatsObsolete[1] }}
+<script type="text/javascript">
   var seeders   = document.querySelector(".tr-se"),
       leechers  = document.querySelector(".tr-le"),
       downloads = document.querySelector(".tr-dl"),
@@ -438,8 +408,9 @@ Modal.Init({
     }
   })
   
-{{end}}
+  
 </script>
+{{end}}
 {{ if User.ID > 0 }}
 <script type="text/javascript" src="{{ URL.Parse("/js/template.js") }}"></script>
 <script type="text/javascript" src="{{ URL.Parse("/js/modal.js") }}"></script>

--- a/templates/site/user/edit.jet.html
+++ b/templates/site/user/edit.jet.html
@@ -33,7 +33,7 @@
 				</select>
 			</td>
 		</tr>
-		{{ if !User.HasAdmin()}}
+		{{ if !User.IsModerator()}}
 		<tr>
 			<td><label for="current_password">{{  T("current_password") }}</label></td>
 			<td><input class="form-input up-input up-input" name="current_password" id="current_password" type="password"/></td>
@@ -51,7 +51,7 @@
 </table>
     {{ yield errors(name="Email")}}
 	{{ yield errors(name="Language")}}
-    {{ if !User.HasAdmin()}}
+    {{ if !User.IsModerator()}}
         {{ yield errors(name="CurrentPassword")}}
     {{end}}
 	{{ yield errors(name="Password")}}
@@ -228,7 +228,7 @@
         {{ yield errors(name="FollowedEmail")}}
     {{end}}
 
-{{ if User.HasAdmin()}}
+{{ if User.IsModerator()}}
 <h2>{{  T("moderation")}}</h2>
 <table class="user-edit-table">
 	<tbody>
@@ -243,8 +243,9 @@
 				  <option value="-1" {{ if UserProfile.Status == -1 }}selected{{end}}>{{  T("userstatus_banned")}}</option>
 				  <option value="0" {{ if UserProfile.Status == 0 }}selected{{end}}>{{  T("userstatus_member")}} ({{  T("default") }})</option>
 				  <option value="1" {{ if UserProfile.Status == 1 }}selected{{end}}>{{  T("userstatus_trusted")}}</option>
-				  {{ if UserProfile.Status == 2}}
-				  <option value="2" selected>{{  T("userstatus_moderator")}}</option>
+				  {{ if User.Status == 2}}
+				  <option value="5" {{ if UserProfile.Status == 5 }}selected{{end}}>{{  T("userstatus_janitor")}}</option>
+				  <option value="2" {{ if UserProfile.Status == 2 }}selected{{end}}>{{  T("userstatus_moderator")}}</option>
 				  {{end}}
 				  <option value="3" {{ if UserProfile.Status == 3 }}selected{{end}}>{{  T("userstatus_scraped")}}</option>
 				</select>

--- a/templates/site/user/edit.jet.html
+++ b/templates/site/user/edit.jet.html
@@ -244,7 +244,7 @@
 				  <option value="0" {{ if UserProfile.Status == 0 }}selected{{end}}>{{  T("userstatus_member")}} ({{  T("default") }})</option>
 				  <option value="1" {{ if UserProfile.Status == 1 }}selected{{end}}>{{  T("userstatus_trusted")}}</option>
 				  {{ if User.Status == 2}}
-				  <option value="5" {{ if UserProfile.Status == 5 }}selected{{end}}>{{  T("userstatus_janitor")}}</option>
+				  <option value="4" {{ if UserProfile.Status == 4 }}selected{{end}}>{{  T("userstatus_janitor")}}</option>
 				  <option value="2" {{ if UserProfile.Status == 2 }}selected{{end}}>{{  T("userstatus_moderator")}}</option>
 				  {{end}}
 				  <option value="3" {{ if UserProfile.Status == 3 }}selected{{end}}>{{  T("userstatus_scraped")}}</option>

--- a/templates/template.go
+++ b/templates/template.go
@@ -168,10 +168,10 @@ func userProfileBase(c *gin.Context, templateName string, userProfile *models.Us
 	query.Set("limit", "15")
 	c.Request.URL.RawQuery = query.Encode()
 	nbTorrents := 0
-	if userProfile.ID > 0 && currentUser.CurrentOrAdmin(userProfile.ID) {
-		_, userProfile.Torrents, nbTorrents, _ = search.ByQuery(c, 1, true, false, false)
+	if userProfile.ID > 0 && currentUser.CurrentOrJanitor(userProfile.ID) {
+		_, userProfile.Torrents, nbTorrents, _ = search.ByQuery(c, 1, true, false, false, true)
 	} else {
-		_, userProfile.Torrents, nbTorrents, _ = search.ByQuery(c, 1, true, false, true)
+		_, userProfile.Torrents, nbTorrents, _ = search.ByQuery(c, 1, true, false, true, false)
 	}
 	
 	var uploadedSize int64

--- a/templates/template_functions.go
+++ b/templates/template_functions.go
@@ -40,6 +40,7 @@ func templateFunctions(vars jet.VarMap) jet.VarMap {
 	vars.Set("GetCategories", categories.GetSelect)
 	vars.Set("GetCategory", getCategory)
 	vars.Set("CategoryName", categoryName)
+	vars.Set("GetCategoryName", GetCategoryName)
 	vars.Set("GetTorrentLanguages", torrentLanguages.GetTorrentLanguages)
 	vars.Set("LanguageName", languageName)
 	vars.Set("LanguageNameFromCode", languageNameFromCode)
@@ -224,13 +225,16 @@ func getCategory(category string, keepParent bool) categories.Categories {
 	return categoryRet
 }
 func categoryName(category string, subCategory string) string {
-	s := category + "_" + subCategory
+	return GetCategoryName( category + "_" + subCategory)
+}
 
-	if category, ok := categories.GetByID(s); ok {
-		return category.Name
+func GetCategoryName(category string) string {
+	if cat, ok := categories.GetByID(category); ok {
+		return cat.Name
 	}
 	return ""
 }
+
 func languageName(lang publicSettings.Language, T publicSettings.TemplateTfunc) string {
 	if strings.Contains(lang.Name, ",") {
 		langs := strings.Split(lang.Name, ", ")

--- a/templates/template_functions_test.go
+++ b/templates/template_functions_test.go
@@ -289,6 +289,37 @@ func TestCategoryName(t *testing.T) {
 	}
 }
 
+func TestCategoryName2(t *testing.T) {
+	var tests = []struct {
+		TestCat    string
+		Expected   string
+	}{
+		{
+			TestCat:    "_",
+			Expected:   "",
+		},
+		{
+			TestCat:    "d",
+			Expected:   "",
+		},
+		{
+			TestCat:    "3_",
+			Expected:   "anime",
+		},
+		{
+			TestCat:    "3_6",
+			Expected:   "anime_raw",
+		},
+	}
+
+	for _, test := range tests {
+		value := GetCategoryName(test.TestCat)
+		if value != test.Expected {
+			t.Errorf("Unexpected value from the function categoryName, got '%s', wanted '%s' for '%s'", value, test.Expected, test.TestCat)
+		}
+	}
+}
+
 func TestLanguageName(t *testing.T) {
 	var tests = []struct {
 		TestLang publicSettings.Language

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -95,3 +95,5 @@
 * + userstatus_janitor
 * + ban
 * + unban
+* + user_banned_by
+* + user_unbanned_by

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -102,3 +102,4 @@
 * + user_unbanned
 * + torrent_uploaded_locked
 * + moderation_guidelines
+* + guidelines

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -91,3 +91,5 @@
 ## 2017/11/04
 * + nsfw_content
 * + generating_torrent_failed
+## 2017/11/09
+* + userstatus_janitor

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -97,3 +97,6 @@
 * + unban
 * + user_banned_by
 * + user_unbanned_by
+## 2017/11/10
+* + user_banned
+* + user_unbanned

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -100,3 +100,4 @@
 ## 2017/11/10
 * + user_banned
 * + user_unbanned
+* + torrent_uploaded_locked

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -101,3 +101,4 @@
 * + user_banned
 * + user_unbanned
 * + torrent_uploaded_locked
+* + moderation_guidelines

--- a/translations/CHANGELOG.md
+++ b/translations/CHANGELOG.md
@@ -93,3 +93,5 @@
 * + generating_torrent_failed
 ## 2017/11/09
 * + userstatus_janitor
+* + ban
+* + unban

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -608,16 +608,16 @@
     "translation": "Current password"
   },
   {
+    "id": "default",
+    "translation": "Default"
+  },
+  {
     "id": "role",
     "translation": "Role"
   },
   {
     "id": "userstatus_banned",
     "translation": "Banned"
-  },
-  {
-    "id": "default",
-    "translation": "Default"
   },
   {
     "id": "userstatus_trusted",
@@ -630,6 +630,10 @@
   {
     "id": "userstatus_moderator",
     "translation": "Moderator"
+  },
+  {
+    "id": "userstatus_janitor",
+    "translation": "Janitor"
   },
   {
     "id": "userstatus_uploader",
@@ -762,6 +766,18 @@
   {
     "id": "no_files",
     "translation": "No files found? That doesn't even make sense!"
+  },
+  {
+    "id": "loading_file_list",
+    "translation": "Loading the file list, long file lists can take time to fetch..."
+  },
+  {
+    "id": "torrent_filelist",
+    "translation": "Torrent filelist"
+  },
+  {
+    "id": "back_to_torrent",
+    "translation": "Back to \"%s\""
   },
   {
     "id": "uploaded_by",

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -2279,4 +2279,12 @@
     "id": "unread",
     "translation": "Unread"
   }
+  {
+    "id": "moderation_guidelines",
+    "translation": "Moderation Guidelines"
+  }
+  {
+    "id": "guidelines",
+    "translation": "Guidelines"
+  }
 ]

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -980,7 +980,7 @@
     "translation": "Torrent #%d from %s has been locked by %s."
   },
   {
-    "id": "torrent_blocked_by",
+    "id": "torrent_unblocked_by",
     "translation": "Torrent #%d from %s has been unlocked by %s."
   },
   {

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -984,8 +984,12 @@
     "translation": "Torrent #%d from %s has been unlocked by %s."
   },
   {
-    "id": "user_banned_by",
-    "translation": "User %s(%d) #%d has been banned by %s"
+    "id": "user_banned",
+    "translation": "User has been banned!"
+  },
+  {
+    "id": "user_banned",
+    "translation": "User has been unbanned!"
   },
   {
     "id": "user_unbanned_by",

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -768,18 +768,6 @@
     "translation": "No files found? That doesn't even make sense!"
   },
   {
-    "id": "loading_file_list",
-    "translation": "Loading the file list, long file lists can take time to fetch..."
-  },
-  {
-    "id": "torrent_filelist",
-    "translation": "Torrent filelist"
-  },
-  {
-    "id": "back_to_torrent",
-    "translation": "Back to \"%s\""
-  },
-  {
     "id": "uploaded_by",
     "translation": "Uploaded by"
   },

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -888,6 +888,10 @@
     "translation": "torrent uploaded successfully!"
   },
   {
+    "id": "torrent_uploaded_locked",
+    "translation": "Your torrent has been uploaded but is locked because you are banned."
+  },
+  {
     "id": "preferences",
     "translation": "Preferences"
   },

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -984,6 +984,14 @@
     "translation": "Torrent #%d from %s has been unlocked by %s."
   },
   {
+    "id": "user_banned_by",
+    "translation": "User %s(%d) #%d has been banned by %s"
+  },
+  {
+    "id": "user_unbanned_by",
+    "translation": "User %s(%d) #%d has been unbanned by %s"
+  },
+  {
     "id": "torrents_deleted",
     "translation": "Torrents Deleted"
   },

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -1104,6 +1104,14 @@
     "translation": "Lock"
   },
   {
+    "id": "unban",
+    "translation": "Unban"
+  },
+  {
+    "id": "ban",
+    "translation": "Ban"
+  },
+  {
     "id": "torrent_deleted_definitely",
     "translation": "Torrent has been erased from the database!"
   },

--- a/translations/en-us.all.json
+++ b/translations/en-us.all.json
@@ -2278,11 +2278,11 @@
   {
     "id": "unread",
     "translation": "Unread"
-  }
+  },
   {
     "id": "moderation_guidelines",
     "translation": "Moderation Guidelines"
-  }
+  },
   {
     "id": "guidelines",
     "translation": "Guidelines"

--- a/utils/search/search.go
+++ b/utils/search/search.go
@@ -45,7 +45,7 @@ func ByQueryNoUser(c *gin.Context, pagenum int) (search TorrentParam, tor []mode
 
 // ByQueryWithUser : search torrents according to request with user
 func ByQueryWithUser(c *gin.Context, pagenum int) (search TorrentParam, tor []models.Torrent, count int, err error) {
-	search, tor, count, err = ByQuery(c, pagenum, true, false, false, false)
+	search, tor, count, err = ByQuery(c, pagenum, true, false, false, true)
 	return
 }
 

--- a/utils/search/search.go
+++ b/utils/search/search.go
@@ -39,25 +39,25 @@ func stringIsASCII(input string) bool {
 
 // ByQueryNoUser : search torrents according to request without user
 func ByQueryNoUser(c *gin.Context, pagenum int) (search TorrentParam, tor []models.Torrent, count int, err error) {
-	search, tor, count, err = ByQuery(c, pagenum, false, false, false)
+	search, tor, count, err = ByQuery(c, pagenum, false, false, false, false)
 	return
 }
 
 // ByQueryWithUser : search torrents according to request with user
 func ByQueryWithUser(c *gin.Context, pagenum int) (search TorrentParam, tor []models.Torrent, count int, err error) {
-	search, tor, count, err = ByQuery(c, pagenum, true, false, false)
+	search, tor, count, err = ByQuery(c, pagenum, true, false, false, false)
 	return
 }
 
 // ByQueryDeleted : search deleted torrents according to request with user and count
 func ByQueryDeleted(c *gin.Context, pagenum int) (search TorrentParam, tor []models.Torrent, count int, err error) {
-	search, tor, count, err = ByQuery(c, pagenum, true, true, false)
+	search, tor, count, err = ByQuery(c, pagenum, true, true, false, true)
 	return
 }
 
 // ByQueryNoHidden : search torrents and filter those hidden
 func ByQueryNoHidden(c *gin.Context, pagenum int) (search TorrentParam, tor []models.Torrent, count int, err error) {
-	search, tor, count, err = ByQuery(c, pagenum, false, false, true)
+	search, tor, count, err = ByQuery(c, pagenum, false, false, true, false)
 	return
 }
 
@@ -66,11 +66,12 @@ func ByQueryNoHidden(c *gin.Context, pagenum int) (search TorrentParam, tor []mo
 // elasticsearch always provide a count to how many hits
 // ES doesn't store users
 // deleted is unused because es doesn't index deleted torrents
-func ByQuery(c *gin.Context, pagenum int, withUser bool, deleted bool, hidden bool) (TorrentParam, []models.Torrent, int, error) {
+func ByQuery(c *gin.Context, pagenum int, withUser bool, deleted bool, hidden bool, locked bool) (TorrentParam, []models.Torrent, int, error) {
 	var torrentParam TorrentParam
 	torrentParam.FromRequest(c)
 	torrentParam.Offset = uint32(pagenum)
 	torrentParam.Hidden = hidden
+	torrentParam.Locked = locked
 	torrentParam.Full = withUser
 	torrentParam.Deleted = deleted
 	
@@ -106,6 +107,6 @@ func ByQuery(c *gin.Context, pagenum int, withUser bool, deleted bool, hidden bo
 }
 
 // AuthorizedQuery return a seach byquery according to the bool. If false, it doesn't look for hidden torrents, else it looks for every torrents
-func AuthorizedQuery(c *gin.Context, pagenum int, authorized bool) (TorrentParam, []models.Torrent, int, error) {
-	return ByQuery(c, pagenum, true, false, !authorized)
+func AuthorizedQuery(c *gin.Context, pagenum int, authorized bool, locked bool) (TorrentParam, []models.Torrent, int, error) {
+	return ByQuery(c, pagenum, true, false, !authorized, locked)
 }

--- a/utils/search/torrentParam_test.go
+++ b/utils/search/torrentParam_test.go
@@ -12,13 +12,13 @@ import (
 func TestTorrentParam_Identifier(t *testing.T) {
 	torrentParam := &TorrentParam{}
 	assert := assert.New(t)
-	assert.Equal("MDAwMDAwMDAwMDBmYWxzZWZhbHNlZmFsc2VmYWxzZQ==", torrentParam.Identifier(), "It should be empty")
+	assert.Equal("MDAwMDAwMDAwMDBmYWxzZWZhbHNlZmFsc2VmYWxzZWZhbHNl", torrentParam.Identifier(), "It should be empty")
 	torrentParam = &TorrentParam{
 		NameLike: "test",
 		NotNull:  "IS NULL",
 		Hidden:   false,
 	}
-	assert.Equal("dGVzdElTIE5VTEwwMDAwMDAwMDAwMGZhbHNlZmFsc2VmYWxzZWZhbHNl", torrentParam.Identifier(), "It should be empty")
+	assert.Equal("dGVzdElTIE5VTEwwMDAwMDAwMDAwMGZhbHNlZmFsc2VmYWxzZWZhbHNlZmFsc2U=", torrentParam.Identifier(), "It should be empty")
 }
 
 func TestTorrentParam_FromRequest(t *testing.T) {

--- a/utils/search/torrentParam_test.go
+++ b/utils/search/torrentParam_test.go
@@ -57,14 +57,14 @@ func TestTorrentParam_ToESQuery(t *testing.T) {
 		Test     TorrentParam
 		Expected string
 	}{
-		{TorrentParam{}, ""},
-		{TorrentParam{NameLike: "lol"}, ""},
-		{TorrentParam{NameLike: "lol", FromID: 12}, "id:>12"},
-		{TorrentParam{NameLike: "lol", FromID: 12, FromDate: DateFilter("2017-08-01"), ToDate: DateFilter("2017-08-05")}, "id:>12 date: [2017-08-01 2017-08-05]"},
-		{TorrentParam{NameLike: "lol", FromID: 12, ToDate: DateFilter("2017-08-05")}, "id:>12 date: [* 2017-08-05]"},
-		{TorrentParam{NameLike: "lol", FromID: 12, FromDate: DateFilter("2017-08-01")}, "id:>12 date: [2017-08-01 *]"},
-		{TorrentParam{NameLike: "lol", FromID: 12, Category: Categories{&Category{3, 12}}}, "(category: 3 AND sub_category: 12) id:>12"},
-		{TorrentParam{NameLike: "lol", FromID: 12, Category: Categories{&Category{3, 12}, &Category{3, 12}}}, "((category: 3 AND sub_category: 12) OR (category: 3 AND sub_category: 12)) id:>12"},
+		{TorrentParam{}, ""!(status:5)"},
+		{TorrentParam{NameLike: "lol"}, "!(status:5)"},
+		{TorrentParam{NameLike: "lol", FromID: 12}, "!(status:5) id:>12"},
+		{TorrentParam{NameLike: "lol", FromID: 12, FromDate: DateFilter("2017-08-01"), ToDate: DateFilter("2017-08-05")}, "!(status:5) id:>12 date: [2017-08-01 2017-08-05]"},
+		{TorrentParam{NameLike: "lol", FromID: 12, ToDate: DateFilter("2017-08-05")}, "!(status:5) id:>12 date: [* 2017-08-05]"},
+		{TorrentParam{NameLike: "lol", FromID: 12, FromDate: DateFilter("2017-08-01")}, "!(status:5) id:>12 date: [2017-08-01 *]"},
+		{TorrentParam{NameLike: "lol", FromID: 12, Category: Categories{&Category{3, 12}}}, "(category: 3 AND sub_category: 12) !(status:5) id:>12"},
+		{TorrentParam{NameLike: "lol", FromID: 12, Category: Categories{&Category{3, 12}, &Category{3, 12}}}, "((category: 3 AND sub_category: 12) OR (category: 3 AND sub_category: 12)) !(status:5) id:>12"},
 	}
 
 	for _, test := range tests {

--- a/utils/search/torrentParam_test.go
+++ b/utils/search/torrentParam_test.go
@@ -57,7 +57,7 @@ func TestTorrentParam_ToESQuery(t *testing.T) {
 		Test     TorrentParam
 		Expected string
 	}{
-		{TorrentParam{}, ""!(status:5)"},
+		{TorrentParam{}, "!(status:5)"},
 		{TorrentParam{NameLike: "lol"}, "!(status:5)"},
 		{TorrentParam{NameLike: "lol", FromID: 12}, "!(status:5) id:>12"},
 		{TorrentParam{NameLike: "lol", FromID: 12, FromDate: DateFilter("2017-08-01"), ToDate: DateFilter("2017-08-05")}, "!(status:5) id:>12 date: [2017-08-01 2017-08-05]"},

--- a/utils/upload/upload.go
+++ b/utils/upload/upload.go
@@ -174,6 +174,9 @@ func UpdateTorrent(r *torrentValidator.UpdateRequest, t *models.Torrent, current
 	} else if currentUser.IsTrusted() {
 		status = models.TorrentStatusTrusted
 	}
+	if status != t.Status && status != models.TorrentStatusBlocked {
+		t.DeletedAt = nil
+	}
 	t.Status = status
 
 	t.Hidden = r.Update.Hidden


### PR DESCRIPTION
Was checking if a variable was set but was checking an undefined variable

Moderator stuff:
- Add Janitors
- Janitors can lock torrents, delete comments and see/delete reports, ban users
- Remove any usage of deprecated HasAdmin() function
- Show lock/unlock buttons next to delete button in admin panel for torrents, and ban/unban button for users
- Add user ban route
- Banned users can still log-in, still upload, but cannot comment and their torrents are locked (invisible) by default
- Add page for moderation guidelines
- Moderators can edit the status of a torrent to undelete it

Other:
- Make locked torrents hidden from torrent listing for non-owners or non-staff
- Show every userstatus (Moderator, Janitor, Member, Banned, Trusted, a+) in comments instead of just Moderator, Banned, Trusted and Uploader
- No status on the anonymous profile
- Visual cue for locked torrents in admin panel
- Add current search (search content, or if empty search category, or if empty "Home") in page title
- Render torrent view template directly instead of redirecting user after submitting a comment
- Make notification page responsive
- Fix "torrent is being generated" message showing up even when the torrent couldn't be generated
- Fix the last html error caused by old nav
- Fix user profile that needed a refresh to visually update after a change
- Fix userprofile buttons overflowing at some specific resolutions
- Fix old (nyaa.se) comments not showing up in torrent listing
- Fix old (nyaa.se) comments's username that constantly showed as anonymous since a few weeks ago
- Fix on-demand stat fetching that tried to scrape HTTP trackers as they were in the default trackers, which is useless because it can only scrape UDP scrapers