### PR TITLE
Fix parseAllDates() that could break dates (in listing)

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -59,8 +59,10 @@ function parseAllDates() {
   var list = document.getElementsByClassName("date-short")
   for(var i = 0; i < list.length; i++) {
     var e = list[i]
-    e.innerText = new Date(e.title).toLocaleString(lang, ymdOpt)
-    e.title = new Date(e.title).toLocaleString(lang)
+    var newDate = new Date(e.title)
+    if(newDate == "Invalid Date") continue
+    e.innerText = newDate.toLocaleString(lang, ymdOpt)
+    e.title = newDate.toLocaleString(lang)
   }
 
   var list = document.getElementsByClassName("date-full")

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -60,7 +60,7 @@ function parseAllDates() {
   for(var i = 0; i < list.length; i++) {
     var e = list[i]
     var newDate = new Date(e.title)
-    if(newDate == "Invalid Date") continue
+    if(isNaN(newDate.valueOf())) continue
     e.innerText = newDate.toLocaleString(lang, ymdOpt)
     e.title = newDate.toLocaleString(lang)
   }


### PR DESCRIPTION
Fix parseAllDates() that would break torrent list dates if it had already been executed before